### PR TITLE
Enforce closed survey restrictions

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -223,5 +223,21 @@ msgstr "Vastaus poistettu"
 msgid "Answer can only be removed while the survey is running"
 msgstr "Vastauksen voi poistaa vain, kun kysely on käynnissä"
 
+#: wikikysely_project/survey/views.py:185
+msgid "Answer can only be edited while the survey is running"
+msgstr "Vastauksen voi muokata vain, kun kysely on käynnissä"
+
+#: wikikysely_project/survey/views.py:101
+msgid "Cannot add questions to a closed survey"
+msgstr "Suljettuun kyselyyn ei voi lisätä kysymyksiä"
+
+#: wikikysely_project/survey/views.py:125
+msgid "Cannot remove questions from a closed survey"
+msgstr "Suljetusta kyselystä ei voi poistaa kysymyksiä"
+
+#: wikikysely_project/survey/views.py:141
+msgid "Cannot restore questions in a closed survey"
+msgstr "Suljettuun kyselyyn ei voi palauttaa kysymyksiä"
+
 #~ msgid "Submit"
 #~ msgstr "Lähetä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -223,5 +223,21 @@ msgstr "Svar borttaget"
 msgid "Answer can only be removed while the survey is running"
 msgstr "Svar kan tas bort endast när enkäten är igång"
 
+#: wikikysely_project/survey/views.py:185
+msgid "Answer can only be edited while the survey is running"
+msgstr "Svar kan redigeras endast när enkäten är igång"
+
+#: wikikysely_project/survey/views.py:101
+msgid "Cannot add questions to a closed survey"
+msgstr "Det går inte att lägga till frågor i en stängd enkät"
+
+#: wikikysely_project/survey/views.py:125
+msgid "Cannot remove questions from a closed survey"
+msgstr "Det går inte att ta bort frågor från en stängd enkät"
+
+#: wikikysely_project/survey/views.py:141
+msgid "Cannot restore questions in a closed survey"
+msgstr "Det går inte att återställa frågor i en stängd enkät"
+
 #~ msgid "Submit"
 #~ msgstr "Skicka"

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -22,13 +22,15 @@
     {% else %}
       <a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info me-2">{% translate 'Results' %}</a>
     {% endif %}
-    {% if can_edit %}
+    {% if can_edit and survey.state != 'closed' %}
       <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
     {% endif %}
   </div>
 {% elif can_edit %}
   <div class="mb-2">
+    {% if survey.state != 'closed' %}
     <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary me-2">{% translate 'Add question' %}</a>
+    {% endif %}
   </div>
 {% endif %}
 {% if user_answers %}

--- a/templates/survey/survey_form.html
+++ b/templates/survey/survey_form.html
@@ -14,7 +14,9 @@
     {% for q in active_questions %}
       <li class="list-group-item d-flex justify-content-between align-items-center">
         <span>{{ q.text }}</span>
+        {% if survey.state != 'closed' %}
         <a href="{% url 'survey:question_delete' q.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove' %}</a>
+        {% endif %}
       </li>
     {% empty %}
       <li class="list-group-item">{% translate 'No questions' %}</li>
@@ -26,7 +28,9 @@
       {% for q in deleted_questions %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
           <span class="text-muted">{{ q.text }}</span>
+          {% if survey.state != 'closed' %}
           <a href="{% url 'survey:question_restore' q.pk %}" class="btn btn-sm btn-secondary">{% translate 'Restore' %}</a>
+          {% endif %}
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
- prevent adding/removing questions when survey is closed
- only allow editing answers while survey is running
- hide add/remove buttons when survey is closed
- update Finnish and Swedish translations

## Testing
- `python manage.py check`
- `django-admin compilemessages`

------
https://chatgpt.com/codex/tasks/task_e_687731628a80832ebd624c622d2112a4