### PR TITLE
Add column for user answer

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -57,6 +57,9 @@
 <tr>
   <th>{% translate 'Published' %}</th>
   <th>{% translate 'Question' %}</th>
+  {% if request.user.is_authenticated %}
+  <th>{% translate 'My answer' %}</th>
+  {% endif %}
   <th>{% translate 'Yes' %}</th>
   <th>{% translate 'No' %}</th>
   <th>{% translate 'Total' %}</th>
@@ -70,13 +73,13 @@
   <td>
     {% if request.user.is_authenticated %}
       <a href="{% url 'survey:answer_question' row.question.pk %}">{{ row.question.text }}</a>
-      {% if row.my_answer %}
-        <span class="badge bg-secondary ms-2">{{ row.my_answer }}</span>
-      {% endif %}
     {% else %}
       {{ row.question.text }}
     {% endif %}
   </td>
+  {% if request.user.is_authenticated %}
+  <td>{{ row.my_answer }}</td>
+  {% endif %}
   <td>{{ row.yes }}</td>
   <td>{{ row.no }}</td>
   <td>{{ row.total }}</td>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -70,6 +70,7 @@
   <tr>
     <th>{% translate 'Published' %}</th>
     <th>{% translate 'Title' %}</th>
+    <th>{% translate 'My answer' %}</th>
     <th>{% translate 'Answers' %}</th>
     <th>{% translate 'Agree' %}</th>
     <th></th>
@@ -81,8 +82,8 @@
       <td>{{ a.question.created_at|date:"Y-m-d" }}</td>
       <td>
         <a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a>
-        <span class="badge bg-secondary ms-2">{{ a.get_answer_display }}</span>
       </td>
+      <td>{{ a.get_answer_display }}</td>
       <td>{{ a.total_answers }}</td>
       <td>{% widthratio a.yes_count a.total_answers 100 %}%</td>
       <td class="text-end">

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -156,14 +156,14 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(response.context['total_users'], 1)
         self.assertContains(response, 'Answer table')
 
-    def test_results_view_displays_my_answer_badge(self):
+    def test_results_view_displays_my_answer_column(self):
         survey = self._create_survey()
         question = self._create_question(survey)
         Answer.objects.create(question=question, user=self.user, answer='yes')
         response = self.client.get(reverse('survey:survey_results'))
         self.assertContains(
             response,
-            '<span class="badge bg-secondary ms-2">Yes</span>',
+            '<td>Yes</td>',
             html=True,
         )
 


### PR DESCRIPTION
## Summary
- show the user's own answer in a separate column on the results page
- show the user's own answer in a separate column on the survey detail page
- update tests for new column

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688194cdc254832ebfd92eee7e2b920c