### PR TITLE
Add direct answer links in survey questions

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -19,7 +19,7 @@
       <ul class="list-group mb-3">
         {% for q in unanswered_questions %}
         <li class="list-group-item">
-          <div><strong>{{ q.text }}</strong></div>
+          <div><a href="{% url 'survey:answer_question' q.pk %}"><strong>{{ q.text }}</strong></a></div>
           <small class="text-muted">
             {% translate 'Published' %}: {{ q.created_at }} |
             {% translate 'Answers' %}: {{ q.total_answers }} |
@@ -70,7 +70,7 @@
   <tbody>
     {% for a in user_answers %}
     <tr>
-      <td>{{ a.question.text }}</td>
+      <td><a href="{% url 'survey:answer_edit' a.pk %}">{{ a.question.text }}</a></td>
       <td>{{ a.get_answer_display }}</td>
       <td>
         {% if survey.state == 'running' %}

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('survey/<int:survey_pk>/question/add/', views.question_add, name='question_add'),
     path('question/<int:pk>/delete/', views.question_delete, name='question_delete'),
     path('question/<int:pk>/restore/', views.question_restore, name='question_restore'),
+    path('question/<int:pk>/answer/', views.answer_question, name='answer_question'),
     path('answer/<int:pk>/edit/', views.answer_edit, name='answer_edit'),
     path('answer/<int:pk>/delete/', views.answer_delete, name='answer_delete'),
     path('answers/', views.answer_list, name='answer_list'),


### PR DESCRIPTION
## Summary
- make question text links to answer or edit
- add `answer_question` view and url

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e2bef098c832eb5e7243e818e6e4b