### PR TITLE
Fix authentication paths

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -28,6 +28,11 @@
         <input type="hidden" name="next" value="{{ request.path }}" />
       </form>
       <span class="navbar-text ms-3">{{ request.user.username }}</span>
+      {% if request.user.is_authenticated %}
+        <a class="nav-link ms-3" href="{% url 'logout' %}?next={{ request.path }}">{% translate 'Logout' %}</a>
+      {% else %}
+        <a class="nav-link ms-3" href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a>
+      {% endif %}
     </div>
   </div>
 </nav>

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% translate 'Login' %}{% endblock %}
+{% block content %}
+<h1>{% translate 'Login' %}</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <input type="hidden" name="next" value="{{ next }}" />
+  <button type="submit" class="btn btn-primary">{% translate 'Login' %}</button>
+</form>
+{% endblock %}

--- a/wikikysely_project/urls.py
+++ b/wikikysely_project/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
 
 urlpatterns += i18n_patterns(
     path('admin/', admin.site.urls),
+    path('accounts/', include('django.contrib.auth.urls')),
     path('', include('wikikysely_project.survey.urls')),
 )
 


### PR DESCRIPTION
## Summary
- enable default Django auth URLs
- add basic login template
- show login/logout links in navbar

## Testing
- `python manage.py check` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876737ea488832eaa5eb380f865ebe6