### PR TITLE
Add missing Finnish and Swedish translations

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1,101 +1,203 @@
 msgid ""
 msgstr ""
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-15 20:42+0000\n"
 "Language: fi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
 # UI strings
+#: templates/base.html:20 templates/survey/survey_form.html:3
+#: templates/survey/survey_form.html:5
 msgid "Create survey"
 msgstr "Luo kysely"
 
+#: templates/base.html:21 templates/survey/answer_list.html:3
+#: templates/survey/answer_list.html:5 templates/survey/survey_detail.html:21
 msgid "My answers"
 msgstr "Vastaukseni"
 
-msgid "Save"
-msgstr "Tallenna"
+#: templates/base.html:37
+msgid "Logout"
+msgstr "Kirjaudu ulos"
 
-msgid "Add question"
-msgstr "Lisää kysymys"
+#: templates/base.html:39 templates/registration/login.html:3
+#: templates/registration/login.html:5 templates/registration/login.html:10
+msgid "Login"
+msgstr "Kirjaudu sisään"
 
-msgid "State"
-msgstr "Tila"
-
-msgid "Start date"
-msgstr "Aloituspäivä"
-
-msgid "End date"
-msgstr "Päättymispäivä"
-
-msgid "Answer survey"
-msgstr "Vastaa kyselyyn"
-
-msgid "Results"
-msgstr "Tulokset"
-
-msgid "Submit"
-msgstr "Lähetä"
-
-msgid "Question"
-msgstr "Kysymys"
-
-msgid "Answer"
-msgstr "Vastaus"
-
-msgid "No answers"
-msgstr "Ei vastauksia"
-
-msgid "Total respondents"
-msgstr "Vastaajien määrä"
-
-msgid "Yes"
-msgstr "Kyllä"
-
-msgid "No"
-msgstr "Ei"
-
-msgid "Total"
-msgstr "Yhteensä"
-
-msgid "Surveys"
-msgstr "Kyselyt"
-
-msgid "Title"
-msgstr "Otsikko"
-
-msgid "No surveys"
-msgstr "Ei kyselyitä"
-
-msgid "Skip"
-msgstr "Ohita"
-
-msgid "Running"
-msgstr "Käynnissä"
-
-msgid "Paused"
-msgstr "Tauolla"
-
-msgid "Closed"
-msgstr "Suljettu"
-
-msgid "Survey created"
-msgstr "Kysely luotu"
-
-msgid "No permission"
-msgstr "Ei oikeuksia"
-
-msgid "Question added"
-msgstr "Kysymys lisätty"
-
-msgid "Survey not active"
-msgstr "Kysely ei ole aktiivinen"
-
-msgid "No more questions"
-msgstr "Ei enempää kysymyksiä"
-
-msgid "Answer saved"
-msgstr "Vastaus tallennettu"
-
+#: templates/base.html:40 templates/registration/register.html:3
+#: templates/registration/register.html:5
+#: templates/registration/register.html:10
 msgid "Register"
 msgstr "Rekisteröidy"
 
