### PR TITLE
Add inline yes/no buttons for answers

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -88,7 +88,12 @@
       <td>{% widthratio a.yes_count a.total_answers 100 %}%</td>
       <td class="text-end">
         {% if a.question.survey.state == 'running' %}
-        <a href="{% url 'survey:answer_edit' a.pk %}" class="btn btn-sm btn-warning">{% translate 'Edit' %}</a>
+        <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline">
+          {% csrf_token %}
+          <input type="hidden" name="question_id" value="{{ a.question.pk }}">
+          <button type="submit" name="answer" value="yes" class="btn btn-sm btn-success me-1{% if a.answer == 'yes' %} active disabled{% endif %}">{% translate 'Yes' %}</button>
+          <button type="submit" name="answer" value="no" class="btn btn-sm btn-danger{% if a.answer == 'no' %} active disabled{% endif %}">{% translate 'No' %}</button>
+        </form>
         <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ms-2">{% translate 'Remove answer' %}</a>
         {% endif %}
       </td>


### PR DESCRIPTION
## Summary
- allow inline editing of answers on survey detail page with Yes/No buttons

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6882331f2654832e83e409eb5a65bdaf