### PR TITLE
Fix missing chart labels

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -19,8 +19,8 @@
 const data = {
     labels: [{% for row in data %}'{{ row.question.text|escapejs }}',{% endfor %}],
     datasets: [
-        {label: gettext('Yes'), data: [{% for row in data %}{{ row.yes }},{% endfor %}], backgroundColor: 'green'},
-        {label: gettext('No'), data: [{% for row in data %}{{ row.no }},{% endfor %}], backgroundColor: 'red'}
+        {label: '{{ yes_label|escapejs }}', data: [{% for row in data %}{{ row.yes }},{% endfor %}], backgroundColor: 'green'},
+        {label: '{{ no_label|escapejs }}', data: [{% for row in data %}{{ row.no }},{% endfor %}], backgroundColor: 'red'}
     ]
 };
 new Chart(document.getElementById('resultsChart'), {

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import UserCreationForm
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, gettext
 from .models import Survey, Question, Answer
 from .forms import SurveyForm, QuestionForm, AnswerForm
 
@@ -222,4 +222,12 @@ def survey_results(request, pk):
         yes_count = q.answers.filter(answer='yes').count()
         no_count = q.answers.filter(answer='no').count()
         data.append({'question': q, 'yes': yes_count, 'no': no_count, 'total': yes_count+no_count})
-    return render(request, 'survey/results.html', {'survey': survey, 'data': data, 'total_users': total_users})
+    yes_label = gettext('Yes')
+    no_label = gettext('No')
+    return render(request, 'survey/results.html', {
+        'survey': survey,
+        'data': data,
+        'total_users': total_users,
+        'yes_label': yes_label,
+        'no_label': no_label,
+    })


### PR DESCRIPTION
## Summary
- serve translated chart labels from the view
- render chart labels with the passed variables

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68773dd9768c832e8a28745491689c0e