### PR TITLE
Enable question deletion by creator

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -69,6 +69,10 @@ msgstr "Peruuta"
 msgid "Remove answer"
 msgstr "Poista vastaus"
 
+#: templates/survey/answer_form.html:21
+msgid "Remove question"
+msgstr "Poista kysymys"
+
 #: templates/survey/answer_form.html:23 wikikysely_project/survey/forms.py:36
 msgid "Skip"
 msgstr "Ohita"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -69,6 +69,10 @@ msgstr "Avbryt"
 msgid "Remove answer"
 msgstr "Ta bort svar"
 
+#: templates/survey/answer_form.html:21
+msgid "Remove question"
+msgstr "Ta bort fråga"
+
 #: templates/survey/answer_form.html:23 wikikysely_project/survey/forms.py:36
 msgid "Skip"
 msgstr "Hoppa över"

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -25,6 +25,9 @@
     {% if survey.state == 'running' %}
     <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger ms-2">{% translate 'Remove answer' %}</a>
     {% endif %}
+    {% if can_delete_question %}
+    <a href="{% url 'survey:question_delete' question.pk %}" class="btn btn-danger ms-2">{% translate 'Remove question' %}</a>
+    {% endif %}
   {% else %}
     <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Skip' %}</button>
   {% endif %}


### PR DESCRIPTION
## Summary
- allow question creators to delete their own question when no one else has answered
- show "Remove question" button on the answer form
- add translations for the new string in Finnish and Swedish

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68824880d060832ea687abf13dee88ac