### PR TITLE
Add edit/delete actions to survey detail answers

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -38,6 +38,10 @@ body {
 .survey-detail-table td:nth-child(4) {
   width: 10%;
 }
+.survey-detail-table th:nth-child(5),
+.survey-detail-table td:nth-child(5) {
+  width: 10%;
+}
 
 /* Make the active navigation link stand out more */
 .nav-link.active {

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -41,6 +41,7 @@
         <th>{% translate 'Title' %}</th>
         <th>{% translate 'Answers' %}</th>
         <th>{% translate 'Agree' %}</th>
+        <th></th>
       </tr>
       </thead>
       <tbody>
@@ -54,6 +55,7 @@
 {% endif %}
         <td>{{ q.total_answers }}</td>
         <td>{% widthratio q.yes_count q.total_answers 100 %}%</td>
+        <td></td>
         </tr>
         {% endfor %}
         </tbody>
@@ -69,6 +71,7 @@
     <th>{% translate 'Title' %}</th>
     <th>{% translate 'Answers' %}</th>
     <th>{% translate 'Agree' %}</th>
+    <th></th>
   </tr>
   </thead>
   <tbody>
@@ -81,6 +84,12 @@
       </td>
       <td>{{ a.total_answers }}</td>
       <td>{% widthratio a.yes_count a.total_answers 100 %}%</td>
+      <td class="text-end">
+        {% if a.question.survey.state == 'running' %}
+        <a href="{% url 'survey:answer_edit' a.pk %}" class="btn btn-sm btn-warning">{% translate 'Edit' %}</a>
+        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ms-2">{% translate 'Remove answer' %}</a>
+        {% endif %}
+      </td>
     </tr>
   {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- give unanswered and answered question lists the same column layout
- allow editing or removing answers directly on the survey detail page

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_688095536b20832e92bb7adae6acbc17