### PR TITLE
Add vote counts to bar chart

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -20,8 +20,8 @@
     <td class="bar-chart-question">{{ row.question.text }}</td>
     <td class="w-100">
       <div class="progress" style="height: 1rem;">
-        <div class="progress-bar bg-success" role="progressbar" style="width: {% widthratio row.yes total_users 100 %}%"></div>
-        <div class="progress-bar bg-danger" role="progressbar" style="width: {% widthratio row.no total_users 100 %}%"></div>
+        <div class="progress-bar bg-success text-dark" role="progressbar" style="width: {% widthratio row.yes total_users 100 %}%">{{ row.yes }}</div>
+        <div class="progress-bar bg-danger text-dark" role="progressbar" style="width: {% widthratio row.no total_users 100 %}%">{{ row.no }}</div>
       </div>
     </td>
   </tr>


### PR DESCRIPTION
## Summary
- show vote counts directly on the bar chart

## Testing
- `python3 manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e7109edbc832e92f4a883f3e7a6c0