### PR TITLE
Add user registration functionality

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -93,3 +93,9 @@ msgstr "Ei enempää kysymyksiä"
 
 msgid "Answer saved"
 msgstr "Vastaus tallennettu"
+
+msgid "Register"
+msgstr "Rekisteröidy"
+
+msgid "Registration successful"
+msgstr "Rekisteröinti onnistui"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -93,3 +93,9 @@ msgstr "Inga fler frågor"
 
 msgid "Answer saved"
 msgstr "Svar sparat"
+
+msgid "Register"
+msgstr "Registrera"
+
+msgid "Registration successful"
+msgstr "Registreringen lyckades"

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,8 +14,10 @@
     <a class="navbar-brand" href="{% url 'survey:survey_list' %}">WikiKysely</a>
     <div class="collapse navbar-collapse">
       <ul class="navbar-nav me-auto">
+        {% if request.user.is_authenticated %}
         <li class="nav-item"><a class="nav-link" href="{% url 'survey:survey_create' %}">{% translate 'Create survey' %}</a></li>
         <li class="nav-item"><a class="nav-link" href="{% url 'survey:answer_list' %}">{% translate 'My answers' %}</a></li>
+        {% endif %}
       </ul>
       <form action="{% url 'set_language' %}" method="post" class="d-flex">
         {% csrf_token %}
@@ -33,6 +35,7 @@
         <a class="nav-link ms-3" href="{% url 'logout' %}?next={{ request.path }}">{% translate 'Logout' %}</a>
       {% else %}
         <a class="nav-link ms-3" href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a>
+        <a class="nav-link ms-3" href="{% url 'survey:register' %}?next={{ request.path }}">{% translate 'Register' %}</a>
       {% endif %}
     </div>
   </div>

--- a/templates/registration/register.html
+++ b/templates/registration/register.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% translate 'Register' %}{% endblock %}
+{% block content %}
+<h1>{% translate 'Register' %}</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <input type="hidden" name="next" value="{{ next }}" />
+  <button type="submit" class="btn btn-primary">{% translate 'Register' %}</button>
+</form>
+{% endblock %}

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -5,6 +5,7 @@ app_name = 'survey'
 
 urlpatterns = [
     path('', views.survey_list, name='survey_list'),
+    path('register/', views.register, name='register'),
     path('survey/create/', views.survey_create, name='survey_create'),
     path('survey/<int:pk>/', views.survey_detail, name='survey_detail'),
     path('survey/<int:pk>/edit/', views.survey_edit, name='survey_edit'),

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -1,6 +1,8 @@
 import random
 from django.contrib import messages
+from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.forms import UserCreationForm
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -11,6 +13,20 @@ from .forms import SurveyForm, QuestionForm, AnswerForm
 def survey_list(request):
     surveys = Survey.objects.filter(deleted=False)
     return render(request, 'survey/survey_list.html', {'surveys': surveys})
+
+
+def register(request):
+    if request.method == 'POST':
+        form = UserCreationForm(request.POST)
+        if form.is_valid():
+            user = form.save()
+            login(request, user)
+            messages.success(request, _('Registration successful'))
+            next_url = request.GET.get('next', '/')
+            return redirect(next_url)
+    else:
+        form = UserCreationForm()
+    return render(request, 'registration/register.html', {'form': form})
 
 
 @login_required


### PR DESCRIPTION
## Summary
- conditionally show survey creation links for logged in users
- add Register link in navbar
- implement registration view and url
- create registration template
- update translations

## Testing
- `python manage.py check`
- `python manage.py compilemessages`

------
https://chatgpt.com/codex/tasks/task_e_6876b6b5f03c832e9bd58b5e3de85379