### PR TITLE
Add duplicate question check

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -247,5 +247,9 @@ msgstr "Suljetusta kyselystä ei voi poistaa kysymyksiä"
 msgid "Cannot restore questions in a closed survey"
 msgstr "Suljettuun kyselyyn ei voi palauttaa kysymyksiä"
 
+#: wikikysely_project/survey/views.py:110
+msgid "This question already exists (%(num)d: %(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."
+msgstr "Tämä kysymys on jo olemassa (%(num)d: %(yes_label)s %(yes)d, %(no_label)s %(no)d). Muotoile kysymys toisin."
+
 #~ msgid "Submit"
 #~ msgstr "Lähetä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -247,5 +247,9 @@ msgstr "Det går inte att ta bort frågor från en stängd enkät"
 msgid "Cannot restore questions in a closed survey"
 msgstr "Det går inte att återställa frågor i en stängd enkät"
 
+#: wikikysely_project/survey/views.py:110
+msgid "This question already exists (%(num)d: %(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."
+msgstr "Denna fråga finns redan (%(num)d: %(yes_label)s %(yes)d, %(no_label)s %(no)d). Formulera frågan annorlunda."
+
 #~ msgid "Submit"
 #~ msgstr "Skicka"


### PR DESCRIPTION
## Summary
- prevent adding duplicate active questions within a survey
- show an error message with question id and current answer distribution if a duplicate exists
- add Finnish and Swedish translations for the new message

## Testing
- `python manage.py compilemessages -l fi -l sv`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68776fd17940832e8906ad242a3c40c0