### PR TITLE
Remove question sorting from survey detail

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -12,25 +12,6 @@
 {% if not questions %}
   <p class="alert alert-warning">{% translate 'This survey has no questions yet. Please add questions.' %}</p>
 {% endif %}
-<form method="get" class="mb-3">
-  <span class="form-label me-2">Sort by</span>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="sort" id="sort-text" value="text"{% if request.GET.sort == 'text' or not request.GET.sort %} checked{% endif %} onchange="this.form.submit()">
-    <label class="form-check-label" for="sort-text">Text</label>
-  </div>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="sort" id="sort-created" value="created"{% if request.GET.sort == 'created' %} checked{% endif %} onchange="this.form.submit()">
-    <label class="form-check-label" for="sort-created">Published</label>
-  </div>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="sort" id="sort-answers" value="answers"{% if request.GET.sort == 'answers' %} checked{% endif %} onchange="this.form.submit()">
-    <label class="form-check-label" for="sort-answers">Answers</label>
-  </div>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="sort" id="sort-agreement" value="agreement"{% if request.GET.sort == 'agreement' %} checked{% endif %} onchange="this.form.submit()">
-    <label class="form-check-label" for="sort-agreement">Agree</label>
-  </div>
-</form>
 {% if request.user.is_authenticated %}
     {# Edit survey button moved next to the Results button at the bottom #}
     {% if unanswered_questions %}

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -197,17 +197,4 @@ class SurveyFlowTests(TransactionTestCase):
         response = self.client.get(reverse('survey:survey_detail', kwargs={'pk': survey.pk}))
         self.assertContains(response, 'This survey is currently paused.')
 
-    def test_question_sorting_by_answers(self):
-        survey = self._create_survey()
-        q1 = self._create_question(survey, text='A?')
-        q2 = self._create_question(survey, text='B?')
-        Answer.objects.create(question=q1, user=self.users[1], answer='yes')
-        Answer.objects.create(question=q1, user=self.users[2], answer='no')
-        Answer.objects.create(question=q2, user=self.user, answer='yes')
-
-        response = self.client.get(
-            reverse('survey:survey_detail', kwargs={'pk': survey.pk}) + '?sort=answers'
-        )
-        questions = list(response.context['questions'])
-        self.assertEqual(questions[0], q1)
 

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -50,7 +50,6 @@ def survey_create(request):
 def survey_detail(request, pk):
     survey = get_object_or_404(Survey, pk=pk, deleted=False)
     base_qs = survey.questions.filter(deleted=False)
-    sort = request.GET.get('sort', 'text')
     user_answers = Answer.objects.none()
     unanswered_questions_qs = base_qs
     if request.user.is_authenticated:
@@ -79,16 +78,9 @@ def survey_detail(request, pk):
         )
     )
 
-    if sort == 'created':
-        order = '-created_at'
-    elif sort == 'answers':
-        order = '-total_answers'
-    elif sort == 'agreement':
-        order = '-agree_ratio'
-    else:
-        order = 'text'
-    questions = questions.order_by(order)
-    unanswered_questions = unanswered_questions.order_by(order)
+    # Preserve original insertion order without exposing sorting options
+    questions = questions.order_by('pk')
+    unanswered_questions = unanswered_questions.order_by('pk')
 
     can_edit = request.user == survey.creator or request.user.is_superuser
 


### PR DESCRIPTION
## Summary
- drop sorting options from the survey detail view
- remove related test

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e2a757478832e81b1ef90d06dfd5c