### PR TITLE
Fix Finnish translation for survey period

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -115,7 +115,7 @@ msgstr "Päättymispäivä"
 
 #: templates/survey/survey_detail.html:8
 msgid "Survey period"
-msgstr "Kyselyaika"
+msgstr "Vastausaika"
 
 #: templates/survey/survey_detail.html:12
 msgid "Unanswered questions"


### PR DESCRIPTION
## Summary
- update Finnish translation for "Survey period" from "Kyselyaika" to "Vastausaika"

## Testing
- `python manage.py compilemessages`
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e7ed1fdf4832eb18484d391870351