### PR TITLE
Add nav highlight and disable answer link

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -43,4 +43,6 @@ body {
 .nav-link.active {
   font-weight: bold;
   color: var(--bs-primary);
+  background-color: var(--bs-primary-bg-subtle);
+  border-radius: 0.25rem;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,11 @@
       {% url 'survey:survey_results' as survey_results_url %}
       <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
+        {% if unanswered_count %}
         <li class="nav-item"><a class="nav-link{% if request.path == answer_survey_url %} active{% endif %}" href="{{ answer_survey_url }}">{% translate 'Answer survey' %}</a></li>
+        {% else %}
+        <li class="nav-item"><span class="nav-link text-secondary">{% translate 'Answer survey' %}</span></li>
+        {% endif %}
         <li class="nav-item"><a class="nav-link{% if request.path == survey_results_url %} active{% endif %}" href="{{ survey_results_url }}">{% translate 'Results' %}</a></li>
       </ul>
       <ul id="userbar" class="navbar-nav ms-auto">

--- a/wikikysely_project/settings.py
+++ b/wikikysely_project/settings.py
@@ -42,6 +42,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'wikikysely_project.survey.context_processors.unanswered_count',
             ],
         },
     },

--- a/wikikysely_project/survey/context_processors.py
+++ b/wikikysely_project/survey/context_processors.py
@@ -1,0 +1,14 @@
+from .models import Survey, Answer
+
+
+def unanswered_count(request):
+    """Return number of unanswered questions for the logged-in user."""
+    if not request.user.is_authenticated:
+        return {}
+    survey = Survey.get_main_survey()
+    answered_ids = Answer.objects.filter(
+        user=request.user,
+        question__survey=survey,
+    ).values_list('question_id', flat=True)
+    count = survey.questions.filter(deleted=False).exclude(id__in=answered_ids).count()
+    return {'unanswered_count': count}


### PR DESCRIPTION
## Summary
- style active nav link with background color
- disable the *Answer survey* link when user has no unanswered questions
- provide unanswered question count via context processor

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688091875944832e9cc546ac818308e7