### PR TITLE
Fix duplicate table error in tests

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -21,6 +21,19 @@ class SurveyFlowTests(TransactionTestCase):
                 schema_editor.create_model(Answer)
         finally:
             connection.enable_constraint_checking()
+
+    @classmethod
+    def tearDownClass(cls):
+        from django.db import connection
+        connection.disable_constraint_checking()
+        try:
+            with connection.schema_editor(atomic=False) as schema_editor:
+                schema_editor.delete_model(Answer)
+                schema_editor.delete_model(Question)
+                schema_editor.delete_model(Survey)
+        finally:
+            connection.enable_constraint_checking()
+        super().tearDownClass()
     def setUp(self):
         activate('en')
         User = get_user_model()


### PR DESCRIPTION
## Summary
- drop tables created in `SurveyFlowTests` when tests finish

## Testing
- `python manage.py test`
- `python manage.py test --keepdb`

------
https://chatgpt.com/codex/tasks/task_e_687deb6d07e8832e8316496e4cf59d00