### PR TITLE
Fix cancel link on answer edit

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -15,7 +15,7 @@
   <button type="submit" name="answer" value="yes" class="btn btn-success me-2">{% translate 'Yes' %}</button>
   <button type="submit" name="answer" value="no" class="btn btn-danger me-2">{% translate 'No' %}</button>
   {% if is_edit %}
-    <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Cancel' %}</button>
+    <a href="{% url 'survey:survey_detail' survey.pk %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
     <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger ms-2">{% translate 'Remove' %}</a>
   {% else %}
     <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Skip' %}</button>


### PR DESCRIPTION
## Summary
- fix Cancel button so editing an answer links back to survey details

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_687725ea8650832e9da5716632bee8bf