### PR TITLE
Update placeholder tooltip

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -64,6 +64,7 @@
 <script>
 const yesLabel = '{{ yes_label|escapejs }}';
 const noLabel = '{{ no_label|escapejs }}';
+const noAnswersLabel = '{{ no_answers_label|escapejs }}';
 const successColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-success').trim() || 'green';
 const dangerColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-danger').trim() || 'red';
 const placeholderColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary-bg').trim() ||
@@ -88,7 +89,7 @@ pieContainers.forEach(el => {
     new Chart(canvas, {
         type: 'pie',
         data: {
-            labels: total === 0 ? [''] : [yesLabel, noLabel],
+            labels: total === 0 ? [noAnswersLabel] : [yesLabel, noLabel],
             datasets: [{
                 data: data,
                 backgroundColor: colors

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -357,10 +357,12 @@ def survey_results(request):
         data.append(row)
     yes_label = gettext('Yes')
     no_label = gettext('No')
+    no_answers_label = gettext('No answers')
     return render(request, 'survey/results.html', {
         'survey': survey,
         'data': data,
         'total_users': total_users,
         'yes_label': yes_label,
         'no_label': no_label,
+        'no_answers_label': no_answers_label,
     })


### PR DESCRIPTION
## Summary
- show `no_answers_label` in placeholder pie charts
- add `no_answers_label` context in Results view

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68804882c02c832e9481cdbfeccfae39