### PR TITLE
Disallow answering when survey is paused

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -20,7 +20,7 @@
       </ul>
     {% endif %}
   <div class="mb-3">
-      {% if unanswered_questions %}
+      {% if unanswered_questions and survey.state == 'running' %}
         <a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary me-2">{% translate 'Answer survey' %}</a>
       {% elif questions %}
         <a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info me-2">{% translate 'Results' %}</a>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -175,3 +175,17 @@ class SurveyFlowTests(TransactionTestCase):
             self.assertEqual(ans.answer, 'yes')
         self.assertEqual(Answer.objects.count(), 3)
 
+    def test_cannot_answer_when_paused(self):
+        survey = self._create_survey()
+        question = self._create_question(survey)
+        survey.state = 'paused'
+        survey.save()
+
+        response = self.client.get(reverse('survey:answer_survey', kwargs={'pk': survey.pk}))
+        self.assertRedirects(response, reverse('survey:survey_detail', kwargs={'pk': survey.pk}))
+
+        data = {'question_id': question.pk, 'answer': 'yes'}
+        response = self.client.post(reverse('survey:answer_survey', kwargs={'pk': survey.pk}), data)
+        self.assertEqual(Answer.objects.count(), 0)
+        self.assertRedirects(response, reverse('survey:survey_detail', kwargs={'pk': survey.pk}))
+

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -172,6 +172,9 @@ def question_restore(request, pk):
 @login_required
 def answer_survey(request, pk):
     survey = get_object_or_404(Survey, pk=pk, deleted=False)
+    if survey.state == 'paused':
+        messages.error(request, _('Survey not active'))
+        return redirect('survey:survey_detail', pk=survey.pk)
     if not survey.is_active():
         messages.error(request, _('Survey not active'))
         return redirect('survey:survey_detail', pk=survey.pk)


### PR DESCRIPTION
## Summary
- prevent posting answers if the survey is paused
- only show "Answer survey" button when survey is running
- add regression test for paused surveys

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e02689dbc832ea9e32ef6e788adb5