### PR TITLE
Add editing for surveys and soft question deletion

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -7,13 +7,19 @@
 <p>{% translate 'State' %}: {{ survey.get_state_display }}</p>
 <p>{% translate 'Start date' %}: {{ survey.start_date }} | {% translate 'End date' %}: {{ survey.end_date }}</p>
 {% if can_edit %}
+  <a href="{% url 'survey:survey_edit' survey.pk %}" class="btn btn-warning">{% translate 'Edit survey' %}</a>
   <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
 {% endif %}
 <a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary">{% translate 'Answer survey' %}</a>
 <a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info">{% translate 'Results' %}</a>
 <ul class="list-group mt-3">
 {% for q in questions %}
-  <li class="list-group-item">{{ q.text }}</li>
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span>{{ q.text }}</span>
+    {% if can_edit %}
+      <a href="{% url 'survey:question_delete' q.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove' %}</a>
+    {% endif %}
+  </li>
 {% endfor %}
 </ul>
 {% endblock %}

--- a/templates/survey/survey_form.html
+++ b/templates/survey/survey_form.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{% translate 'Create survey' %}{% endblock %}
+{% block title %}{% if is_edit %}{% translate 'Edit survey' %}{% else %}{% translate 'Create survey' %}{% endif %}{% endblock %}
 {% block content %}
-<h1>{% translate 'Create survey' %}</h1>
+<h1>{% if is_edit %}{% translate 'Edit survey' %}{% else %}{% translate 'Create survey' %}{% endif %}</h1>
 <form method="post">
   {% csrf_token %}
   {{ form.as_p }}

--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 class SurveyForm(forms.ModelForm):
     class Meta:
         model = Survey
-        fields = ['title', 'description', 'start_date', 'end_date']
+        fields = ['title', 'description', 'start_date', 'end_date', 'state']
 
     def clean(self):
         cleaned_data = super().clean()

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -7,8 +7,10 @@ urlpatterns = [
     path('', views.survey_list, name='survey_list'),
     path('survey/create/', views.survey_create, name='survey_create'),
     path('survey/<int:pk>/', views.survey_detail, name='survey_detail'),
+    path('survey/<int:pk>/edit/', views.survey_edit, name='survey_edit'),
     path('survey/<int:pk>/answer/', views.answer_survey, name='answer_survey'),
     path('survey/<int:survey_pk>/question/add/', views.question_add, name='question_add'),
+    path('question/<int:pk>/delete/', views.question_delete, name='question_delete'),
     path('answers/', views.answer_list, name='answer_list'),
     path('results/<int:pk>/', views.survey_results, name='survey_results'),
 ]


### PR DESCRIPTION
## Summary
- allow state to be modified in `SurveyForm`
- create view & URL for editing a survey
- allow questions to be soft deleted
- show edit and remove actions in survey detail template
- make survey form template work for both creating and editing

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6876841cdd7c832e88398e4518df6830