+#: templates/survey/answer_form.html:11 templates/survey/question_form.html:9
+#: templates/survey/survey_form.html:9
+msgid "Save"
+msgstr "Tallenna"
+
+#: templates/survey/answer_form.html:19 templates/survey/results.html:9
+#: wikikysely_project/survey/models.py:42
+msgid "Yes"
+msgstr "Kyllä"
+
+#: templates/survey/answer_form.html:20 templates/survey/results.html:9
+#: wikikysely_project/survey/models.py:43
+msgid "No"
+msgstr "Ei"
+
+#: templates/survey/answer_form.html:21 wikikysely_project/survey/forms.py:42
+msgid "Skip"
+msgstr "Ohita"
+
+#: templates/survey/answer_list.html:7 templates/survey/results.html:9
+#: templates/survey/survey_detail.html:23
+msgid "Question"
+msgstr "Kysymys"
+
+#: templates/survey/answer_list.html:7 templates/survey/survey_detail.html:23
+msgid "Answer"
+msgstr "Vastaus"
+
+#: templates/survey/answer_list.html:12
+msgid "No answers"
+msgstr "Ei vastauksia"
+
+#: templates/survey/question_form.html:3 templates/survey/question_form.html:5
+#: templates/survey/survey_detail.html:11
+msgid "Add question"
+msgstr "Lisää kysymys"
+
+#: templates/survey/results.html:5 templates/survey/survey_detail.html:19
+msgid "Results"
+msgstr "Tulokset"
+
+#: templates/survey/results.html:7
+msgid "Total respondents"
+msgstr "Vastaajien määrä"
+
+#: templates/survey/results.html:9
+msgid "Total"
+msgstr "Yhteensä"
+
+#: templates/survey/survey_detail.html:7 templates/survey/survey_list.html:7
+msgid "State"
+msgstr "Tila"
+
+#: templates/survey/survey_detail.html:8
+msgid "Start date"
+msgstr "Aloituspäivä"
+
+#: templates/survey/survey_detail.html:8
+msgid "End date"
+msgstr "Päättymispäivä"
+
+# UI strings
+#: templates/survey/survey_detail.html:10 templates/survey/survey_form.html:3
+#: templates/survey/survey_form.html:5
+msgid "Edit survey"
+msgstr "Muokkaa kyselyä"
+
+#: templates/survey/survey_detail.html:15
+msgid "Unanswered questions"
+msgstr "Vastaamattomat kysymykset"
+
+#: templates/survey/survey_detail.html:16
+msgid "Answer survey"
+msgstr "Vastaa kyselyyn"
+
+#: templates/survey/survey_detail.html:30
+msgid "Edit"
+msgstr "Muokkaa"
+
+#: templates/survey/survey_detail.html:31 templates/survey/survey_form.html:17
+msgid "Remove"
+msgstr "Poista"
+
+#: templates/survey/survey_form.html:12
+msgid "Questions"
+msgstr "Kysymykset"
+
+#: templates/survey/survey_form.html:20
+msgid "No questions"
+msgstr "Ei kysymyksiä"
+msgid "Deleted questions"
+msgstr "Poistetut kysymykset"
+
+#: templates/survey/survey_form.html:29
+msgid "Restore"
+msgstr "Palauta"
+#: templates/survey/survey_list.html:3 templates/survey/survey_list.html:5
+msgid "Surveys"
+msgstr "Kyselyt"
+
+#: templates/survey/survey_list.html:7
+msgid "Title"
+msgstr "Otsikko"
+
+#: templates/survey/survey_list.html:12
+msgid "No surveys"
+msgstr "Ei kyselyitä"
+
+#: wikikysely_project/survey/forms.py:30
+msgid "End date must be after start date."
+msgstr "Päättymispäivän on oltava aloituspäivän jälkeen."
+#: wikikysely_project/survey/models.py:9
+msgid "Running"
+msgstr "Käynnissä"
+
+#: wikikysely_project/survey/models.py:10
+msgid "Paused"
+msgstr "Tauolla"
+
+#: wikikysely_project/survey/models.py:11
+msgid "Closed"
+msgstr "Suljettu"
+
+#: wikikysely_project/survey/views.py:24
 msgid "Registration successful"
 msgstr "Rekisteröinti onnistui"
+
+#: wikikysely_project/survey/views.py:40
+msgid "Survey created"
+msgstr "Kysely luotu"
+
+#: wikikysely_project/survey/views.py:74 wikikysely_project/survey/views.py:99
+#: wikikysely_project/survey/views.py:120
+#: wikikysely_project/survey/views.py:133
+msgid "No permission"
+msgstr "Ei oikeuksia"
+
+#: wikikysely_project/survey/views.py:80
+msgid "Survey updated"
+msgstr "Kysely päivitetty"
+#: wikikysely_project/survey/views.py:108
+msgid "Question added"
+msgstr "Kysymys lisätty"
+
+#: wikikysely_project/survey/views.py:124
+msgid "Question removed"
+msgstr "Kysymys poistettu"
+msgid "Question restored"
+msgstr "Kysymys palautettu"
+
+#: wikikysely_project/survey/views.py:145
+msgid "Survey not active"
+msgstr "Kysely ei ole aktiivinen"
+
+#: wikikysely_project/survey/views.py:151
+msgid "No more questions"
+msgstr "Ei enempää kysymyksiä"
+
+#: wikikysely_project/survey/views.py:159
+msgid "Answer saved"
+msgstr "Vastaus tallennettu"
+
+#: wikikysely_project/survey/views.py:180
+msgid "Answer updated"
+msgstr "Vastaus päivitetty"
+msgid "Answer removed"
+msgstr "Vastaus poistettu"
+
+#~ msgid "Submit"
+#~ msgstr "Lähetä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -1,101 +1,190 @@
 msgid ""
 msgstr ""
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-15 20:42+0000\n"
 "Language: sv\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
 # UI strings
