### PR TITLE
Allow respondents to add questions during running surveys

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -17,15 +17,15 @@
       </ul>
     {% endif %}
   <div class="mb-3">
-    {% if unanswered_questions %}
-      <a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary me-2">{% translate 'Answer survey' %}</a>
-    {% else %}
-      <a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info me-2">{% translate 'Results' %}</a>
-    {% endif %}
-    {% if can_edit and survey.state != 'closed' %}
-      <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
+      {% if unanswered_questions %}
+        <a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary me-2">{% translate 'Answer survey' %}</a>
+      {% else %}
+        <a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info me-2">{% translate 'Results' %}</a>
       {% endif %}
-    </div>
+      {% if survey.state == 'running' or can_edit and survey.state != 'closed' %}
+        <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
+      {% endif %}
+      </div>
 {% elif can_edit %}
     <div class="mb-2">
       {% if survey.state != 'closed' %}

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -95,11 +95,11 @@ def survey_edit(request, pk):
 @login_required
 def question_add(request, survey_pk):
     survey = get_object_or_404(Survey, pk=survey_pk, deleted=False)
-    if request.user != survey.creator and not request.user.is_superuser:
-        messages.error(request, _('No permission'))
-        return redirect('survey:survey_detail', pk=survey.pk)
     if survey.state == 'closed':
         messages.error(request, _('Cannot add questions to a closed survey'))
+        return redirect('survey:survey_detail', pk=survey.pk)
+    if survey.state != 'running' and request.user != survey.creator and not request.user.is_superuser:
+        messages.error(request, _('No permission'))
         return redirect('survey:survey_detail', pk=survey.pk)
     if request.method == 'POST':
         form = QuestionForm(request.POST)


### PR DESCRIPTION
## Summary
- enable question addition for any logged-in user when survey state is Running
- show an Add question button for all respondents while the survey is running

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68776cc1b550832eb012df08defbe313