### PR TITLE
Show results only if questions exist

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -247,6 +247,10 @@ msgstr "Suljetusta kyselystä ei voi poistaa kysymyksiä"
 msgid "Cannot restore questions in a closed survey"
 msgstr "Suljettuun kyselyyn ei voi palauttaa kysymyksiä"
 
+#: templates/survey/survey_detail.html:10
+msgid "This survey has no questions yet. Please add questions."
+msgstr "Kyselyssä ei ole yhtään kysymystä vielä. Lisää kysymyksiä."
+
 #: wikikysely_project/survey/views.py:110
 msgid "The question \"%(text)s\" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."
 msgstr "Kysymys \"%(text)s\" on jo olemassa ja sille on %(count)d vastausta (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Muotoile kysymys toisin."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -247,6 +247,10 @@ msgstr "Det går inte att ta bort frågor från en stängd enkät"
 msgid "Cannot restore questions in a closed survey"
 msgstr "Det går inte att återställa frågor i en stängd enkät"
 
+#: templates/survey/survey_detail.html:10
+msgid "This survey has no questions yet. Please add questions."
+msgstr "Enkäten har inga frågor ännu. Lägg till frågor."
+
 #: wikikysely_project/survey/views.py:110
 msgid "The question \"%(text)s\" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."
 msgstr "Frågan \"%(text)s\" finns redan och har %(count)d svar (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Formulera frågan annorlunda."

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -6,6 +6,9 @@
 <p>{{ survey.description }}</p>
 <p>{% translate 'State' %}: {{ survey.get_state_display }}</p>
 <p>{% translate 'Start date' %}: {{ survey.start_date }} | {% translate 'End date' %}: {{ survey.end_date }}</p>
+{% if not questions %}
+  <p class="alert alert-warning">{% translate 'This survey has no questions yet. Please add questions.' %}</p>
+{% endif %}
 {% if request.user.is_authenticated %}
     {# Edit survey button moved next to the Results button at the bottom #}
     {% if unanswered_questions %}
@@ -19,7 +22,7 @@
   <div class="mb-3">
       {% if unanswered_questions %}
         <a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary me-2">{% translate 'Answer survey' %}</a>
-      {% else %}
+      {% elif questions %}
         <a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info me-2">{% translate 'Results' %}</a>
       {% endif %}
       {% if survey.state == 'running' or can_edit and survey.state != 'closed' %}
@@ -61,7 +64,9 @@
   </tbody>
 </table>
 {% endif %}
+{% if questions %}
 <a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info mt-3 me-2">{% translate 'Results' %}</a>
+{% endif %}
 {% if can_edit %}
 <a href="{% url 'survey:survey_edit' survey.pk %}" class="btn btn-warning mt-3">{% translate 'Edit survey' %}</a>
 {% endif %}


### PR DESCRIPTION
## Summary
- hide the results link when there are no questions
- inform the user if a survey has no questions
- add Finnish and Swedish translations for the new notice

## Testing
- `python manage.py test`
- `python manage.py compilemessages`

------
https://chatgpt.com/codex/tasks/task_e_68777a9aab8c832ea74918c1927a4d89