### PR TITLE
Show login warning after Answer survey click

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -9,7 +9,14 @@
   <p class="alert alert-warning">{% translate 'This survey has no questions yet. Please add questions.' %}</p>
 {% endif %}
 {% if not request.user.is_authenticated and questions %}
-  <p class="alert alert-info">{% translate 'You must be logged in to answer questions' %}</p>
+  {% if request.GET.login_required %}
+    <p class="alert alert-info">
+      {% translate 'You must be logged in to answer questions' %}
+      <a href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a>
+    </p>
+  {% else %}
+    <a href="?login_required=1" class="btn btn-primary">{% translate 'Answer survey' %}</a>
+  {% endif %}
 {% endif %}
 <p>{{ survey.description }}</p>
 {% if request.user.is_authenticated %}


### PR DESCRIPTION
## Summary
- show "Answer survey" button for anonymous users
- show login prompt with login link if user clicks the button

## Testing
- `python manage.py test -v 1`

------
https://chatgpt.com/codex/tasks/task_e_687f19200fc4832ea5f3bc3758caad43