### PR TITLE
Display user answer on results page

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -61,9 +61,6 @@
   <th>{% translate 'No' %}</th>
   <th>{% translate 'Total' %}</th>
   <th>{% translate 'Agree' %}</th>
-  {% if request.user.is_authenticated %}
-  <!--th>{% translate 'My answer' %}</th-->
-  {% endif %}
 </tr>
 </thead>
 <tbody>
@@ -73,6 +70,9 @@
   <td>
     {% if request.user.is_authenticated %}
       <a href="{% url 'survey:answer_question' row.question.pk %}">{{ row.question.text }}</a>
+      {% if row.my_answer %}
+        <span class="badge bg-secondary ms-2">{{ row.my_answer }}</span>
+      {% endif %}
     {% else %}
       {{ row.question.text }}
     {% endif %}
@@ -81,9 +81,6 @@
   <td>{{ row.no }}</td>
   <td>{{ row.total }}</td>
   <td>{% widthratio row.yes row.total 100 %}%</td>
-  {% if request.user.is_authenticated %}
-  <!--td>{{ row.my_answer|default:"" }}</td-->
-  {% endif %}
 </tr>
 {% endfor %}
 </tbody>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -156,6 +156,17 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(response.context['total_users'], 1)
         self.assertContains(response, 'Answer table')
 
+    def test_results_view_displays_my_answer_badge(self):
+        survey = self._create_survey()
+        question = self._create_question(survey)
+        Answer.objects.create(question=question, user=self.user, answer='yes')
+        response = self.client.get(reverse('survey:survey_results'))
+        self.assertContains(
+            response,
+            '<span class="badge bg-secondary ms-2">Yes</span>',
+            html=True,
+        )
+
     def test_answer_saved_to_correct_question_and_user(self):
         survey = self._create_survey()
         questions = self._create_questions(survey, 10)


### PR DESCRIPTION
## Summary
- show authenticated user's answer as a badge in results table
- add test ensuring the badge is rendered

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6880f2f3c128832e8081361ec052722c