### PR TITLE
Single main survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # wikikysely
 
 Prototype implementation of a multilingual wiki survey tool built with Django.
+All questions belong to a single main survey. Administrators can edit the survey
+description, manage questions and change the state (running, paused or closed).
 
 ## Requirements
 - Python 3.11

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{% url 'survey:survey_list' %}">WikiKysely</a>
+    <a class="navbar-brand" href="{% url 'survey:survey_detail' %}">WikiKysely</a>
     <div class="collapse navbar-collapse">
       <form action="{% url 'set_language' %}" method="post" class="d-flex">
         {% csrf_token %}

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -16,7 +16,7 @@
   <button type="submit" name="answer" value="yes" class="btn btn-success me-2">{% translate 'Yes' %}</button>
   <button type="submit" name="answer" value="no" class="btn btn-danger me-2">{% translate 'No' %}</button>
   {% if is_edit %}
-    <a href="{% url 'survey:survey_detail' survey.pk %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
+    <a href="{% url 'survey:survey_detail' %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
     {% if survey.state == 'running' %}
     <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger ms-2">{% translate 'Remove answer' %}</a>
     {% endif %}

--- a/templates/survey/question_form.html
+++ b/templates/survey/question_form.html
@@ -7,6 +7,6 @@
   {% csrf_token %}
   {{ form.as_p }}
   <button type="submit" class="btn btn-primary me-2">{% translate 'Save' %}</button>
