### PR TITLE
Fix login redirect path

### DIFF
--- a/wikikysely_project/settings.py
+++ b/wikikysely_project/settings.py
@@ -76,3 +76,7 @@ STATIC_URL = 'static/'
 STATIC_ROOT = BASE_DIR / 'static'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# After logging in, redirect users to the Finnish index page instead of the
+# nonexistent ``/accounts/profile/`` path provided by Django's defaults.
+LOGIN_REDIRECT_URL = '/fi/'


### PR DESCRIPTION
## Summary
- redirect users to /fi/ after login so `/accounts/profile/` doesn't 404

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6876813cdf00832e85efa2b0f7d9152d