### PR TITLE
Move Add question button to navbar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,8 +12,11 @@
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
-  <div class="container-fluid">
+  <div class="container-fluid d-flex align-items-center">
     <a class="navbar-brand" href="{% url 'survey:survey_detail' %}">WikiKysely</a>
+    {% if request.user.is_authenticated %}
+      <a href="{% url 'survey:question_add' %}" class="btn btn-secondary ms-2">{% translate 'Add question' %}</a>
+    {% endif %}
     <div class="collapse navbar-collapse">
       <ul id="userbar" class="navbar-nav ms-auto">
       <li class="nav-item">

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -27,7 +27,7 @@
       <a href="{% url 'survey:survey_results' %}" class="btn btn-info">{% translate 'Results' %}</a>
     {% endif %}
     {% if survey.state == 'running' or can_edit and survey.state != 'closed' %}
-      <a href="{% url 'survey:question_add' %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
+      {# Add question button moved to the navbar #}
     {% endif %}
     {% if can_edit %}
     <a href="{% url 'survey:survey_edit' %}" class="btn btn-warning">{% translate 'Edit survey' %}</a>


### PR DESCRIPTION
## Summary
- show "Add question" button in the top navbar whenever a user is logged in
- remove the button from the survey detail page

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687f2732e344832ebd9a81593fa0ca8a