### PR TITLE
Make my answers list match unanswered table

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -64,29 +64,29 @@
 
 {% if user_answers %}
 <h2 class="mt-4">{% translate 'My answers' %}</h2>
-<ul class="list-group mb-3">
+<table class="table mb-3">
+  <thead>
+    <tr>
+      <th>{% translate 'Title' %}</th>
+      <th>{% translate 'Published' %}</th>
+      <th>{% translate 'Answers' %}</th>
+      <th>{% translate 'Agree' %}</th>
+    </tr>
+  </thead>
+  <tbody>
   {% for a in user_answers %}
-  <li class="list-group-item">
-    <div class="d-flex justify-content-between">
-      <div>
-        <a href="{% url 'survey:answer_question' a.question.pk %}"><strong>{{ a.question.text }}</strong></a>
+    <tr>
+      <td>
+        <a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a>
         <span class="badge bg-secondary ms-2">{{ a.get_answer_display }}</span>
-      </div>
-      {% if survey.state == 'running' %}
-      <div>
-        <a href="{% url 'survey:answer_question' a.question.pk %}" class="btn btn-sm btn-warning me-2">{% translate 'Edit' %}</a>
-        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove answer' %}</a>
-      </div>
-      {% endif %}
-    </div>
-    <small class="text-muted">
-      {% translate 'Published' %}: {{ a.question.created_at|date:"Y-m-d" }} |
-      {% translate 'Answers' %}: {{ a.total_answers }} |
-      {% translate 'Agree' %}: {% widthratio a.yes_count a.total_answers 100 %}%
-    </small>
-  </li>
+      </td>
+      <td>{{ a.question.created_at|date:"Y-m-d" }}</td>
+      <td>{{ a.total_answers }}</td>
+      <td>{% widthratio a.yes_count a.total_answers 100 %}%</td>
+    </tr>
   {% endfor %}
-</ul>
+  </tbody>
+</table>
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- make the 'My answers' list a table
- remove edit/remove answer buttons so both lists share the same look

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688060d6b67c832eb5f084334f24ab0e