### PR TITLE
Remove survey title from answer and results pages

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -125,6 +125,10 @@ msgstr "Vastaamattomat kysymykset"
 msgid "Answer survey"
 msgstr "Vastaa kyselyyn"
 
+#: templates/survey/answer_form.html:3
+msgid "Answer question"
+msgstr "Vastaa kysymykseen"
+
 #: templates/survey/survey_detail.html:36
 msgid "You must be logged in to answer questions"
 msgstr "Sinun tulee olla kirjautunut sisään vastataksesi kysymyksiin"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -125,6 +125,10 @@ msgstr "Obesvarade frågor"
 msgid "Answer survey"
 msgstr "Svara på enkäten"
 
+#: templates/survey/answer_form.html:3
+msgid "Answer question"
+msgstr "Svara på frågan"
+
 #: templates/survey/survey_detail.html:36
 msgid "You must be logged in to answer questions"
 msgstr "Du måste vara inloggad för att kunna svara på frågorna"

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -1,8 +1,7 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{{ survey.title }}{% endblock %}
+{% block title %}{% translate 'Answer question' %}{% endblock %}
 {% block content %}
-<h1>{{ survey.title }}</h1>
 <h2>{{ question.text }}</h2>
 {% if request.user.is_authenticated %}
 <form method="post">

--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{{ survey.title }}{% endblock %}
+{% block title %}{% translate 'Results' %}{% endblock %}
 {% block content %}
-<h1>{{ survey.title }} - {% translate 'Results' %}</h1>
+<h1>{% translate 'Results' %}</h1>
 <div class="mb-3">
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="chartType" id="pieChartRadio" value="pie" checked>


### PR DESCRIPTION
## Summary
- hide survey title in answer form
- hide survey title in results page
- add translations for new page title in Finnish and Swedish

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687f2a6084ec832e893c1eba846eac00