### PR TITLE
Add multi-user answer test

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -37,8 +37,12 @@ class SurveyFlowTests(TransactionTestCase):
     def setUp(self):
         activate('en')
         User = get_user_model()
-        self.user = User.objects.create_user(username='tester', password='pass')
-        self.client.login(username='tester', password='pass')
+        self.users = [
+            User.objects.create_user(username=f'tester{i}', password='pass')
+            for i in range(1, 4)
+        ]
+        self.user = self.users[0]
+        self.client.login(username=self.user.username, password='pass')
         self.today = timezone.now().date()
 
     def _create_survey(self):
@@ -57,6 +61,12 @@ class SurveyFlowTests(TransactionTestCase):
             text=text,
             creator=self.user,
         )
+
+    def _create_questions(self, survey, count=10):
+        return [
+            self._create_question(survey, text=f'Question {i}?')
+            for i in range(1, count + 1)
+        ]
 
     def test_survey_creation(self):
         data = {
@@ -97,25 +107,50 @@ class SurveyFlowTests(TransactionTestCase):
 
     def test_answer_question_and_edit(self):
         survey = self._create_survey()
-        question = self._create_question(survey)
-        # answer
-        data = {'question_id': question.pk, 'answer': 'yes'}
-        response = self.client.post(reverse('survey:answer_survey', kwargs={'pk': survey.pk}), data)
+        questions = self._create_questions(survey, 10)
+
+        # answer by first user (already logged in)
+        data = {'question_id': questions[0].pk, 'answer': 'yes'}
+        response = self.client.post(
+            reverse('survey:answer_survey', kwargs={'pk': survey.pk}),
+            data,
+        )
         self.assertEqual(Answer.objects.count(), 1)
-        answer = Answer.objects.first()
+        answer = Answer.objects.get(question=questions[0], user=self.user)
         self.assertEqual(answer.answer, 'yes')
-        self.assertEqual(answer.user, self.user)
         self.assertRedirects(
             response,
             reverse('survey:answer_survey', kwargs={'pk': survey.pk}),
             fetch_redirect_response=False,
         )
-        # edit
-        edit_data = {'question_id': question.pk, 'answer': 'no'}
-        response = self.client.post(reverse('survey:answer_edit', kwargs={'pk': answer.pk}), edit_data)
+
+        # answer by second and third users
+        for idx, user in enumerate(self.users[1:], start=1):
+            self.client.logout()
+            self.client.login(username=user.username, password='pass')
+            data = {'question_id': questions[idx].pk, 'answer': 'yes'}
+            self.client.post(
+                reverse('survey:answer_survey', kwargs={'pk': survey.pk}),
+                data,
+            )
+            ans = Answer.objects.get(question=questions[idx], user=user)
+            self.assertEqual(ans.answer, 'yes')
+        self.assertEqual(Answer.objects.count(), 3)
+
+        # edit first user's answer
+        self.client.logout()
+        self.client.login(username=self.user.username, password='pass')
+        edit_data = {'question_id': questions[0].pk, 'answer': 'no'}
+        response = self.client.post(
+            reverse('survey:answer_edit', kwargs={'pk': answer.pk}),
+            edit_data,
+        )
         answer.refresh_from_db()
         self.assertEqual(answer.answer, 'no')
-        self.assertRedirects(response, reverse('survey:survey_detail', kwargs={'pk': survey.pk}))
+        self.assertRedirects(
+            response,
+            reverse('survey:survey_detail', kwargs={'pk': survey.pk}),
+        )
 
     def test_results_view(self):
         survey = self._create_survey()
@@ -127,4 +162,16 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(data['yes'], 1)
         self.assertEqual(data['no'], 0)
         self.assertEqual(response.context['total_users'], 1)
+
+    def test_answer_saved_to_correct_question_and_user(self):
+        survey = self._create_survey()
+        questions = self._create_questions(survey, 10)
+        for idx, user in enumerate(self.users):
+            self.client.logout()
+            self.client.login(username=user.username, password='pass')
+            data = {'question_id': questions[idx].pk, 'answer': 'yes'}
+            self.client.post(reverse('survey:answer_survey', kwargs={'pk': survey.pk}), data)
+            ans = Answer.objects.get(question=questions[idx], user=user)
+            self.assertEqual(ans.answer, 'yes')
+        self.assertEqual(Answer.objects.count(), 3)
 


### PR DESCRIPTION
## Summary
- extend setup to create three users
- add helper for creating multiple questions
- update and extend answer tests to check question and user links

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687df1a1e5bc832e88086e3580073012