### PR TITLE
Add unanswered question count on survey page

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -10,7 +10,12 @@
   <a href="{% url 'survey:survey_edit' survey.pk %}" class="btn btn-warning">{% translate 'Edit survey' %}</a>
   <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
 {% endif %}
-<a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary">{% translate 'Answer survey' %}</a>
+{% if request.user.is_authenticated %}
+<p class="mt-3">
+  {% translate 'Unanswered questions' %}: {{ unanswered_count }}
+  <a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary ms-2">{% translate 'Answer survey' %}</a>
+</p>
+{% endif %}
 <a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info">{% translate 'Results' %}</a>
 {% if user_answers %}
 <h2 class="mt-4">{% translate 'My answers' %}</h2>

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -35,11 +35,19 @@ def survey_detail(request, pk):
     if request.user.is_authenticated:
         user_answers = Answer.objects.filter(user=request.user, question__survey=survey)
     can_edit = request.user == survey.creator or request.user.is_superuser
+
+    unanswered_count = 0
+    if request.user.is_authenticated:
+        total_questions = questions.count()
+        answered_count = user_answers.count()
+        unanswered_count = max(total_questions - answered_count, 0)
+
     return render(request, 'survey/survey_detail.html', {
         'survey': survey,
         'questions': questions,
         'can_edit': can_edit,
         'user_answers': user_answers,
+        'unanswered_count': unanswered_count,
     })
 
 


### PR DESCRIPTION
## Summary
- show how many questions are unanswered for the current user
- move the **Answer survey** button near that information

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68768bd41e74832e9e3a83d750cc47fd