### PR TITLE
Improve answer button layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -50,3 +50,10 @@ body {
   background-color: var(--bs-primary-bg-subtle);
   border-radius: 0.25rem;
 }
+
+/* Keep answer page buttons aligned */
+.answer-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -12,25 +12,27 @@
   {% for field in form.hidden_fields %}
     {{ field }}
   {% endfor %}
-  <div class="mb-2" role="group" aria-label="{% translate 'Answer' %}">
-    <input type="radio" class="btn-check" name="answer" id="answerYes"
-           value="yes" onchange="this.form.submit()"{% if form.answer.value == 'yes' %} checked{% endif %}>
-    <label class="btn btn-outline-success me-2" for="answerYes">{% translate 'Yes' %}</label>
-    <input type="radio" class="btn-check" name="answer" id="answerNo"
-           value="no" onchange="this.form.submit()"{% if form.answer.value == 'no' %} checked{% endif %}>
-    <label class="btn btn-outline-danger" for="answerNo">{% translate 'No' %}</label>
+  <div class="answer-buttons mb-2" role="group" aria-label="{% translate 'Answer' %}">
+    <div class="btn-group me-2" role="group">
+      <input type="radio" class="btn-check" name="answer" id="answerYes"
+             value="yes" onchange="this.form.submit()"{% if form.answer.value == 'yes' %} checked{% endif %}>
+      <label class="btn {% if form.answer.value and is_edit %}{% if form.answer.value == 'yes' %}btn-success{% else %}btn-outline-success{% endif %}{% else %}btn-success{% endif %}" for="answerYes">{% translate 'Yes' %}</label>
+      <input type="radio" class="btn-check" name="answer" id="answerNo"
+             value="no" onchange="this.form.submit()"{% if form.answer.value == 'no' %} checked{% endif %}>
+      <label class="btn {% if form.answer.value and is_edit %}{% if form.answer.value == 'no' %}btn-danger{% else %}btn-outline-danger{% endif %}{% else %}btn-danger{% endif %}" for="answerNo">{% translate 'No' %}</label>
+    </div>
+    {% if is_edit %}
+      <a href="{% url 'survey:survey_detail' %}" class="btn btn-secondary me-2">{% translate 'Cancel' %}</a>
+      {% if survey.state == 'running' %}
+      <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger me-2">{% translate 'Remove answer' %}</a>
+      {% endif %}
+      {% if can_delete_question %}
+      <a href="{% url 'survey:question_delete' question.pk %}" class="btn btn-danger">{% translate 'Remove question' %}</a>
+      {% endif %}
+    {% else %}
+      <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Skip' %}</button>
+    {% endif %}
   </div>
-  {% if is_edit %}
-    <a href="{% url 'survey:survey_detail' %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
-    {% if survey.state == 'running' %}
-    <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger ms-2">{% translate 'Remove answer' %}</a>
-    {% endif %}
-    {% if can_delete_question %}
-    <a href="{% url 'survey:question_delete' question.pk %}" class="btn btn-danger ms-2">{% translate 'Remove question' %}</a>
-    {% endif %}
-  {% else %}
-    <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Skip' %}</button>
-  {% endif %}
 </form>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- align Yes/No buttons and action buttons in a single flex row
- apply outline styles only when editing an existing answer
- add `.answer-buttons` style for layout

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6882a8b8bf28832eb389e4ee92a1ea5e