### PR TITLE
Add navigation link to answer survey

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -127,7 +127,7 @@ msgstr "Vastaamattomat kysymykset"
 
 #: templates/survey/survey_detail.html:21
 msgid "Answer survey"
-msgstr "Vastaa kyselyyn"
+msgstr "Vastaa"
 
 #: templates/survey/answer_form.html:3
 msgid "Answer question"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -127,7 +127,7 @@ msgstr "Obesvarade frågor"
 
 #: templates/survey/survey_detail.html:21
 msgid "Answer survey"
-msgstr "Svara på enkäten"
+msgstr "Svara"
 
 #: templates/survey/answer_form.html:3
 msgid "Answer question"

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,9 +16,13 @@
     <a class="navbar-brand" href="{% url 'survey:survey_detail' %}">WikiKysely</a>
     {# Removed "Add question" button - now located on the survey detail page #}
     <div class="collapse navbar-collapse">
+      {% url 'survey:survey_detail' as survey_detail_url %}
+      {% url 'survey:answer_survey' as answer_survey_url %}
+      {% url 'survey:survey_results' as survey_results_url %}
       <ul class="navbar-nav me-auto">
-        <li class="nav-item"><a class="nav-link" href="{% url 'survey:survey_detail' %}">{% translate 'Questions' %}</a></li>
-        <li class="nav-item"><a class="nav-link" href="{% url 'survey:survey_results' %}">{% translate 'Results' %}</a></li>
+        <li class="nav-item"><a class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
+        <li class="nav-item"><a class="nav-link{% if request.path == answer_survey_url %} active{% endif %}" href="{{ answer_survey_url }}">{% translate 'Answer survey' %}</a></li>
+        <li class="nav-item"><a class="nav-link{% if request.path == survey_results_url %} active{% endif %}" href="{{ survey_results_url }}">{% translate 'Results' %}</a></li>
       </ul>
       <ul id="userbar" class="navbar-nav ms-auto">
       <li class="nav-item">


### PR DESCRIPTION
## Summary
- add link to answer survey in the navbar
- highlight current page link
- adjust Finnish and Swedish translations

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68808c5b09a8832e8fa6fce2b32ebb0d