### PR TITLE
Add question and answer management

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -7,6 +7,6 @@
 <form method="post">
   {% csrf_token %}
   {{ form.as_p }}
-  <button type="submit" class="btn btn-primary">{% translate 'Submit' %}</button>
+  <button type="submit" class="btn btn-primary">{% if is_edit %}{% translate 'Save' %}{% else %}{% translate 'Submit' %}{% endif %}</button>
 </form>
 {% endblock %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -16,10 +16,25 @@
 {% for q in questions %}
   <li class="list-group-item d-flex justify-content-between align-items-center">
     <span>{{ q.text }}</span>
-    {% if can_edit %}
-      <a href="{% url 'survey:question_delete' q.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove' %}</a>
-    {% endif %}
   </li>
 {% endfor %}
 </ul>
+{% if user_answers %}
+<h2 class="mt-4">{% translate 'My answers' %}</h2>
+<table class="table">
+  <thead><tr><th>{% translate 'Question' %}</th><th>{% translate 'Answer' %}</th><th></th></tr></thead>
+  <tbody>
+    {% for a in user_answers %}
+    <tr>
+      <td>{{ a.question.text }}</td>
+      <td>{{ a.get_answer_display }}</td>
+      <td>
+        <a href="{% url 'survey:answer_edit' a.pk %}" class="btn btn-sm btn-warning">{% translate 'Edit' %}</a>
+        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove' %}</a>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
 {% endblock %}

--- a/templates/survey/survey_form.html
+++ b/templates/survey/survey_form.html
@@ -8,4 +8,28 @@
   {{ form.as_p }}
   <button type="submit" class="btn btn-primary">{% translate 'Save' %}</button>
 </form>
+{% if is_edit %}
+  <h2 class="mt-4">{% translate 'Questions' %}</h2>
+  <ul class="list-group mb-3">
+    {% for q in active_questions %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span>{{ q.text }}</span>
+        <a href="{% url 'survey:question_delete' q.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove' %}</a>
+      </li>
+    {% empty %}
+      <li class="list-group-item">{% translate 'No questions' %}</li>
+    {% endfor %}
+  </ul>
+  {% if deleted_questions %}
+    <h3>{% translate 'Deleted questions' %}</h3>
+    <ul class="list-group">
+      {% for q in deleted_questions %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <span class="text-muted">{{ q.text }}</span>
+          <a href="{% url 'survey:question_restore' q.pk %}" class="btn btn-sm btn-secondary">{% translate 'Restore' %}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+{% endif %}
 {% endblock %}

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -11,6 +11,9 @@ urlpatterns = [
     path('survey/<int:pk>/answer/', views.answer_survey, name='answer_survey'),
     path('survey/<int:survey_pk>/question/add/', views.question_add, name='question_add'),
     path('question/<int:pk>/delete/', views.question_delete, name='question_delete'),
+    path('question/<int:pk>/restore/', views.question_restore, name='question_restore'),
+    path('answer/<int:pk>/edit/', views.answer_edit, name='answer_edit'),
+    path('answer/<int:pk>/delete/', views.answer_delete, name='answer_delete'),
     path('answers/', views.answer_list, name='answer_list'),
     path('results/<int:pk>/', views.survey_results, name='survey_results'),
 ]


### PR DESCRIPTION
## Summary
- show user answers on survey page with edit/delete actions
- move question deletion to survey edit page and allow restoring
- show deleted questions with restore button
- support editing an answer

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687687c8cd84832ea01aefa4a2d846d1