### PR TITLE
Fix date sorting on results page

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -169,6 +169,11 @@ document.addEventListener('DOMContentLoaded', () => {
         rows.sort((a, b) => {
             const aText = a.children[index].textContent.trim();
             const bText = b.children[index].textContent.trim();
+            const aDate = Date.parse(aText);
+            const bDate = Date.parse(bText);
+            if (!isNaN(aDate) && !isNaN(bDate)) {
+                return (aDate - bDate) * multiplier;
+            }
             const aNum = parseFloat(aText);
             const bNum = parseFloat(bText);
             if (!isNaN(aNum) && !isNaN(bNum)) {


### PR DESCRIPTION
## Summary
- parse date column as Date objects when sorting results table

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68805067b478832ea51e93f9cd76df4c