### PR TITLE
Add example dates in survey form

### DIFF
--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -20,6 +20,10 @@ class SurveyForm(BootstrapMixin, forms.ModelForm):
     class Meta:
         model = Survey
         fields = ['title', 'description', 'start_date', 'end_date', 'state']
+        widgets = {
+            'start_date': forms.DateInput(attrs={'type': 'date', 'placeholder': '2024-01-01'}),
+            'end_date': forms.DateInput(attrs={'type': 'date', 'placeholder': '2024-12-31'}),
+        }
 
     def clean(self):
         cleaned_data = super().clean()


### PR DESCRIPTION
## Summary
- add placeholders with example dates for `start_date` and `end_date` fields in the survey creation form

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_687777c50288832eb92e68c6f4d58795