### PR TITLE
Add message for anonymous users on survey page

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -105,6 +105,10 @@ msgstr "Vastaamattomat kysymykset"
 msgid "Answer survey"
 msgstr "Vastaa kyselyyn"
 
+#: templates/survey/survey_detail.html:36
+msgid "You must be logged in to answer questions"
+msgstr "Sinun tulee olla kirjautunut sisään vastataksesi kysymyksiin"
+
 #: templates/survey/survey_detail.html:44
 msgid "Edit"
 msgstr "Muokkaa"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -105,6 +105,10 @@ msgstr "Obesvarade frågor"
 msgid "Answer survey"
 msgstr "Svara på enkäten"
 
+#: templates/survey/survey_detail.html:36
+msgid "You must be logged in to answer questions"
+msgstr "Du måste vara inloggad för att kunna svara på frågorna"
+
 #: templates/survey/survey_detail.html:44
 msgid "Edit"
 msgstr "Redigera"

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -7,15 +7,15 @@
 <p>{% translate 'State' %}: {{ survey.get_state_display }}</p>
 <p>{% translate 'Start date' %}: {{ survey.start_date }} | {% translate 'End date' %}: {{ survey.end_date }}</p>
 {% if request.user.is_authenticated %}
-  {# Edit survey button moved next to the Results button at the bottom #}
-  {% if unanswered_questions %}
-    <h2 class="mt-3">{% translate 'Unanswered questions' %}</h2>
-    <ul class="list-group mb-3">
-      {% for q in unanswered_questions %}
-      <li class="list-group-item">{{ q.text }}</li>
-      {% endfor %}
-    </ul>
-  {% endif %}
+    {# Edit survey button moved next to the Results button at the bottom #}
+    {% if unanswered_questions %}
+      <h2 class="mt-3">{% translate 'Unanswered questions' %}</h2>
+      <ul class="list-group mb-3">
+        {% for q in unanswered_questions %}
+        <li class="list-group-item">{{ q.text }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
   <div class="mb-3">
     {% if unanswered_questions %}
       <a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary me-2">{% translate 'Answer survey' %}</a>
@@ -24,14 +24,22 @@
     {% endif %}
     {% if can_edit and survey.state != 'closed' %}
       <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
-    {% endif %}
-  </div>
+      {% endif %}
+    </div>
 {% elif can_edit %}
-  <div class="mb-2">
-    {% if survey.state != 'closed' %}
-    <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary me-2">{% translate 'Add question' %}</a>
-    {% endif %}
-  </div>
+    <div class="mb-2">
+      {% if survey.state != 'closed' %}
+      <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary me-2">{% translate 'Add question' %}</a>
+      {% endif %}
+    </div>
+{% else %}
+  <p class="alert alert-info">{% translate 'You must be logged in to answer questions' %}</p>
+  <h2 class="mt-3">{% translate 'Questions' %}</h2>
+  <ul class="list-group mb-3">
+    {% for q in questions %}
+    <li class="list-group-item">{{ q.text }}</li>
+    {% endfor %}
+  </ul>
 {% endif %}
 {% if user_answers %}
 <h2 class="mt-4">{% translate 'My answers' %}</h2>


### PR DESCRIPTION
## Summary
- notify anonymous users that login is required to answer
- show list of all questions for anonymous users
- add Finnish and Swedish translations

## Testing
- `python manage.py compilemessages`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68776ab2c964832ebfa403c05fcba144