### PR TITLE
Add user questions to profile view

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -25,6 +25,10 @@ msgstr "Tulokset"
 msgid "My answers"
 msgstr "Vastaukseni"
 
+#: templates/survey/answer_list.html:6
+msgid "My questions"
+msgstr "Omat kysymykset"
+
 #: templates/base.html:48
 msgid "Logout"
 msgstr "Kirjaudu ulos"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -25,6 +25,10 @@ msgstr "Resultat"
 msgid "My answers"
 msgstr "Mina svar"
 
+#: templates/survey/answer_list.html:6
+msgid "My questions"
+msgstr "Mina frågor"
+
 #: templates/base.html:48
 msgid "Logout"
 msgstr "Logga ut"

--- a/templates/survey/answer_list.html
+++ b/templates/survey/answer_list.html
@@ -1,8 +1,34 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{% translate 'My answers' %}{% endblock %}
+{% block title %}{{ request.user.username }}{% endblock %}
 {% block content %}
-<h1>{% translate 'My answers' %}</h1>
+<h1>{{ request.user.username }}</h1>
+
+<h2>{% translate 'My questions' %}</h2>
+<table class="table mb-4">
+  <thead>
+    <tr>
+      <th>{% translate 'Question' %}</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for question in questions %}
+    <tr>
+      <td>{{ question.text }}</td>
+      <td class="text-end">
+        {% if question.pk in deletable_questions %}
+        <a href="{% url 'survey:question_delete' question.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove question' %}</a>
+        {% endif %}
+      </td>
+    </tr>
+  {% empty %}
+    <tr><td colspan="2">{% translate 'No questions' %}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+
+<h2>{% translate 'My answers' %}</h2>
 <table class="table">
 <thead>
   <tr>


### PR DESCRIPTION
## Summary
- extend `answer_list` view to provide user's own questions
- show questions with delete option on user page
- localize "My questions" in Finnish and Swedish

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68824cc6ad84832e93d539e8db0f4ba5