### PR TITLE
Relax login requirements for viewing surveys

### DIFF
--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -8,7 +8,6 @@ from .models import Survey, Question, Answer
 from .forms import SurveyForm, QuestionForm, AnswerForm
 
 
-@login_required
 def survey_list(request):
     surveys = Survey.objects.filter(deleted=False)
     return render(request, 'survey/survey_list.html', {'surveys': surveys})
@@ -29,7 +28,6 @@ def survey_create(request):
     return render(request, 'survey/survey_form.html', {'form': form})
 
 
-@login_required
 def survey_detail(request, pk):
     survey = get_object_or_404(Survey, pk=pk, deleted=False)
     questions = survey.questions.filter(deleted=False)
@@ -92,7 +90,6 @@ def answer_list(request):
     return render(request, 'survey/answer_list.html', {'answers': answers})
 
 
-@login_required
 def survey_results(request, pk):
     survey = get_object_or_404(Survey, pk=pk, deleted=False)
     questions = survey.questions.filter(deleted=False)


### PR DESCRIPTION
## Summary
- allow anonymous users to browse survey list
- allow anonymous users to view individual surveys
- allow anonymous users to view survey results

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement django==4.2)*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687673f77970832e82a63803551675e8