### PR TITLE
Move add question button under unanswered list

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -9,7 +9,6 @@
 {% if request.user.is_authenticated %}
   {% if can_edit %}
     <div class="mb-2">
-      <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary me-2">{% translate 'Add question' %}</a>
       <a href="{% url 'survey:survey_edit' survey.pk %}" class="btn btn-warning">{% translate 'Edit survey' %}</a>
     </div>
   {% endif %}
@@ -21,7 +20,16 @@
       {% endfor %}
     </ul>
   {% endif %}
-  <a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary mb-3">{% translate 'Answer survey' %}</a>
+  <div class="mb-3">
+    {% if unanswered_questions %}
+      <a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary me-2">{% translate 'Answer survey' %}</a>
+    {% else %}
+      <a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info me-2">{% translate 'Results' %}</a>
+    {% endif %}
+    {% if can_edit %}
+      <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
+    {% endif %}
+  </div>
 {% elif can_edit %}
   <div class="mb-2">
     <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary me-2">{% translate 'Add question' %}</a>


### PR DESCRIPTION
## Summary
- rearrange survey detail page
- move the "Add question" button next to the answer/questions button
- show "Results" button instead of "Answer survey" when no unanswered questions remain

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_687729ff6298832e8f1abd7417838518