### PR TITLE
Redirect survey edit save to survey detail

### DIFF
--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -78,7 +78,7 @@ def survey_edit(request, pk):
         if form.is_valid():
             form.save()
             messages.success(request, _('Survey updated'))
-            return redirect('survey:survey_edit', pk=survey.pk)
+            return redirect('survey:survey_detail', pk=survey.pk)
     else:
         form = SurveyForm(instance=survey)
     active_questions = survey.questions.filter(deleted=False)


### PR DESCRIPTION
## Summary
- redirect to the survey detail view after saving the edit form

## Testing
- `pip install -r requirements.txt`
- `python manage.py check`
- `python manage.py compilemessages`

------
https://chatgpt.com/codex/tasks/task_e_687739292ca0832e807aa62c753845fc