### PR TITLE
Add 'Vastaustaulukko' heading to results page

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -88,6 +88,10 @@ msgstr "Piirakkadiagrammi"
 msgid "Total respondents"
 msgstr "Vastaajien määrä"
 
+#: templates/survey/results.html:42
+msgid "Answer table"
+msgstr "Vastaustaulukko"
+
 #: templates/survey/results.html:9
 msgid "Total"
 msgstr "Yhteensä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -88,6 +88,10 @@ msgstr "Cirkeldiagram"
 msgid "Total respondents"
 msgstr "Antal svarande"
 
+#: templates/survey/results.html:42
+msgid "Answer table"
+msgstr "Svarstabell"
+
 #: templates/survey/results.html:9
 msgid "Total"
 msgstr "Totalt"

--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -39,6 +39,7 @@
 </div>
 </div>
 <p class="mt-3">{% translate 'Total respondents' %}: {{ total_users }}</p>
+<h2>{% translate 'Answer table' %}</h2>
 <table class="table">
 <thead><tr><th>{% translate 'Question' %}</th><th>{% translate 'Yes' %}</th><th>{% translate 'No' %}</th><th>{% translate 'Total' %}</th></tr></thead>
 <tbody>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -162,6 +162,7 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(data['yes'], 1)
         self.assertEqual(data['no'], 0)
         self.assertEqual(response.context['total_users'], 1)
+        self.assertContains(response, 'Answer table')
 
     def test_answer_saved_to_correct_question_and_user(self):
         survey = self._create_survey()


### PR DESCRIPTION
## Summary
- show a new subheading between graphs and the results table
- provide Finnish and Swedish translations for the heading
- test that the heading is present in the results view

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e4f3265d4832e8047fed44eaa8b81