### PR TITLE
Move Edit button

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -7,11 +7,7 @@
 <p>{% translate 'State' %}: {{ survey.get_state_display }}</p>
 <p>{% translate 'Start date' %}: {{ survey.start_date }} | {% translate 'End date' %}: {{ survey.end_date }}</p>
 {% if request.user.is_authenticated %}
-  {% if can_edit %}
-    <div class="mb-2">
-      <a href="{% url 'survey:survey_edit' survey.pk %}" class="btn btn-warning">{% translate 'Edit survey' %}</a>
-    </div>
-  {% endif %}
+  {# Edit survey button moved next to the Results button at the bottom #}
   {% if unanswered_questions %}
     <h2 class="mt-3">{% translate 'Unanswered questions' %}</h2>
     <ul class="list-group mb-3">
@@ -33,7 +29,6 @@
 {% elif can_edit %}
   <div class="mb-2">
     <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary me-2">{% translate 'Add question' %}</a>
-    <a href="{% url 'survey:survey_edit' survey.pk %}" class="btn btn-warning">{% translate 'Edit survey' %}</a>
   </div>
 {% endif %}
 {% if user_answers %}
@@ -54,5 +49,8 @@
   </tbody>
 </table>
 {% endif %}
-<a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info mt-3">{% translate 'Results' %}</a>
+<a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info mt-3 me-2">{% translate 'Results' %}</a>
+{% if can_edit %}
+<a href="{% url 'survey:survey_edit' survey.pk %}" class="btn btn-warning mt-3">{% translate 'Edit survey' %}</a>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- move the **Edit survey** button next to the **Results** button on the survey detail page

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68772be19718832e8529f62417cabc1c