### PR TITLE
Display extra data on results table

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -96,6 +96,10 @@ msgstr "Vastaajien määrä"
 msgid "Answer table"
 msgstr "Vastaustaulukko"
 
+#: templates/survey/results.html:53
+msgid "My answer"
+msgstr "Oma vastaus"
+
 #: templates/survey/results.html:9
 msgid "Total"
 msgstr "Yhteensä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -96,6 +96,10 @@ msgstr "Antal svarande"
 msgid "Answer table"
 msgstr "Svarstabell"
 
+#: templates/survey/results.html:53
+msgid "My answer"
+msgstr "Mitt svar"
+
 #: templates/survey/results.html:9
 msgid "Total"
 msgstr "Totalt"

--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -41,7 +41,19 @@
 <p class="mt-3">{% translate 'Total respondents' %}: {{ total_users }}</p>
 <h2>{% translate 'Answer table' %}</h2>
 <table class="table">
-<thead><tr><th>{% translate 'Question' %}</th><th>{% translate 'Yes' %}</th><th>{% translate 'No' %}</th><th>{% translate 'Total' %}</th></tr></thead>
+<thead>
+<tr>
+  <th>{% translate 'Question' %}</th>
+  <th>{% translate 'Published' %}</th>
+  <th>{% translate 'Yes' %}</th>
+  <th>{% translate 'No' %}</th>
+  <th>{% translate 'Total' %}</th>
+  <th>{% translate 'Agree' %}</th>
+  {% if request.user.is_authenticated %}
+  <th>{% translate 'My answer' %}</th>
+  {% endif %}
+</tr>
+</thead>
 <tbody>
 {% for row in data %}
 <tr>
@@ -52,9 +64,14 @@
       {{ row.question.text }}
     {% endif %}
   </td>
+  <td>{{ row.published|date:"Y-m-d" }}</td>
   <td>{{ row.yes }}</td>
   <td>{{ row.no }}</td>
   <td>{{ row.total }}</td>
+  <td>{% widthratio row.yes row.total 100 %}%</td>
+  {% if request.user.is_authenticated %}
+  <td>{{ row.my_answer }}</td>
+  {% endif %}
 </tr>
 {% endfor %}
 </tbody>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -150,6 +150,9 @@ class SurveyFlowTests(TransactionTestCase):
         data = response.context['data'][0]
         self.assertEqual(data['yes'], 1)
         self.assertEqual(data['no'], 0)
+        self.assertIn('published', data)
+        self.assertEqual(data['agree_ratio'], 100.0)
+        self.assertEqual(data['my_answer'], 'Yes')
         self.assertEqual(response.context['total_users'], 1)
         self.assertContains(response, 'Answer table')
 

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -339,21 +339,25 @@ def survey_results(request):
     user_answers = {}
     if request.user.is_authenticated:
         user_answers = {
-            a.question_id: a.pk
+            a.question_id: a.get_answer_display()
             for a in Answer.objects.filter(user=request.user, question__survey=survey)
         }
 
     for q in questions:
         yes_count = q.answers.filter(answer='yes').count()
         no_count = q.answers.filter(answer='no').count()
+        total = yes_count + no_count
+        agree_ratio = (yes_count * 100.0 / total) if total else 0
         row = {
             'question': q,
+            'published': q.created_at,
             'yes': yes_count,
             'no': no_count,
-            'total': yes_count + no_count,
+            'total': total,
+            'agree_ratio': agree_ratio,
         }
         if request.user.is_authenticated:
-            row['answer_pk'] = user_answers.get(q.pk)
+            row['my_answer'] = user_answers.get(q.pk)
         data.append(row)
     yes_label = gettext('Yes')
     no_label = gettext('No')


### PR DESCRIPTION
## Summary
- include publication date, agreement ratio, and user's answer on results page
- update translations for new heading
- adjust test expectations for results view

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68804a1b3be8832e81e8be2716a348f3