### PR TITLE
Improve yes/no toggle style

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -50,3 +50,41 @@ body {
   background-color: var(--bs-primary-bg-subtle);
   border-radius: 0.25rem;
 }
+/* Yes/No toggle styling */
+.yes-no-toggle {
+  display: inline-flex;
+  border: 1px solid var(--bs-success);
+  border-radius: 0.375rem;
+}
+.yes-no-toggle.no-active {
+  border-color: var(--bs-danger);
+}
+.yes-no-toggle button {
+  border: none;
+  background-color: var(--bs-body-bg);
+  color: inherit;
+  padding: 0.25rem 0.75rem;
+}
+.yes-no-toggle button:first-child {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+.yes-no-toggle button:last-child {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+.yes-no-toggle .yes-btn {
+  color: var(--bs-success);
+}
+.yes-no-toggle .no-btn {
+  color: var(--bs-danger);
+}
+.yes-no-toggle .btn.active {
+  color: #000;
+}
+.yes-no-toggle.yes-active .btn.active {
+  background-color: var(--bs-success);
+}
+.yes-no-toggle.no-active .btn.active {
+  background-color: var(--bs-danger);
+}

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -12,8 +12,12 @@
   {% for field in form.hidden_fields %}
     {{ field }}
   {% endfor %}
-  <button type="submit" name="answer" value="yes" class="btn btn-success me-2">{% translate 'Yes' %}</button>
-  <button type="submit" name="answer" value="no" class="btn btn-danger me-2">{% translate 'No' %}</button>
+  {% with current=form.instance.answer %}
+  <div class="yes-no-toggle {% if current == 'no' %}no-active{% else %}yes-active{% endif %}">
+    <button type="submit" name="answer" value="yes" class="btn yes-btn{% if current == 'yes' %} active{% endif %}">{% translate 'Yes' %}</button>
+    <button type="submit" name="answer" value="no" class="btn no-btn{% if current == 'no' %} active{% endif %}">{% translate 'No' %}</button>
+  </div>
+  {% endwith %}
   {% if is_edit %}
     <a href="{% url 'survey:survey_detail' %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
     {% if survey.state == 'running' %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -91,8 +91,10 @@
         <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline">
           {% csrf_token %}
           <input type="hidden" name="question_id" value="{{ a.question.pk }}">
-          <button type="submit" name="answer" value="yes" class="btn btn-sm btn-success me-1{% if a.answer == 'yes' %} active disabled{% endif %}">{% translate 'Yes' %}</button>
-          <button type="submit" name="answer" value="no" class="btn btn-sm btn-danger{% if a.answer == 'no' %} active disabled{% endif %}">{% translate 'No' %}</button>
+          <div class="yes-no-toggle {% if a.answer == 'no' %}no-active{% else %}yes-active{% endif %}">
+            <button type="submit" name="answer" value="yes" class="btn btn-sm yes-btn{% if a.answer == 'yes' %} active disabled{% endif %}">{% translate 'Yes' %}</button>
+            <button type="submit" name="answer" value="no" class="btn btn-sm no-btn{% if a.answer == 'no' %} active disabled{% endif %}">{% translate 'No' %}</button>
+          </div>
         </form>
         <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ms-2">{% translate 'Remove answer' %}</a>
         {% endif %}


### PR DESCRIPTION
## Summary
- style yes/no buttons as a single toggle
- update answer and survey detail forms to use the new toggle

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688236320e00832e87e34e0369641405