### PR TITLE
Add normalized stacked bars to results

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -26,7 +26,17 @@ const data = {
 new Chart(document.getElementById('resultsChart'), {
     type: 'bar',
     data: data,
-    options: { responsive: true, indexAxis: 'y', scales: { x: { stacked: true }, y: { stacked: true } } }
+    options: {
+        responsive: true,
+        indexAxis: 'y',
+        scales: {
+            x: { stacked: true, max: {{ total_users }} },
+            y: { stacked: true }
+        },
+        plugins: {
+            legend: { display: true }
+        }
+    }
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- normalize results chart x-axis by total respondents
- show legend for yes/no answers

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68773c712ce4832eb1188c5b69955ebf