### PR TITLE
Add edit and delete buttons on answers page

### DIFF
--- a/templates/survey/answer_list.html
+++ b/templates/survey/answer_list.html
@@ -4,12 +4,27 @@
 {% block content %}
 <h1>{% translate 'My answers' %}</h1>
 <table class="table">
-<thead><tr><th>{% translate 'Question' %}</th><th>{% translate 'Answer' %}</th></tr></thead>
+<thead>
+  <tr>
+    <th>{% translate 'Question' %}</th>
+    <th>{% translate 'Answer' %}</th>
+    <th></th>
+  </tr>
+</thead>
 <tbody>
 {% for answer in answers %}
-<tr><td>{{ answer.question.text }}</td><td>{{ answer.get_answer_display }}</td></tr>
+  <tr>
+    <td>{{ answer.question.text }}</td>
+    <td>{{ answer.get_answer_display }}</td>
+    <td class="text-end">
+      {% if answer.question.survey.state == 'running' %}
+      <a href="{% url 'survey:answer_edit' answer.pk %}" class="btn btn-sm btn-warning">{% translate 'Edit' %}</a>
+      <a href="{% url 'survey:answer_delete' answer.pk %}" class="btn btn-sm btn-danger ms-2">{% translate 'Remove answer' %}</a>
+      {% endif %}
+    </td>
+  </tr>
 {% empty %}
-<tr><td colspan="2">{% translate 'No answers' %}</td></tr>
+  <tr><td colspan="3">{% translate 'No answers' %}</td></tr>
 {% endfor %}
 </tbody>
 </table>


### PR DESCRIPTION
## Summary
- show action buttons in answer list
- only show edit/remove when the survey is running

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68807cbcef90832e87a8b2d66ff202b7