### PR TITLE
Add cancel button and translations

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -169,6 +169,10 @@ msgstr "Suljettu"
 msgid "Description"
 msgstr "Kuvaus"
 
+#: wikikysely_project/survey/forms.py:37
+msgid "Text"
+msgstr "Teksti"
+
 #: wikikysely_project/survey/views.py:24
 msgid "Registration successful"
 msgstr "Rekisteröinti onnistui"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -169,6 +169,10 @@ msgstr "Stängd"
 msgid "Description"
 msgstr "Beskrivning"
 
+#: wikikysely_project/survey/forms.py:37
+msgid "Text"
+msgstr "Text"
+
 #: wikikysely_project/survey/views.py:24
 msgid "Registration successful"
 msgstr "Registreringen lyckades"

--- a/templates/survey/question_form.html
+++ b/templates/survey/question_form.html
@@ -6,6 +6,7 @@
 <form method="post">
   {% csrf_token %}
   {{ form.as_p }}
-  <button type="submit" class="btn btn-primary">{% translate 'Save' %}</button>
+  <button type="submit" class="btn btn-primary me-2">{% translate 'Save' %}</button>
+  <a href="{% url 'survey:survey_detail' survey.pk %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
 </form>
 {% endblock %}

--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -36,6 +36,9 @@ class QuestionForm(BootstrapMixin, forms.ModelForm):
     class Meta:
         model = Question
         fields = ['text']
+        labels = {
+            'text': _('Text'),
+        }
 
 
 class AnswerForm(BootstrapMixin, forms.ModelForm):


### PR DESCRIPTION
## Summary
- add Cancel button to question form
- translate question text label into Finnish and Swedish

## Testing
- `python manage.py compilemessages -l fi -l sv`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68773a5f9644832eb054c625e81fdd33