### PR TITLE
Fix missing messages and validate survey dates

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -37,6 +37,14 @@
   </div>
 </nav>
 <div class="container mt-4">
+    {% if messages %}
+        {% for message in messages %}
+            <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
     {% block content %}{% endblock %}
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -8,6 +8,16 @@ class SurveyForm(forms.ModelForm):
         model = Survey
         fields = ['title', 'description', 'start_date', 'end_date']
 
+    def clean(self):
+        cleaned_data = super().clean()
+        start = cleaned_data.get('start_date')
+        end = cleaned_data.get('end_date')
+        if start and end and end < start:
+            raise forms.ValidationError({
+                'end_date': _('End date must be after start date.')
+            })
+        return cleaned_data
+
 
 class QuestionForm(forms.ModelForm):
     class Meta:


### PR DESCRIPTION
## Summary
- display Django messages in the base template
- validate that `end_date` occurs after `start_date` in `SurveyForm`

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68767796f608832ebd689828a37e4339