-  <a href="{% url 'survey:survey_detail' survey.pk %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
+  <a href="{% url 'survey:survey_detail' %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
 </form>
 {% endblock %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -4,7 +4,6 @@
 {% block content %}
 <h1>{{ survey.title }}</h1>
 <p>{{ survey.description }}</p>
-<p>{% translate 'Survey period' %}: {{ survey.start_date }} - {{ survey.end_date }}</p>
 {% if survey.state == 'paused' %}
   <div class="alert alert-info">{% translate 'This survey is currently paused.' %}</div>
 {% endif %}
@@ -30,18 +29,18 @@
     {% endif %}
   <div class="mb-3">
       {% if unanswered_questions and survey.state == 'running' %}
-        <a href="{% url 'survey:answer_survey' survey.pk %}" class="btn btn-primary me-2">{% translate 'Answer survey' %}</a>
+        <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary me-2">{% translate 'Answer survey' %}</a>
       {% elif questions %}
-        <a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info me-2">{% translate 'Results' %}</a>
+        <a href="{% url 'survey:survey_results' %}" class="btn btn-info me-2">{% translate 'Results' %}</a>
       {% endif %}
       {% if survey.state == 'running' or can_edit and survey.state != 'closed' %}
-        <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
+        <a href="{% url 'survey:question_add' %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
       {% endif %}
       </div>
 {% elif can_edit %}
     <div class="mb-2">
       {% if survey.state != 'closed' %}
-      <a href="{% url 'survey:question_add' survey_pk=survey.pk %}" class="btn btn-secondary me-2">{% translate 'Add question' %}</a>
+      <a href="{% url 'survey:question_add' %}" class="btn btn-secondary me-2">{% translate 'Add question' %}</a>
       {% endif %}
     </div>
 {% else %}
@@ -83,9 +82,9 @@
 </table>
 {% endif %}
 {% if questions %}
-<a href="{% url 'survey:survey_results' survey.pk %}" class="btn btn-info mt-3 me-2">{% translate 'Results' %}</a>
+<a href="{% url 'survey:survey_results' %}" class="btn btn-info mt-3 me-2">{% translate 'Results' %}</a>
 {% endif %}
 {% if can_edit %}
-<a href="{% url 'survey:survey_edit' survey.pk %}" class="btn btn-warning mt-3">{% translate 'Edit survey' %}</a>
+<a href="{% url 'survey:survey_edit' %}" class="btn btn-warning mt-3">{% translate 'Edit survey' %}</a>
 {% endif %}
 {% endblock %}

--- a/templates/survey/survey_form.html
+++ b/templates/survey/survey_form.html
@@ -8,7 +8,7 @@
   {{ form.as_p }}
   <button type="submit" class="btn btn-primary me-2">{% translate 'Save' %}</button>
   {% if is_edit %}
-  <a href="{% url 'survey:survey_detail' survey.pk %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
+  <a href="{% url 'survey:survey_detail' %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
   {% endif %}
 </form>
 {% if is_edit %}

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -7,13 +7,13 @@
 <thead><tr><th>{% translate 'Title' %}</th><th>{% translate 'State' %}</th></tr></thead>
 <tbody>
 {% for survey in surveys %}
-<tr><td><a href="{% url 'survey:survey_detail' survey.pk %}">{{ survey.title }}</a></td><td>{{ survey.get_state_display }}</td></tr>
+<tr><td><a href="{% url 'survey:survey_detail' %}">{{ survey.title }}</a></td><td>{{ survey.get_state_display }}</td></tr>
 {% empty %}
 <tr><td colspan="2">{% translate 'No surveys' %}</td></tr>
 {% endfor %}
 </tbody>
 </table>
 {% if request.user.is_authenticated %}
-<a href="{% url 'survey:survey_create' %}" class="btn btn-primary mt-3">{% translate 'Create survey' %}</a>
+<a href="{% url 'survey:survey_edit' %}" class="btn btn-primary mt-3">{% translate 'Edit survey' %}</a>
 {% endif %}
 {% endblock %}

--- a/wikikysely_project/survey/admin.py
+++ b/wikikysely_project/survey/admin.py
@@ -9,7 +9,7 @@ class QuestionInline(admin.TabularInline):
 
 class SurveyAdmin(admin.ModelAdmin):
     inlines = [QuestionInline]
-    list_display = ('title', 'state', 'start_date', 'end_date', 'deleted')
+    list_display = ('title', 'state', 'deleted')
     list_filter = ('state', 'deleted')
 
 

--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -19,38 +19,7 @@ class BootstrapMixin:
 class SurveyForm(BootstrapMixin, forms.ModelForm):
     class Meta:
         model = Survey
-        fields = ['title', 'description', 'start_date', 'end_date', 'state']
-        widgets = {
-            'start_date': forms.DateInput(
-                format="%Y-%m-%d",
-                attrs={
-                    'type': 'date',
-                    'placeholder': '2024-01-01',
-                },
-            ),
-            'end_date': forms.DateInput(
-                format="%Y-%m-%d",
-                attrs={
-                    'type': 'date',
-                    'placeholder': '2024-12-31',
-                },
-            ),
-        }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields['start_date'].input_formats = ['%Y-%m-%d']
-        self.fields['end_date'].input_formats = ['%Y-%m-%d']
-
-    def clean(self):
-        cleaned_data = super().clean()
-        start = cleaned_data.get('start_date')
-        end = cleaned_data.get('end_date')
-        if start and end and end < start:
-            raise forms.ValidationError({
-                'end_date': _('End date must be after start date.')
-            })
-        return cleaned_data
+        fields = ['title', 'description', 'state']
 
 
 class QuestionForm(BootstrapMixin, forms.ModelForm):

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -4,18 +4,16 @@ from . import views
 app_name = 'survey'
 
 urlpatterns = [
-    path('', views.survey_list, name='survey_list'),
+    path('', views.survey_detail, name='survey_detail'),
     path('register/', views.register, name='register'),
-    path('survey/create/', views.survey_create, name='survey_create'),
-    path('survey/<int:pk>/', views.survey_detail, name='survey_detail'),
-    path('survey/<int:pk>/edit/', views.survey_edit, name='survey_edit'),
-    path('survey/<int:pk>/answer/', views.answer_survey, name='answer_survey'),
-    path('survey/<int:survey_pk>/question/add/', views.question_add, name='question_add'),
+    path('survey/edit/', views.survey_edit, name='survey_edit'),
+    path('survey/answer/', views.answer_survey, name='answer_survey'),
+    path('survey/question/add/', views.question_add, name='question_add'),
     path('question/<int:pk>/delete/', views.question_delete, name='question_delete'),
     path('question/<int:pk>/restore/', views.question_restore, name='question_restore'),
     path('question/<int:pk>/', views.answer_question, name='answer_question'),
     path('answer/<int:pk>/edit/', views.answer_edit, name='answer_edit'),
     path('answer/<int:pk>/delete/', views.answer_delete, name='answer_delete'),
     path('answers/', views.answer_list, name='answer_list'),
-    path('results/<int:pk>/', views.survey_results, name='survey_results'),
+    path('results/', views.survey_results, name='survey_results'),
 ]


### PR DESCRIPTION
## Summary
- simplify app around a single main survey
- drop start/end dates and update admin, forms and templates
- adjust URLs and views for the main survey
- update tests for new behaviour

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687f0a2d0d64832eadcf47e13dc98533