### PR TITLE
Center pie charts on results page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -9,7 +9,14 @@ body {
 }
 
 /* Ensure bar chart titles have some room */
-.bar-chart-question {
-  min-width: 15rem;
+  .bar-chart-question {
+    min-width: 15rem;
+  }
+
+/* Center pie charts relative to the question text */
+#pieCharts .pie-chart canvas {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }
 


### PR DESCRIPTION
## Summary
- ensure pie chart canvases center beneath their questions

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687fa0618a08832ea83b9942bfc5f43e