### PR TITLE
Move published column to first position

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -20,14 +20,14 @@ body {
   margin-right: auto;
 }
 
-/* Use equal column widths on question tables */
+/* Set column widths on question tables */
 .survey-detail-table th:nth-child(1),
 .survey-detail-table td:nth-child(1) {
-  width: 60%;
+  width: 20%;
 }
 .survey-detail-table th:nth-child(2),
 .survey-detail-table td:nth-child(2) {
-  width: 20%;
+  width: 60%;
 }
 .survey-detail-table th:nth-child(3),
 .survey-detail-table td:nth-child(3) {

--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -43,8 +43,8 @@
 <table id="answerTable" class="table">
 <thead>
 <tr>
-  <th>{% translate 'Question' %}</th>
   <th>{% translate 'Published' %}</th>
+  <th>{% translate 'Question' %}</th>
   <th>{% translate 'Yes' %}</th>
   <th>{% translate 'No' %}</th>
   <th>{% translate 'Total' %}</th>
@@ -57,6 +57,7 @@
 <tbody>
 {% for row in data %}
 <tr>
+  <td>{{ row.published|date:"Y-m-d" }}</td>
   <td>
     {% if request.user.is_authenticated %}
       <a href="{% url 'survey:answer_question' row.question.pk %}">{{ row.question.text }}</a>
@@ -64,7 +65,6 @@
       {{ row.question.text }}
     {% endif %}
   </td>
-  <td>{{ row.published|date:"Y-m-d" }}</td>
   <td>{{ row.yes }}</td>
   <td>{{ row.no }}</td>
   <td>{{ row.total }}</td>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -38,25 +38,25 @@
         <h2 class="mt-3">{% translate 'Unanswered questions' %}</h2>
       <table class="table mb-3 survey-detail-table">
         <thead>
-          <tr>
-            <th>{% translate 'Title' %}</th>
-            <th>{% translate 'Published' %}</th>
-            <th>{% translate 'Answers' %}</th>
-            <th>{% translate 'Agree' %}</th>
-          </tr>
-        </thead>
-        <tbody>
-        {% for q in unanswered_questions %}
-          <tr>
+      <tr>
+        <th>{% translate 'Published' %}</th>
+        <th>{% translate 'Title' %}</th>
+        <th>{% translate 'Answers' %}</th>
+        <th>{% translate 'Agree' %}</th>
+      </tr>
+      </thead>
+      <tbody>
+      {% for q in unanswered_questions %}
+        <tr>
+        <td>{{ q.created_at | date:"Y-m-d" }}</td>
 {% if request.user.is_authenticated %}
-            <td><a href="{% url 'survey:answer_question' q.pk %}">{{ q.text }}</a></td>
+        <td><a href="{% url 'survey:answer_question' q.pk %}">{{ q.text }}</a></td>
 {% else %}
-            <td>{{ q.text }}</td>
+        <td>{{ q.text }}</td>
 {% endif %}
-            <td>{{ q.created_at | date:"Y-m-d" }}</td>
-            <td>{{ q.total_answers }}</td>
-            <td>{% widthratio q.yes_count q.total_answers 100 %}%</td>
-          </tr>
+        <td>{{ q.total_answers }}</td>
+        <td>{% widthratio q.yes_count q.total_answers 100 %}%</td>
+        </tr>
         {% endfor %}
         </tbody>
       </table>
@@ -66,21 +66,21 @@
 <h2 class="mt-4">{% translate 'My answers' %}</h2>
 <table class="table mb-3 survey-detail-table">
   <thead>
-    <tr>
-      <th>{% translate 'Title' %}</th>
-      <th>{% translate 'Published' %}</th>
-      <th>{% translate 'Answers' %}</th>
-      <th>{% translate 'Agree' %}</th>
-    </tr>
+  <tr>
+    <th>{% translate 'Published' %}</th>
+    <th>{% translate 'Title' %}</th>
+    <th>{% translate 'Answers' %}</th>
+    <th>{% translate 'Agree' %}</th>
+  </tr>
   </thead>
   <tbody>
   {% for a in user_answers %}
     <tr>
+      <td>{{ a.question.created_at|date:"Y-m-d" }}</td>
       <td>
         <a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a>
         <span class="badge bg-secondary ms-2">{{ a.get_answer_display }}</span>
       </td>
-      <td>{{ a.question.created_at|date:"Y-m-d" }}</td>
       <td>{{ a.total_answers }}</td>
       <td>{% widthratio a.yes_count a.total_answers 100 %}%</td>
     </tr>


### PR DESCRIPTION
## Summary
- reorder `Published` column to left on survey details and results pages
- adjust column widths in CSS

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68807e3376a0832e801bfbc150a940e3