### PR TITLE
Fix URL configuration for survey app

### DIFF
--- a/wikikysely_project/urls.py
+++ b/wikikysely_project/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
 
 urlpatterns += i18n_patterns(
     path('admin/', admin.site.urls),
-    path('', include('survey.urls')),
+    path('', include('wikikysely_project.survey.urls')),
 )
 
 if settings.DEBUG:


### PR DESCRIPTION
## Summary
- fix include path for survey URLs

## Testing
- `python manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687672498308832e9ac48568411ef49c