### PR TITLE
Improve bar chart label layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -7,3 +7,18 @@ body {
 .table th, .table td {
   vertical-align: middle;
 }
+
+#resultsChartContainer {
+  position: relative;
+}
+
+#barChartLabels {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+#barChartLabels .chart-label {
+  display: flex;
+  align-items: center;
+}

--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -13,7 +13,8 @@
     <label class="form-check-label" for="pieChartRadio">{% translate 'Pie chart' %}</label>
   </div>
 </div>
-<div id="resultsChartContainer" style="display:none">
+<div id="resultsChartContainer" style="display:none" class="position-relative">
+  <div id="barChartLabels"></div>
   <canvas id="resultsChart"></canvas>
 </div>
 <div id="pieChartsContainer" style="display:none">
@@ -54,6 +55,7 @@ const noLabel = '{{ no_label|escapejs }}';
 
 // Calculate appropriate height based on number of questions
 const chartEl = document.getElementById('resultsChart');
+const labelsEl = document.getElementById('barChartLabels');
 const lineHeight = parseFloat(getComputedStyle(document.body).lineHeight);
 const barHeight = Math.ceil(lineHeight * 1.2);
 const chartHeight = barHeight * data.labels.length + 100; // +100 for padding, legend, etc.
@@ -61,6 +63,13 @@ const chartHeight = barHeight * data.labels.length + 100; // +100 for padding, l
 // Set container height and disable responsive behavior
 chartEl.style.height = `${chartHeight}px`;
 chartEl.style.width = '100%';
+data.labels.forEach(text => {
+    const div = document.createElement('div');
+    div.className = 'chart-label';
+    div.textContent = text;
+    div.style.height = `${barHeight}px`;
+    labelsEl.appendChild(div);
+});
 
 new Chart(chartEl, {
     type: 'bar',
@@ -81,9 +90,12 @@ new Chart(chartEl, {
                     precision: 0
                 }
             },
-            y: { 
+            y: {
                 stacked: true,
                 grid: {
+                    display: false
+                },
+                ticks: {
                     display: false
                 }
             }
@@ -110,6 +122,13 @@ new Chart(chartEl, {
         }
     }
 });
+
+const chart = Chart.getChart(chartEl);
+const chartTop = chart.chartArea.top;
+labelsEl.style.top = chartTop + 'px';
+const labelWidth = labelsEl.offsetWidth + 10;
+chartEl.style.marginLeft = labelWidth + 'px';
+chartEl.style.width = `calc(100% - ${labelWidth}px)`;
 
 // Pie charts
 const pieContainers = document.querySelectorAll('#pieCharts .pie-chart');


### PR DESCRIPTION
## Summary
- adjust bar chart layout so question labels are rendered as HTML
- hide y-axis tick labels
- add CSS for chart labels container

## Testing
- `pip install -r requirements.txt`
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e367ed694832ebb73b58e6f173b73