### PR TITLE
Add compilemessages step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,15 @@ Prototype implementation of a multilingual wiki survey tool built with Django.
    ```bash
    python manage.py createsuperuser
    ```
-4. Run the development server:
+4. Compile translation messages:
+   ```bash
+   python manage.py compilemessages
+   ```
+5. Run the development server:
    ```bash
    python manage.py runserver
    ```
-5. Access the site at `http://localhost:8000/`.
+6. Access the site at `http://localhost:8000/`.
 
 The UI supports Finnish, Swedish and English. You can change the language from the menu.
+If the selected language does not apply, ensure translation files have been compiled using `python manage.py compilemessages`.


### PR DESCRIPTION
## Summary
- document running `python manage.py compilemessages`
- note how to fix UI language mismatches

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6877190e9094832eb22a90ff92b671ac