### PR TITLE
Improve unanswered question display

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -133,6 +133,18 @@ msgstr "Sinun tulee olla kirjautunut sisään vastataksesi kysymyksiin"
 msgid "Edit"
 msgstr "Muokkaa"
 
+#: templates/survey/survey_detail.html:45
+msgid "Published"
+msgstr "Julkaistu"
+
+#: templates/survey/survey_detail.html:46
+msgid "Answers"
+msgstr "Vastaukset"
+
+#: templates/survey/survey_detail.html:47
+msgid "Agree"
+msgstr "Samanmielisyys"
+
 # UI strings
 #: templates/survey/survey_detail.html:54 templates/survey/survey_form.html:3
 #: templates/survey/survey_form.html:5

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -133,6 +133,18 @@ msgstr "Du måste vara inloggad för att kunna svara på frågorna"
 msgid "Edit"
 msgstr "Redigera"
 
+#: templates/survey/survey_detail.html:45
+msgid "Published"
+msgstr "Publicerad"
+
+#: templates/survey/survey_detail.html:46
+msgid "Answers"
+msgstr "Svar"
+
+#: templates/survey/survey_detail.html:47
+msgid "Agree"
+msgstr "Instämmande"
+
 # UI strings
 #: templates/survey/survey_detail.html:54 templates/survey/survey_form.html:3
 #: templates/survey/survey_form.html:5

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -38,18 +38,26 @@
     {# Edit survey button moved next to the Results button at the bottom #}
     {% if unanswered_questions %}
       <h2 class="mt-3">{% translate 'Unanswered questions' %}</h2>
-      <ul class="list-group mb-3">
+      <table class="table mb-3">
+        <thead>
+          <tr>
+            <th>{% translate 'Title' %}</th>
+            <th>{% translate 'Published' %}</th>
+            <th>{% translate 'Answers' %}</th>
+            <th>{% translate 'Agree' %}</th>
+          </tr>
+        </thead>
+        <tbody>
         {% for q in unanswered_questions %}
-        <li class="list-group-item">
-          <div><a href="{% url 'survey:answer_question' q.pk %}"><strong>{{ q.text }}</strong></a></div>
-          <small class="text-muted">
-            {% translate 'Published' %}: {{ q.created_at }} |
-            {% translate 'Answers' %}: {{ q.total_answers }} |
-            {% translate 'Agree' %}: {% widthratio q.yes_count q.total_answers 100 %}%
-          </small>
-        </li>
+          <tr>
+            <td><a href="{% url 'survey:answer_question' q.pk %}">{{ q.text }}</a></td>
+            <td>{{ q.created_at }}</td>
+            <td>{{ q.total_answers }}</td>
+            <td>{% widthratio q.yes_count q.total_answers 100 %}%</td>
+          </tr>
         {% endfor %}
-      </ul>
+        </tbody>
+      </table>
     {% endif %}
 {% else %}
   <h2 class="mt-3">{% translate 'Questions' %}</h2>


### PR DESCRIPTION
## Summary
- show unanswered questions in a table
- add translations for table column headers

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687f21bfed64832eb373cb071ecdf7ea