### PR TITLE
Adjust bar height

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -23,6 +23,10 @@ const data = {
         {label: '{{ no_label|escapejs }}', data: [{% for row in data %}{{ row.no }},{% endfor %}], backgroundColor: 'red'}
     ]
 };
+// Adjust bar height to be slightly larger than the line height of the text
+const lineHeight = parseFloat(getComputedStyle(document.body).lineHeight);
+const barHeight = Math.ceil(lineHeight * 1.2);
+data.datasets.forEach(ds => ds.barThickness = barHeight);
 new Chart(document.getElementById('resultsChart'), {
     type: 'bar',
     data: data,


### PR DESCRIPTION
## Summary
- tweak results chart to make bar height slightly larger than the text line height

## Testing
- `python -m py_compile `git ls-files '*.py'``

------
https://chatgpt.com/codex/tasks/task_e_68775b8f3cd0832e89d48f3b15a07e76