+#: templates/base.html:20 templates/survey/survey_form.html:3
+#: templates/survey/survey_form.html:5
 msgid "Create survey"
 msgstr "Skapa enkät"
 
+#: templates/base.html:21 templates/survey/answer_list.html:3
+#: templates/survey/answer_list.html:5 templates/survey/survey_detail.html:21
 msgid "My answers"
 msgstr "Mina svar"
 
-msgid "Save"
-msgstr "Spara"
+#: templates/base.html:37
+msgid "Logout"
+msgstr "Logga ut"
 
-msgid "Add question"
-msgstr "Lägg till fråga"
+#: templates/base.html:39 templates/registration/login.html:3
+#: templates/registration/login.html:5 templates/registration/login.html:10
+msgid "Login"
+msgstr "Logga in"
 
-msgid "State"
-msgstr "Status"
-
-msgid "Start date"
-msgstr "Startdatum"
-
-msgid "End date"
-msgstr "Slutdatum"
-
-msgid "Answer survey"
-msgstr "Svara på enkäten"
-
-msgid "Results"
-msgstr "Resultat"
-
-msgid "Submit"
-msgstr "Skicka"
-
-msgid "Question"
-msgstr "Fråga"
-
-msgid "Answer"
-msgstr "Svar"
-
-msgid "No answers"
-msgstr "Inga svar"
-
-msgid "Total respondents"
-msgstr "Antal svarande"
-
-msgid "Yes"
-msgstr "Ja"
-
-msgid "No"
-msgstr "Nej"
-
-msgid "Total"
-msgstr "Totalt"
-
-msgid "Surveys"
-msgstr "Enkäter"
-
-msgid "Title"
-msgstr "Titel"
-
-msgid "No surveys"
-msgstr "Inga enkäter"
-
-msgid "Skip"
-msgstr "Hoppa över"
-
-msgid "Running"
-msgstr "Pågår"
-
-msgid "Paused"
-msgstr "Pausad"
-
-msgid "Closed"
-msgstr "Stängd"
-
-msgid "Survey created"
-msgstr "Enkät skapad"
-
-msgid "No permission"
-msgstr "Ingen behörighet"
-
-msgid "Question added"
-msgstr "Fråga tillagd"
-
-msgid "Survey not active"
-msgstr "Enkäten är inte aktiv"
-
-msgid "No more questions"
-msgstr "Inga fler frågor"
-
-msgid "Answer saved"
-msgstr "Svar sparat"
-
+#: templates/base.html:40 templates/registration/register.html:3
+#: templates/registration/register.html:5
+#: templates/registration/register.html:10
 msgid "Register"
 msgstr "Registrera"
 
