### PR TITLE
Add hidden field for answered question

### DIFF
--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -46,7 +46,11 @@ class QuestionForm(BootstrapMixin, forms.ModelForm):
 
 
 class AnswerForm(BootstrapMixin, forms.ModelForm):
-    answer = forms.ChoiceField(choices=Answer.ANSWER_CHOICES + [('', _('Skip'))], widget=forms.RadioSelect)
+    answer = forms.ChoiceField(
+        choices=Answer.ANSWER_CHOICES + [('', _('Skip'))],
+        widget=forms.RadioSelect,
+    )
+    question_id = forms.IntegerField(widget=forms.HiddenInput)
 
     class Meta:
         model = Answer


### PR DESCRIPTION
## Summary
- include `question_id` as a hidden field in `AnswerForm`
- use posted `question_id` when saving answers
- prefill the hidden field when rendering the answer form

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68778c486728832e9479814a0c744146