### PR TITLE
Remove answer column from survey detail

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -70,7 +70,6 @@
   <tr>
     <th>{% translate 'Published' %}</th>
     <th>{% translate 'Title' %}</th>
-    <th>{% translate 'My answer' %}</th>
     <th>{% translate 'Answers' %}</th>
     <th>{% translate 'Agree' %}</th>
     <th></th>
@@ -83,7 +82,6 @@
       <td>
         <a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a>
       </td>
-      <td>{{ a.get_answer_display }}</td>
       <td>{{ a.total_answers }}</td>
       <td>{% widthratio a.yes_count a.total_answers 100 %}%</td>
       <td class="text-end">


### PR DESCRIPTION
## Summary
- clean up survey detail page
- remove the "My answer" column from the "Vastaukseni" table

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68823f4e60fc832e96175cd9e3709d20