### PR TITLE
Fix chart height expanding continuously

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -27,7 +27,7 @@ const data = {
 const chartEl = document.getElementById('resultsChart');
 const lineHeight = parseFloat(getComputedStyle(document.body).lineHeight);
 const barHeight = Math.ceil(lineHeight * 1.2);
-chartEl.height = barHeight * data.labels.length;
+chartEl.style.height = `${barHeight * data.labels.length}px`;
 data.datasets.forEach(ds => ds.barThickness = barHeight);
 new Chart(chartEl, {
     type: 'bar',


### PR DESCRIPTION
## Summary
- fix continuous growth of bar graph height by setting canvas style

## Testing
- `pip install -q -r requirements.txt`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68775fa90c2c832ea6ec25e99ca722dc