### PR TITLE
Add delete button to answer edit form

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -6,18 +6,18 @@
 <h2>{{ question.text }}</h2>
 <form method="post">
   {% csrf_token %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+  {% for field in form.hidden_fields %}
+    {{ field }}
+  {% endfor %}
+  <button type="submit" name="answer" value="yes" class="btn btn-success me-2">{% translate 'Yes' %}</button>
+  <button type="submit" name="answer" value="no" class="btn btn-danger me-2">{% translate 'No' %}</button>
   {% if is_edit %}
-    {{ form.as_p }}
-    <button type="submit" class="btn btn-primary">{% translate 'Save' %}</button>
+    <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Cancel' %}</button>
+    <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger ms-2">{% translate 'Remove' %}</a>
   {% else %}
-    {% if form.non_field_errors %}
-      <div class="alert alert-danger">{{ form.non_field_errors }}</div>
-    {% endif %}
-    {% for field in form.hidden_fields %}
-      {{ field }}
-    {% endfor %}
-    <button type="submit" name="answer" value="yes" class="btn btn-success me-2">{% translate 'Yes' %}</button>
-    <button type="submit" name="answer" value="no" class="btn btn-danger me-2">{% translate 'No' %}</button>
     <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Skip' %}</button>
   {% endif %}
 </form>


### PR DESCRIPTION
## Summary
- show a remove button when editing an answer so users can delete their response
- display a Cancel button instead of Skip when editing

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68771f948bb4832ea1e546048ae482a0