### PR TITLE
Add Finnish and Swedish translations

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1,0 +1,95 @@
+msgid ""
+msgstr ""
+"Language: fi\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+# UI strings
+msgid "Create survey"
+msgstr "Luo kysely"
+
+msgid "My answers"
+msgstr "Vastaukseni"
+
+msgid "Save"
+msgstr "Tallenna"
+
+msgid "Add question"
+msgstr "Lisää kysymys"
+
+msgid "State"
+msgstr "Tila"
+
+msgid "Start date"
+msgstr "Aloituspäivä"
+
+msgid "End date"
+msgstr "Päättymispäivä"
+
+msgid "Answer survey"
+msgstr "Vastaa kyselyyn"
+
+msgid "Results"
+msgstr "Tulokset"
+
+msgid "Submit"
+msgstr "Lähetä"
+
+msgid "Question"
+msgstr "Kysymys"
+
+msgid "Answer"
+msgstr "Vastaus"
+
+msgid "No answers"
+msgstr "Ei vastauksia"
+
+msgid "Total respondents"
+msgstr "Vastaajien määrä"
+
+msgid "Yes"
+msgstr "Kyllä"
+
+msgid "No"
+msgstr "Ei"
+
+msgid "Total"
+msgstr "Yhteensä"
+
+msgid "Surveys"
+msgstr "Kyselyt"
+
+msgid "Title"
+msgstr "Otsikko"
+
+msgid "No surveys"
+msgstr "Ei kyselyitä"
+
+msgid "Skip"
+msgstr "Ohita"
+
+msgid "Running"
+msgstr "Käynnissä"
+
+msgid "Paused"
+msgstr "Tauolla"
+
+msgid "Closed"
+msgstr "Suljettu"
+
+msgid "Survey created"
+msgstr "Kysely luotu"
+
+msgid "No permission"
+msgstr "Ei oikeuksia"
+
+msgid "Question added"
+msgstr "Kysymys lisätty"
+
+msgid "Survey not active"
+msgstr "Kysely ei ole aktiivinen"
+
+msgid "No more questions"
+msgstr "Ei enempää kysymyksiä"
+
+msgid "Answer saved"
+msgstr "Vastaus tallennettu"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -1,0 +1,95 @@
+msgid ""
+msgstr ""
+"Language: sv\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+# UI strings
+msgid "Create survey"
+msgstr "Skapa enkät"
+
+msgid "My answers"
+msgstr "Mina svar"
+
+msgid "Save"
+msgstr "Spara"
+
+msgid "Add question"
+msgstr "Lägg till fråga"
+
+msgid "State"
+msgstr "Status"
+
+msgid "Start date"
+msgstr "Startdatum"
+
+msgid "End date"
+msgstr "Slutdatum"
+
+msgid "Answer survey"
+msgstr "Svara på enkäten"
+
+msgid "Results"
+msgstr "Resultat"
+
+msgid "Submit"
+msgstr "Skicka"
+
+msgid "Question"
+msgstr "Fråga"
+
+msgid "Answer"
+msgstr "Svar"
+
+msgid "No answers"
+msgstr "Inga svar"
+
+msgid "Total respondents"
+msgstr "Antal svarande"
+
+msgid "Yes"
+msgstr "Ja"
+
+msgid "No"
+msgstr "Nej"
+
+msgid "Total"
+msgstr "Totalt"
+
+msgid "Surveys"
+msgstr "Enkäter"
+
+msgid "Title"
+msgstr "Titel"
+
+msgid "No surveys"
+msgstr "Inga enkäter"
+
+msgid "Skip"
+msgstr "Hoppa över"
+
+msgid "Running"
+msgstr "Pågår"
+
+msgid "Paused"
+msgstr "Pausad"
+
+msgid "Closed"
+msgstr "Stängd"
+
+msgid "Survey created"
+msgstr "Enkät skapad"
+
+msgid "No permission"
+msgstr "Ingen behörighet"
+
+msgid "Question added"
+msgstr "Fråga tillagd"
+
+msgid "Survey not active"
+msgstr "Enkäten är inte aktiv"
+
+msgid "No more questions"
+msgstr "Inga fler frågor"
+
+msgid "Answer saved"
+msgstr "Svar sparat"


### PR DESCRIPTION
## Summary
- provide Django translation files for Finnish and Swedish

## Testing
- `python manage.py check` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6876666b4974832ebcee9751aca5cd5a