### PR TITLE
Add tab navigation for survey pages

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -169,6 +169,20 @@ msgstr "Luo kysely"
 msgid "Questions"
 msgstr "Kysymykset"
 
+# Navigation tabs
+#: templates/survey/survey_base.html:5
+msgid "Survey info"
+msgstr "Kyselyn tiedot"
+
+#: templates/survey/survey_base.html:9
+msgid "All answers"
+msgstr "Kaikkien vastaukset"
+
+# Headings
+#: templates/survey/answer_list.html:5
+msgid "My answers heading"
+msgstr "Omat vastaukseni"
+
 #: templates/survey/survey_form.html:20
 msgid "No questions"
 msgstr "Ei kysymyksiä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -169,6 +169,20 @@ msgstr "Skapa enkät"
 msgid "Questions"
 msgstr "Frågor"
 
+# Navigation tabs
+#: templates/survey/survey_base.html:5
+msgid "Survey info"
+msgstr "Enkätinfo"
+
+#: templates/survey/survey_base.html:9
+msgid "All answers"
+msgstr "Allas svar"
+
+# Headings
+#: templates/survey/answer_list.html:5
+msgid "My answers heading"
+msgstr "Mina egna svar"
+
 #: templates/survey/survey_form.html:20
 msgid "No questions"
 msgstr "Inga frågor"

--- a/templates/survey/answer_list.html
+++ b/templates/survey/answer_list.html
@@ -1,8 +1,8 @@
-{% extends 'base.html' %}
+{% extends 'survey/survey_base.html' %}
 {% load i18n %}
 {% block title %}{% translate 'My answers' %}{% endblock %}
-{% block content %}
-<h1>{% translate 'My answers' %}</h1>
+{% block survey_content %}
+<h1>{% translate 'My answers heading' %}</h1>
 <table class="table">
 <thead><tr><th>{% translate 'Question' %}</th><th>{% translate 'Answer' %}</th></tr></thead>
 <tbody>

--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -1,8 +1,8 @@
-{% extends 'base.html' %}
+{% extends 'survey/survey_base.html' %}
 {% load i18n %}
 {% block title %}{% translate 'Results' %}{% endblock %}
-{% block content %}
-<h1>{% translate 'Results' %}</h1>
+{% block survey_content %}
+<h1>{% translate 'All answers' %}</h1>
 <div class="mb-3">
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="chartType" id="pieChartRadio" value="pie" checked>

--- a/templates/survey/survey_base.html
+++ b/templates/survey/survey_base.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block content %}
+<ul class="nav nav-tabs mb-4">
+  <li class="nav-item">
+    <a class="nav-link {% if active_tab == 'detail' %}active{% endif %}" href="{% url 'survey:survey_detail' %}">{% translate 'Survey info' %}</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link {% if active_tab == 'answers' %}active{% endif %}" href="{% url 'survey:answer_list' %}">{% translate 'My answers' %}</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link {% if active_tab == 'results' %}active{% endif %}" href="{% url 'survey:survey_results' %}">{% translate 'Results' %}</a>
+  </li>
+</ul>
+{% block survey_content %}{% endblock %}
+{% endblock %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -1,7 +1,8 @@
-{% extends 'base.html' %}
+{% extends 'survey/survey_base.html' %}
 {% load i18n %}
 {% block title %}{{ survey.title }}{% endblock %}
-{% block content %}
+{% block survey_content %}
+<h1>{% translate 'Questions' %}</h1>
 {% if survey.state == 'paused' %}
   <div class="alert alert-info">{% translate 'This survey is currently paused.' %}</div>
 {% endif %}


### PR DESCRIPTION
## Summary
- add new survey base template with nav tabs
- use new template on detail, answers and results pages
- update headings on pages and translations

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688079fe2398832e88b0f331818e05ba