### PR TITLE
Update Finnish text for delete answer button

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -44,6 +44,10 @@ msgstr "Peruuta"
 msgid "Remove"
 msgstr "Poista"
 
+#: templates/survey/answer_form.html:19 templates/survey/survey_detail.html:78
+msgid "Remove answer"
+msgstr "Poista vastaus"
+
 #: templates/survey/answer_form.html:21 wikikysely_project/survey/forms.py:42
 msgid "Skip"
 msgstr "Ohita"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -44,6 +44,10 @@ msgstr "Avbryt"
 msgid "Remove"
 msgstr "Ta bort"
 
+#: templates/survey/answer_form.html:19 templates/survey/survey_detail.html:78
+msgid "Remove answer"
+msgstr "Ta bort svar"
+
 #: templates/survey/answer_form.html:21 wikikysely_project/survey/forms.py:42
 msgid "Skip"
 msgstr "Hoppa över"

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -18,7 +18,7 @@
   {% if is_edit %}
     <a href="{% url 'survey:survey_detail' survey.pk %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
     {% if survey.state == 'running' %}
-    <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger ms-2">{% translate 'Remove' %}</a>
+    <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger ms-2">{% translate 'Remove answer' %}</a>
     {% endif %}
   {% else %}
     <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Skip' %}</button>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -75,7 +75,7 @@
       <td>
         {% if survey.state == 'running' %}
         <a href="{% url 'survey:answer_question' a.question.pk %}" class="btn btn-sm btn-warning">{% translate 'Edit' %}</a>
-        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove' %}</a>
+        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove answer' %}</a>
         {% endif %}
       </td>
     </tr>


### PR DESCRIPTION
## Summary
- tweak templates to use `Remove answer` string
- add new translation entries for Finnish and Swedish
- compile translation messages

## Testing
- `python manage.py compilemessages`
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_687e627d2e3c832e98c5c1003207d02d