### PR TITLE
Fix survey app import

### DIFF
--- a/wikikysely_project/settings.py
+++ b/wikikysely_project/settings.py
@@ -15,7 +15,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'survey',
+    'wikikysely_project.survey',
 ]
 
 MIDDLEWARE = [

--- a/wikikysely_project/survey/apps.py
+++ b/wikikysely_project/survey/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class SurveyConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'survey'
+    name = 'wikikysely_project.survey'


### PR DESCRIPTION
## Summary
- update survey app path in settings
- set survey app config's name

## Testing
- `python3 manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687671188a14832ea87f4314c3b37917