### PR TITLE
Remember dates when editing surveys

### DIFF
--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -21,9 +21,26 @@ class SurveyForm(BootstrapMixin, forms.ModelForm):
         model = Survey
         fields = ['title', 'description', 'start_date', 'end_date', 'state']
         widgets = {
-            'start_date': forms.DateInput(attrs={'type': 'date', 'placeholder': '2024-01-01'}),
-            'end_date': forms.DateInput(attrs={'type': 'date', 'placeholder': '2024-12-31'}),
+            'start_date': forms.DateInput(
+                format="%Y-%m-%d",
+                attrs={
+                    'type': 'date',
+                    'placeholder': '2024-01-01',
+                },
+            ),
+            'end_date': forms.DateInput(
+                format="%Y-%m-%d",
+                attrs={
+                    'type': 'date',
+                    'placeholder': '2024-12-31',
+                },
+            ),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['start_date'].input_formats = ['%Y-%m-%d']
+        self.fields['end_date'].input_formats = ['%Y-%m-%d']
 
     def clean(self):
         cleaned_data = super().clean()


### PR DESCRIPTION
## Summary
- ensure HTML `date` inputs output ISO format values
- set allowed ISO input formats for survey start and end dates

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_687e17583268832eb0a6fb0a643f3b17