### PR TITLE
Suppress success alerts

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -45,10 +45,12 @@
 <div class="container mt-4">
     {% if messages %}
         {% for message in messages %}
+            {% if "success" not in message.tags %}
             <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
                 {{ message }}
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
+            {% endif %}
         {% endfor %}
     {% endif %}
     {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- hide success alerts in base template so they are not displayed

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68771c0cad00832ebc26620654559555