### PR TITLE
Update duplicate question message to show answer count

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -248,8 +248,8 @@ msgid "Cannot restore questions in a closed survey"
 msgstr "Suljettuun kyselyyn ei voi palauttaa kysymyksiä"
 
 #: wikikysely_project/survey/views.py:110
-msgid "This question already exists (%(num)d: %(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."
-msgstr "Tämä kysymys on jo olemassa (%(num)d: %(yes_label)s %(yes)d, %(no_label)s %(no)d). Muotoile kysymys toisin."
+msgid "The question \"%(text)s\" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."
+msgstr "Kysymys \"%(text)s\" on jo olemassa ja sille on %(count)d vastausta (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Muotoile kysymys toisin."
 
 #~ msgid "Submit"
 #~ msgstr "Lähetä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -248,8 +248,8 @@ msgid "Cannot restore questions in a closed survey"
 msgstr "Det går inte att återställa frågor i en stängd enkät"
 
 #: wikikysely_project/survey/views.py:110
-msgid "This question already exists (%(num)d: %(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."
-msgstr "Denna fråga finns redan (%(num)d: %(yes_label)s %(yes)d, %(no_label)s %(no)d). Formulera frågan annorlunda."
+msgid "The question \"%(text)s\" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."
+msgstr "Frågan \"%(text)s\" finns redan och har %(count)d svar (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Formulera frågan annorlunda."
 
 #~ msgid "Submit"
 #~ msgstr "Skicka"

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -109,13 +109,15 @@ def question_add(request, survey_pk):
             if existing:
                 yes_count = existing.answers.filter(answer='yes').count()
                 no_count = existing.answers.filter(answer='no').count()
+                answer_count = yes_count + no_count
                 yes_label = gettext('Yes')
                 no_label = gettext('No')
                 messages.error(
                     request,
-                    _('This question already exists (%(num)d: %(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question.')
+                    _('The question "%(text)s" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question.')
                     % {
-                        'num': existing.pk,
+                        'text': existing.text,
+                        'count': answer_count,
                         'yes_label': yes_label,
                         'yes': yes_count,
                         'no_label': no_label,


### PR DESCRIPTION
## Summary
- show total answer count when a question already exists
- update Finnish and Swedish translations

## Testing
- `python manage.py check`
- `python manage.py compilemessages`

------
https://chatgpt.com/codex/tasks/task_e_6877718cd2e8832eba054ead536a5e29