### PR TITLE
Add cancel button on edit survey page

### DIFF
--- a/templates/survey/survey_form.html
+++ b/templates/survey/survey_form.html
@@ -6,7 +6,10 @@
 <form method="post">
   {% csrf_token %}
   {{ form.as_p }}
-  <button type="submit" class="btn btn-primary">{% translate 'Save' %}</button>
+  <button type="submit" class="btn btn-primary me-2">{% translate 'Save' %}</button>
+  {% if is_edit %}
+  <a href="{% url 'survey:survey_detail' survey.pk %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
+  {% endif %}
 </form>
 {% if is_edit %}
   <h2 class="mt-4">{% translate 'Questions' %}</h2>


### PR DESCRIPTION
## Summary
- add Cancel link next to Save on edit survey form

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_687736c7f030832eb36e5bfd644344cc