### PR TITLE
Adjust login prompt and Finnish translations

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -249,7 +249,7 @@ msgstr "Suljettuun kyselyyn ei voi palauttaa kysymyksiä"
 
 #: templates/survey/survey_detail.html:10
 msgid "This survey has no questions yet. Please add questions."
-msgstr "Kyselyssä ei ole yhtään kysymystä vielä. Lisää kysymyksiä."
+msgstr "Kyselyssä ei ole yhtään kysymystä vielä."
 
 #: wikikysely_project/survey/views.py:110
 msgid "The question \"%(text)s\" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -36,7 +36,9 @@
       {% endif %}
     </div>
 {% else %}
+  {% if questions %}
   <p class="alert alert-info">{% translate 'You must be logged in to answer questions' %}</p>
+  {% endif %}
   <h2 class="mt-3">{% translate 'Questions' %}</h2>
   <ul class="list-group mb-3">
     {% for q in questions %}


### PR DESCRIPTION
## Summary
- tweak Finnish translation for empty survey message
- show login notice on survey page only when questions exist

## Testing
- `python manage.py compilemessages`

------
https://chatgpt.com/codex/tasks/task_e_68777f29e460832ebbfb76cfcf406e64