### PR TITLE
Fix edit answer button visibility

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -43,8 +43,8 @@
       <td>{{ a.question.text }}</td>
       <td>{{ a.get_answer_display }}</td>
       <td>
-        <a href="{% url 'survey:answer_edit' a.pk %}" class="btn btn-sm btn-warning">{% translate 'Edit' %}</a>
         {% if survey.state == 'running' %}
+        <a href="{% url 'survey:answer_edit' a.pk %}" class="btn btn-sm btn-warning">{% translate 'Edit' %}</a>
         <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove' %}</a>
         {% endif %}
       </td>


### PR DESCRIPTION
## Summary
- hide Edit Answer buttons if the survey is not running

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6877353a1fd4832e9869f56fb4b5e75d