### PR TITLE
Fix missing i18n load

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,10 +1,10 @@
+{% load static i18n %}
 <!DOCTYPE html>
 <html lang="{% get_current_language %}">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}WikiKysely{% endblock %}</title>
-    {% load static %}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- ensure translation tags are loaded in `base.html`

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6876764d71c8832ebd31507658022d57