### PR TITLE
Move add question button

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -14,9 +14,7 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <div class="container-fluid d-flex align-items-center">
     <a class="navbar-brand" href="{% url 'survey:survey_detail' %}">WikiKysely</a>
-    {% if request.user.is_authenticated %}
-      <a href="{% url 'survey:question_add' %}" class="btn btn-secondary ms-2">{% translate 'Add question' %}</a>
-    {% endif %}
+    {# Removed "Add question" button - now located on the survey detail page #}
     <div class="collapse navbar-collapse">
       <ul id="userbar" class="navbar-nav ms-auto">
       <li class="nav-item">

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -25,8 +25,9 @@
     {% if questions %}
       <a href="{% url 'survey:survey_results' %}" class="btn btn-info">{% translate 'Results' %}</a>
     {% endif %}
+    <a href="{% url 'survey:question_add' %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
     {% if can_edit %}
-      <a href="{% url 'survey:survey_edit' %}" class="btn btn-warning">{% translate 'Edit survey' %}</a>
+      <a href="{% url 'survey:survey_edit' %}" class="btn btn-warning ms-2">{% translate 'Edit survey' %}</a>
     {% endif %}
   </div>
 {% else %}


### PR DESCRIPTION
## Summary
- move "Add question" button from the navbar to the survey detail page

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68807d31f8c4832ead93128b4d4969a7