### PR TITLE
Add paused state alert

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -251,6 +251,10 @@ msgstr "Suljettuun kyselyyn ei voi palauttaa kysymyksiä"
 msgid "This survey has no questions yet. Please add questions."
 msgstr "Kyselyssä ei ole yhtään kysymystä vielä."
 
+#: templates/survey/survey_detail.html:9
+msgid "This survey is currently paused."
+msgstr "Tämä kysely on tauolla."
+
 #: wikikysely_project/survey/views.py:110
 msgid "The question \"%(text)s\" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."
 msgstr "Kysymys \"%(text)s\" on jo olemassa ja sille on %(count)d vastausta (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Muotoile kysymys toisin."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -251,6 +251,10 @@ msgstr "Det går inte att återställa frågor i en stängd enkät"
 msgid "This survey has no questions yet. Please add questions."
 msgstr "Enkäten har inga frågor ännu. Lägg till frågor."
 
+#: templates/survey/survey_detail.html:9
+msgid "This survey is currently paused."
+msgstr "Den här enkäten är pausad."
+
 #: wikikysely_project/survey/views.py:110
 msgid "The question \"%(text)s\" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question."
 msgstr "Frågan \"%(text)s\" finns redan och har %(count)d svar (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Formulera frågan annorlunda."

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -6,6 +6,9 @@
 <p>{{ survey.description }}</p>
 <p>{% translate 'State' %}: {{ survey.get_state_display }}</p>
 <p>{% translate 'Start date' %}: {{ survey.start_date }} | {% translate 'End date' %}: {{ survey.end_date }}</p>
+{% if survey.state == 'paused' %}
+  <div class="alert alert-info">{% translate 'This survey is currently paused.' %}</div>
+{% endif %}
 {% if not questions %}
   <p class="alert alert-warning">{% translate 'This survey has no questions yet. Please add questions.' %}</p>
 {% endif %}

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -189,3 +189,11 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(Answer.objects.count(), 0)
         self.assertRedirects(response, reverse('survey:survey_detail', kwargs={'pk': survey.pk}))
 
+    def test_detail_shows_paused_alert(self):
+        survey = self._create_survey()
+        survey.state = 'paused'
+        survey.save()
+
+        response = self.client.get(reverse('survey:survey_detail', kwargs={'pk': survey.pk}))
+        self.assertContains(response, 'This survey is currently paused.')
+


### PR DESCRIPTION
## Summary
- show a Bootstrap info alert on the survey detail page when survey state is paused
- localize the new alert message in Finnish and Swedish
- test that the alert is visible when survey is paused

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687e1a380e84832e9148cf6a4d06e167