+#: templates/survey/answer_form.html:11 templates/survey/question_form.html:9
+#: templates/survey/survey_form.html:9
+msgid "Save"
+msgstr "Spara"
+
+#: templates/survey/answer_form.html:19 templates/survey/results.html:9
+#: wikikysely_project/survey/models.py:42
+msgid "Yes"
+msgstr "Ja"
+
+#: templates/survey/answer_form.html:20 templates/survey/results.html:9
+#: wikikysely_project/survey/models.py:43
+msgid "No"
+msgstr "Nej"
+
+#: templates/survey/answer_form.html:21 wikikysely_project/survey/forms.py:42
+msgid "Skip"
+msgstr "Hoppa över"
+
+#: templates/survey/answer_list.html:7 templates/survey/results.html:9
+#: templates/survey/survey_detail.html:23
+msgid "Question"
+msgstr "Fråga"
+
+#: templates/survey/answer_list.html:7 templates/survey/survey_detail.html:23
+msgid "Answer"
+msgstr "Svar"
+
+#: templates/survey/answer_list.html:12
+msgid "No answers"
+msgstr "Inga svar"
+
+#: templates/survey/question_form.html:3 templates/survey/question_form.html:5
+#: templates/survey/survey_detail.html:11
+msgid "Add question"
+msgstr "Lägg till fråga"
+
+#: templates/survey/results.html:5 templates/survey/survey_detail.html:19
+msgid "Results"
+msgstr "Resultat"
+
+#: templates/survey/results.html:7
+msgid "Total respondents"
+msgstr "Antal svarande"
+
+#: templates/survey/results.html:9
+msgid "Total"
+msgstr "Totalt"
+
+#: templates/survey/survey_detail.html:7 templates/survey/survey_list.html:7
+msgid "State"
+msgstr "Status"
+
+#: templates/survey/survey_detail.html:8
+msgid "Start date"
+msgstr "Startdatum"
+
+#: templates/survey/survey_detail.html:8
+msgid "End date"
+msgstr "Slutdatum"
+
+# UI strings
+#: templates/survey/survey_detail.html:10 templates/survey/survey_form.html:3
+#: templates/survey/survey_form.html:5
+msgid "Edit survey"
+msgstr "Redigera enkät"
+
+#: templates/survey/survey_detail.html:15
+msgid "Unanswered questions"
+msgstr "Obesvarade frågor"
+#: templates/survey/survey_detail.html:16
+msgid "Answer survey"
+msgstr "Svara på enkäten"
+
+#: templates/survey/survey_detail.html:30
+msgid "Edit"
+msgstr "Redigera"
+
+#: templates/survey/survey_detail.html:31 templates/survey/survey_form.html:17
+msgid "Remove"
+msgstr "Ta bort"
+
+#: templates/survey/survey_form.html:12
+msgid "Questions"
+msgstr "Frågor"
+#: templates/survey/survey_form.html:20
+msgid "No questions"
+msgstr "Inga frågor"
+msgid "Deleted questions"
+msgstr "Borttagna frågor"
+#: templates/survey/survey_form.html:29
+msgid "Restore"
+msgstr "Återställ"
+#: templates/survey/survey_list.html:3 templates/survey/survey_list.html:5
+msgid "Surveys"
+msgstr "Enkäter"
+
+#: templates/survey/survey_list.html:7
+msgid "Title"
+msgstr "Titel"
+
+#: templates/survey/survey_list.html:12
+msgid "No surveys"
+msgstr "Inga enkäter"
+
+#: wikikysely_project/survey/forms.py:30
+msgid "End date must be after start date."
+msgstr "Slutdatum måste vara efter startdatum."
+msgid "Running"
+msgstr "Pågår"
+
+#: wikikysely_project/survey/models.py:10
+msgid "Paused"
+msgstr "Pausad"
+
+#: wikikysely_project/survey/models.py:11
+msgid "Closed"
+msgstr "Stängd"
+
+#: wikikysely_project/survey/views.py:24
 msgid "Registration successful"
 msgstr "Registreringen lyckades"
+
+#: wikikysely_project/survey/views.py:40
+msgid "Survey created"
+msgstr "Enkät skapad"
+
+#: wikikysely_project/survey/views.py:74 wikikysely_project/survey/views.py:99
+#: wikikysely_project/survey/views.py:120
+#: wikikysely_project/survey/views.py:133
+msgid "No permission"
+msgstr "Ingen behörighet"
+
+#: wikikysely_project/survey/views.py:80
+msgid "Survey updated"
+msgstr "Enkät uppdaterad"
+msgid "Question added"
+msgstr "Fråga tillagd"
+
+#: wikikysely_project/survey/views.py:124
+msgid "Question removed"
+msgstr "Fråga borttagen"
+msgid "Question restored"
+msgstr "Fråga återställd"
+msgid "Survey not active"
+msgstr "Enkäten är inte aktiv"
+msgid "No more questions"
+msgstr "Inga fler frågor"
+msgid "Answer saved"
+msgstr "Svar sparat"
+msgid "Answer updated"
+msgstr "Svar uppdaterat"
+msgid "Answer removed"
+msgstr "Svar borttaget"
+
+#~ msgid "Submit"
+#~ msgstr "Skicka"


### PR DESCRIPTION
## Summary
- update Finnish translations
- update Swedish translations

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6876bd08b900832eb832b85fe05aada5