### PR TITLE
Update answer edit button label

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -50,6 +50,10 @@ msgstr "Ei"
 msgid "Skip"
 msgstr "Ohita"
 
+#: templates/survey/answer_form.html:21
+msgid "Cancel"
+msgstr "Peruuta"
+
 #: templates/survey/answer_list.html:7 templates/survey/results.html:9
 #: templates/survey/survey_detail.html:23
 msgid "Question"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -50,6 +50,10 @@ msgstr "Nej"
 msgid "Skip"
 msgstr "Hoppa över"
 
+#: templates/survey/answer_form.html:21
+msgid "Cancel"
+msgstr "Avbryt"
+
 #: templates/survey/answer_list.html:7 templates/survey/results.html:9
 #: templates/survey/survey_detail.html:23
 msgid "Question"

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -14,9 +14,11 @@
   {% endfor %}
   <button type="submit" name="answer" value="yes" class="btn btn-success me-2">{% translate 'Yes' %}</button>
   <button type="submit" name="answer" value="no" class="btn btn-danger me-2">{% translate 'No' %}</button>
-  <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Skip' %}</button>
   {% if is_edit %}
+    <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Cancel' %}</button>
     <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger ms-2">{% translate 'Remove' %}</a>
+  {% else %}
+    <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Skip' %}</button>
   {% endif %}
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show `Cancel` button when editing answers
- add Finnish and Swedish translations for `Cancel`

## Testing
- `python manage.py check`
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py compilemessages`


------
https://chatgpt.com/codex/tasks/task_e_687723e9c944832ebecc7f538d97cd84