### PR TITLE
Limit answer removal to active survey

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -219,5 +219,9 @@ msgstr "Vastaus päivitetty"
 msgid "Answer removed"
 msgstr "Vastaus poistettu"
 
+#: wikikysely_project/survey/views.py:196
+msgid "Answer can only be removed while the survey is running"
+msgstr "Vastauksen voi poistaa vain, kun kysely on käynnissä"
+
 #~ msgid "Submit"
 #~ msgstr "Lähetä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -219,5 +219,9 @@ msgstr "Svar uppdaterat"
 msgid "Answer removed"
 msgstr "Svar borttaget"
 
+#: wikikysely_project/survey/views.py:196
+msgid "Answer can only be removed while the survey is running"
+msgstr "Svar kan tas bort endast när enkäten är igång"
+
 #~ msgid "Submit"
 #~ msgstr "Skicka"

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -16,7 +16,9 @@
   <button type="submit" name="answer" value="no" class="btn btn-danger me-2">{% translate 'No' %}</button>
   {% if is_edit %}
     <a href="{% url 'survey:survey_detail' survey.pk %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
+    {% if survey.state == 'running' %}
     <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger ms-2">{% translate 'Remove' %}</a>
+    {% endif %}
   {% else %}
     <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Skip' %}</button>
   {% endif %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -42,7 +42,9 @@
       <td>{{ a.get_answer_display }}</td>
       <td>
         <a href="{% url 'survey:answer_edit' a.pk %}" class="btn btn-sm btn-warning">{% translate 'Edit' %}</a>
+        {% if survey.state == 'running' %}
         <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove' %}</a>
+        {% endif %}
       </td>
     </tr>
     {% endfor %}

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -192,10 +192,13 @@ def answer_edit(request, pk):
 @login_required
 def answer_delete(request, pk):
     answer = get_object_or_404(Answer, pk=pk, user=request.user)
-    survey_pk = answer.question.survey.pk
+    survey = answer.question.survey
+    if survey.state != 'running':
+        messages.error(request, _('Answer can only be removed while the survey is running'))
+        return redirect('survey:survey_detail', pk=survey.pk)
     answer.delete()
     messages.success(request, _('Answer removed'))
-    return redirect('survey:survey_detail', pk=survey_pk)
+    return redirect('survey:survey_detail', pk=survey.pk)
 
 
 def survey_results(request, pk):


### PR DESCRIPTION
## Summary
- prevent deleting answers from surveys that are not running
- hide delete buttons for answers when survey not running
- update translations

## Testing
- `pip install -r requirements.txt`
- `python manage.py compilemessages`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68772f492464832eaa9c62bdcd875aac