### PR TITLE
Add question edit feature

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -291,6 +291,18 @@ msgstr "Suljettuun kyselyyn ei voi palauttaa kysymyksiä"
 msgid "Question restored"
 msgstr "Kysymys palautettu"
 
+#: wikikysely_project/survey/views.py:213
+msgid "Cannot edit questions in a closed survey"
+msgstr "Suljetussa kyselyssä ei voi muokata kysymyksiä"
+
+#: templates/survey/question_form.html:3 templates/survey/question_form.html:5
+msgid "Edit question"
+msgstr "Muokkaa kysymystä"
+
+#: wikikysely_project/survey/views.py:216
+msgid "Question updated"
+msgstr "Kysymys päivitetty"
+
 #: wikikysely_project/survey/views.py:201
 #: wikikysely_project/survey/views.py:204
 #: wikikysely_project/survey/views.py:259

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -291,6 +291,18 @@ msgstr "Det går inte att återställa frågor i en stängd enkät"
 msgid "Question restored"
 msgstr "Fråga återställd"
 
+#: wikikysely_project/survey/views.py:213
+msgid "Cannot edit questions in a closed survey"
+msgstr "Det går inte att redigera frågor i en stängd enkät"
+
+#: templates/survey/question_form.html:3 templates/survey/question_form.html:5
+msgid "Edit question"
+msgstr "Redigera fråga"
+
+#: wikikysely_project/survey/views.py:216
+msgid "Question updated"
+msgstr "Fråga uppdaterad"
+
 #: wikikysely_project/survey/views.py:201
 #: wikikysely_project/survey/views.py:204
 #: wikikysely_project/survey/views.py:259

--- a/templates/survey/answer_list.html
+++ b/templates/survey/answer_list.html
@@ -17,6 +17,9 @@
     <tr>
       <td>{{ question.text }}</td>
       <td class="text-end">
+        {% if question.pk in editable_questions %}
+        <a href="{% url 'survey:question_edit' question.pk %}" class="btn btn-sm btn-warning me-2">{% translate 'Edit' %}</a>
+        {% endif %}
         {% if question.pk in deletable_questions %}
         <a href="{% url 'survey:question_delete' question.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove question' %}</a>
         {% endif %}

--- a/templates/survey/question_form.html
+++ b/templates/survey/question_form.html
@@ -1,16 +1,18 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{% translate 'Add question' %}{% endblock %}
+{% block title %}{% if is_edit %}{% translate 'Edit question' %}{% else %}{% translate 'Add question' %}{% endif %}{% endblock %}
 {% block content %}
-<h1>{% translate 'Add question' %}</h1>
+<h1>{% if is_edit %}{% translate 'Edit question' %}{% else %}{% translate 'Add question' %}{% endif %}</h1>
 <form method="post">
   {% csrf_token %}
   {{ form.as_p }}
   <button type="submit" class="btn btn-primary me-2">{% translate 'Save' %}</button>
   <a href="{% url 'survey:survey_detail' %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
 </form>
+{% if not is_edit %}
 <hr>
 <p>{% translate "Add any question related to the survey's topic, but phrase it so it can only be answered 'Yes' or 'No'. You may also add a statement, provided the respondent can similarly answer whether they agree or disagree - yes or no." %}</p>
 <p><a href="https://fi.wikipedia.org/wiki/Wikiprojekti:Wikikysely_2025/ohjeet" target="_blank">{% translate 'Read more instructions' %}</a></p>
+{% endif %}
 </div>
 {% endblock %}

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -12,6 +12,7 @@ class SurveyFlowTests(TransactionTestCase):
     def setUpClass(cls):
         super().setUpClass()
         from django.db import connection
+
         connection.disable_constraint_checking()
         try:
             with connection.schema_editor(atomic=False) as schema_editor:
@@ -24,6 +25,7 @@ class SurveyFlowTests(TransactionTestCase):
     @classmethod
     def tearDownClass(cls):
         from django.db import connection
+
         connection.disable_constraint_checking()
         try:
             with connection.schema_editor(atomic=False) as schema_editor:
@@ -33,25 +35,26 @@ class SurveyFlowTests(TransactionTestCase):
         finally:
             connection.enable_constraint_checking()
         super().tearDownClass()
+
     def setUp(self):
-        activate('en')
+        activate("en")
         User = get_user_model()
         self.users = [
-            User.objects.create_user(username=f'tester{i}', password='pass')
+            User.objects.create_user(username=f"tester{i}", password="pass")
             for i in range(1, 4)
         ]
         self.user = self.users[0]
-        self.client.login(username=self.user.username, password='pass')
+        self.client.login(username=self.user.username, password="pass")
 
     def _create_survey(self):
         return Survey.objects.create(
-            title='Test Survey',
-            description='desc',
+            title="Test Survey",
+            description="desc",
             creator=self.user,
-            state='running',
+            state="running",
         )
 
-    def _create_question(self, survey, text='Question?'):
+    def _create_question(self, survey, text="Question?"):
         return Question.objects.create(
             survey=survey,
             text=text,
@@ -60,110 +63,144 @@ class SurveyFlowTests(TransactionTestCase):
 
     def _create_questions(self, survey, count=10):
         return [
-            self._create_question(survey, text=f'Question {i}?')
+            self._create_question(survey, text=f"Question {i}?")
             for i in range(1, count + 1)
         ]
 
     def test_survey_edit(self):
         survey = self._create_survey()
         data = {
-            'title': 'Edited Survey',
-            'description': 'changed',
-            'state': 'paused',
+            "title": "Edited Survey",
+            "description": "changed",
+            "state": "paused",
         }
-        response = self.client.post(reverse('survey:survey_edit'), data)
+        response = self.client.post(reverse("survey:survey_edit"), data)
         survey.refresh_from_db()
-        self.assertEqual(survey.title, 'Edited Survey')
-        self.assertEqual(survey.state, 'paused')
-        self.assertRedirects(response, reverse('survey:survey_detail'))
+        self.assertEqual(survey.title, "Edited Survey")
+        self.assertEqual(survey.state, "paused")
+        self.assertRedirects(response, reverse("survey:survey_detail"))
 
     def test_add_question(self):
         survey = self._create_survey()
-        data = {'text': 'What do you think?'}
-        response = self.client.post(reverse('survey:question_add'), data)
+        data = {"text": "What do you think?"}
+        response = self.client.post(reverse("survey:question_add"), data)
         self.assertEqual(survey.questions.filter(deleted=False).count(), 1)
         question = survey.questions.first()
-        self.assertEqual(question.text, 'What do you think?')
-        self.assertRedirects(response, reverse('survey:survey_detail'))
+        self.assertEqual(question.text, "What do you think?")
+        self.assertRedirects(response, reverse("survey:survey_detail"))
 
     def test_delete_and_restore_question(self):
         survey = self._create_survey()
         question = self._create_question(survey)
         # delete
-        response = self.client.post(reverse('survey:question_delete', kwargs={'pk': question.pk}))
+        response = self.client.post(
+            reverse("survey:question_delete", kwargs={"pk": question.pk})
+        )
         question.refresh_from_db()
         self.assertTrue(question.deleted)
-        self.assertRedirects(response, reverse('survey:survey_edit'))
+        self.assertRedirects(response, reverse("survey:survey_edit"))
         # restore
-        response = self.client.post(reverse('survey:question_restore', kwargs={'pk': question.pk}))
+        response = self.client.post(
+            reverse("survey:question_restore", kwargs={"pk": question.pk})
+        )
         question.refresh_from_db()
         self.assertFalse(question.deleted)
-        self.assertRedirects(response, reverse('survey:survey_edit'))
+        self.assertRedirects(response, reverse("survey:survey_edit"))
+
+    def test_edit_question(self):
+        survey = self._create_survey()
+        question = self._create_question(survey)
+        data = {"text": "Updated question?"}
+        response = self.client.post(
+            reverse("survey:question_edit", kwargs={"pk": question.pk}),
+            data,
+        )
+        question.refresh_from_db()
+        self.assertEqual(question.text, "Updated question?")
+        self.assertRedirects(response, reverse("survey:survey_edit"))
+
+    def test_cannot_edit_question_answered_by_others(self):
+        other_user = self.users[1]
+        survey = Survey.objects.create(
+            title="Test", description="d", creator=other_user, state="running"
+        )
+        question = Question.objects.create(
+            survey=survey, text="Original?", creator=self.user
+        )
+        Answer.objects.create(question=question, user=other_user, answer="yes")
+        data = {"text": "Updated?"}
+        response = self.client.post(
+            reverse("survey:question_edit", kwargs={"pk": question.pk}),
+            data,
+        )
+        question.refresh_from_db()
+        self.assertEqual(question.text, "Original?")
+        self.assertRedirects(response, reverse("survey:survey_detail"))
 
     def test_answer_question_and_edit(self):
         survey = self._create_survey()
         questions = self._create_questions(survey, 10)
 
         # answer by first user (already logged in)
-        data = {'question_id': questions[0].pk, 'answer': 'yes'}
-        response = self.client.post(reverse('survey:answer_survey'), data)
+        data = {"question_id": questions[0].pk, "answer": "yes"}
+        response = self.client.post(reverse("survey:answer_survey"), data)
         self.assertEqual(Answer.objects.count(), 1)
         answer = Answer.objects.get(question=questions[0], user=self.user)
-        self.assertEqual(answer.answer, 'yes')
+        self.assertEqual(answer.answer, "yes")
         self.assertRedirects(
             response,
-            reverse('survey:answer_survey'),
+            reverse("survey:answer_survey"),
             fetch_redirect_response=False,
         )
 
         # answer by second and third users
         for idx, user in enumerate(self.users[1:], start=1):
             self.client.logout()
-            self.client.login(username=user.username, password='pass')
-            data = {'question_id': questions[idx].pk, 'answer': 'yes'}
-            self.client.post(reverse('survey:answer_survey'), data)
+            self.client.login(username=user.username, password="pass")
+            data = {"question_id": questions[idx].pk, "answer": "yes"}
+            self.client.post(reverse("survey:answer_survey"), data)
             ans = Answer.objects.get(question=questions[idx], user=user)
-            self.assertEqual(ans.answer, 'yes')
+            self.assertEqual(ans.answer, "yes")
         self.assertEqual(Answer.objects.count(), 3)
 
         # edit first user's answer
         self.client.logout()
-        self.client.login(username=self.user.username, password='pass')
-        edit_data = {'question_id': questions[0].pk, 'answer': 'no'}
+        self.client.login(username=self.user.username, password="pass")
+        edit_data = {"question_id": questions[0].pk, "answer": "no"}
         response = self.client.post(
-            reverse('survey:answer_question', kwargs={'pk': questions[0].pk}),
+            reverse("survey:answer_question", kwargs={"pk": questions[0].pk}),
             edit_data,
         )
         answer.refresh_from_db()
-        self.assertEqual(answer.answer, 'no')
+        self.assertEqual(answer.answer, "no")
         self.assertRedirects(
             response,
-            reverse('survey:survey_detail'),
+            reverse("survey:survey_detail"),
         )
 
     def test_results_view(self):
         survey = self._create_survey()
         question = self._create_question(survey)
-        Answer.objects.create(question=question, user=self.user, answer='yes')
-        response = self.client.get(reverse('survey:survey_results'))
+        Answer.objects.create(question=question, user=self.user, answer="yes")
+        response = self.client.get(reverse("survey:survey_results"))
         self.assertEqual(response.status_code, 200)
-        data = response.context['data'][0]
-        self.assertEqual(data['yes'], 1)
-        self.assertEqual(data['no'], 0)
-        self.assertIn('published', data)
-        self.assertEqual(data['agree_ratio'], 100.0)
-        self.assertEqual(data['my_answer'], 'Yes')
-        self.assertEqual(response.context['total_users'], 1)
-        self.assertContains(response, 'Answer table')
+        data = response.context["data"][0]
+        self.assertEqual(data["yes"], 1)
+        self.assertEqual(data["no"], 0)
+        self.assertIn("published", data)
+        self.assertEqual(data["agree_ratio"], 100.0)
+        self.assertEqual(data["my_answer"], "Yes")
+        self.assertEqual(response.context["total_users"], 1)
+        self.assertContains(response, "Answer table")
 
     def test_results_view_displays_my_answer_column(self):
         survey = self._create_survey()
         question = self._create_question(survey)
-        Answer.objects.create(question=question, user=self.user, answer='yes')
-        response = self.client.get(reverse('survey:survey_results'))
+        Answer.objects.create(question=question, user=self.user, answer="yes")
+        response = self.client.get(reverse("survey:survey_results"))
         self.assertContains(
             response,
-            '<td>Yes</td>',
+            "<td>Yes</td>",
             html=True,
         )
 
@@ -172,33 +209,31 @@ class SurveyFlowTests(TransactionTestCase):
         questions = self._create_questions(survey, 10)
         for idx, user in enumerate(self.users):
             self.client.logout()
-            self.client.login(username=user.username, password='pass')
-            data = {'question_id': questions[idx].pk, 'answer': 'yes'}
-            self.client.post(reverse('survey:answer_survey'), data)
+            self.client.login(username=user.username, password="pass")
+            data = {"question_id": questions[idx].pk, "answer": "yes"}
+            self.client.post(reverse("survey:answer_survey"), data)
             ans = Answer.objects.get(question=questions[idx], user=user)
-            self.assertEqual(ans.answer, 'yes')
+            self.assertEqual(ans.answer, "yes")
         self.assertEqual(Answer.objects.count(), 3)
 
     def test_cannot_answer_when_paused(self):
         survey = self._create_survey()
         question = self._create_question(survey)
-        survey.state = 'paused'
+        survey.state = "paused"
         survey.save()
 
-        response = self.client.get(reverse('survey:answer_survey'))
-        self.assertRedirects(response, reverse('survey:survey_detail'))
+        response = self.client.get(reverse("survey:answer_survey"))
+        self.assertRedirects(response, reverse("survey:survey_detail"))
 
-        data = {'question_id': question.pk, 'answer': 'yes'}
-        response = self.client.post(reverse('survey:answer_survey'), data)
+        data = {"question_id": question.pk, "answer": "yes"}
+        response = self.client.post(reverse("survey:answer_survey"), data)
         self.assertEqual(Answer.objects.count(), 0)
-        self.assertRedirects(response, reverse('survey:survey_detail'))
+        self.assertRedirects(response, reverse("survey:survey_detail"))
 
     def test_detail_shows_paused_alert(self):
         survey = self._create_survey()
-        survey.state = 'paused'
+        survey.state = "paused"
         survey.save()
 
-        response = self.client.get(reverse('survey:survey_detail'))
-        self.assertContains(response, 'This survey is currently paused.')
-
-
+        response = self.client.get(reverse("survey:survey_detail"))
+        self.assertContains(response, "This survey is currently paused.")

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -1,19 +1,20 @@
 from django.urls import path
 from . import views
 
-app_name = 'survey'
+app_name = "survey"
 
 urlpatterns = [
-    path('', views.survey_detail, name='survey_detail'),
-    path('register/', views.register, name='register'),
-    path('survey/edit/', views.survey_edit, name='survey_edit'),
-    path('survey/answer/', views.answer_survey, name='answer_survey'),
-    path('survey/question/add/', views.question_add, name='question_add'),
-    path('question/<int:pk>/delete/', views.question_delete, name='question_delete'),
-    path('question/<int:pk>/restore/', views.question_restore, name='question_restore'),
-    path('question/<int:pk>/', views.answer_question, name='answer_question'),
-    path('answer/<int:pk>/edit/', views.answer_edit, name='answer_edit'),
-    path('answer/<int:pk>/delete/', views.answer_delete, name='answer_delete'),
-    path('answers/', views.answer_list, name='answer_list'),
-    path('results/', views.survey_results, name='survey_results'),
+    path("", views.survey_detail, name="survey_detail"),
+    path("register/", views.register, name="register"),
+    path("survey/edit/", views.survey_edit, name="survey_edit"),
+    path("survey/answer/", views.answer_survey, name="answer_survey"),
+    path("survey/question/add/", views.question_add, name="question_add"),
+    path("question/<int:pk>/edit/", views.question_edit, name="question_edit"),
+    path("question/<int:pk>/delete/", views.question_delete, name="question_delete"),
+    path("question/<int:pk>/restore/", views.question_restore, name="question_restore"),
+    path("question/<int:pk>/", views.answer_question, name="answer_question"),
+    path("answer/<int:pk>/edit/", views.answer_edit, name="answer_edit"),
+    path("answer/<int:pk>/delete/", views.answer_delete, name="answer_delete"),
+    path("answers/", views.answer_list, name="answer_list"),
+    path("results/", views.survey_results, name="survey_results"),
 ]

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -14,17 +14,17 @@ from .forms import SurveyForm, QuestionForm, AnswerForm
 
 
 def register(request):
-    if request.method == 'POST':
+    if request.method == "POST":
         form = UserCreationForm(request.POST)
         if form.is_valid():
             user = form.save()
             login(request, user)
-            messages.success(request, _('Registration successful'))
-            next_url = request.GET.get('next', '/')
+            messages.success(request, _("Registration successful"))
+            next_url = request.GET.get("next", "/")
             return redirect(next_url)
     else:
         form = UserCreationForm()
-    return render(request, 'registration/register.html', {'form': form})
+    return render(request, "registration/register.html", {"form": form})
 
 
 def survey_detail(request):
@@ -54,100 +54,116 @@ def survey_detail(request):
         answered_ids = user_answers.values_list("question_id", flat=True)
         unanswered_questions_qs = base_qs.exclude(id__in=answered_ids)
     questions = base_qs.annotate(
-        yes_count=Count('answers', filter=Q(answers__answer='yes')),
-        total_answers=Count('answers'),
+        yes_count=Count("answers", filter=Q(answers__answer="yes")),
+        total_answers=Count("answers"),
     )
     unanswered_questions = unanswered_questions_qs.annotate(
-        yes_count=Count('answers', filter=Q(answers__answer='yes')),
-        total_answers=Count('answers'),
+        yes_count=Count("answers", filter=Q(answers__answer="yes")),
+        total_answers=Count("answers"),
     )
 
     questions = questions.annotate(
         agree_ratio=ExpressionWrapper(
-            F('yes_count') * 1.0 / NullIf(F('total_answers'), 0),
+            F("yes_count") * 1.0 / NullIf(F("total_answers"), 0),
             output_field=FloatField(),
         )
     )
     unanswered_questions = unanswered_questions.annotate(
         agree_ratio=ExpressionWrapper(
-            F('yes_count') * 1.0 / NullIf(F('total_answers'), 0),
+            F("yes_count") * 1.0 / NullIf(F("total_answers"), 0),
             output_field=FloatField(),
         )
     )
 
     # Preserve original insertion order without exposing sorting options
-    questions = questions.order_by('pk')
-    unanswered_questions = unanswered_questions.order_by('pk')
+    questions = questions.order_by("pk")
+    unanswered_questions = unanswered_questions.order_by("pk")
 
     can_edit = request.user == survey.creator or request.user.is_superuser
 
-    unanswered_count = unanswered_questions.count() if request.user.is_authenticated else 0
+    unanswered_count = (
+        unanswered_questions.count() if request.user.is_authenticated else 0
+    )
 
-    return render(request, 'survey/survey_detail.html', {
-        'survey': survey,
-        'questions': questions,
-        'can_edit': can_edit,
-        'user_answers': user_answers,
-        'unanswered_count': unanswered_count,
-        'unanswered_questions': unanswered_questions,
-    })
+    return render(
+        request,
+        "survey/survey_detail.html",
+        {
+            "survey": survey,
+            "questions": questions,
+            "can_edit": can_edit,
+            "user_answers": user_answers,
+            "unanswered_count": unanswered_count,
+            "unanswered_questions": unanswered_questions,
+        },
+    )
 
 
 @login_required
 def survey_edit(request):
     survey = Survey.get_main_survey()
     if request.user != survey.creator and not request.user.is_superuser:
-        messages.error(request, _('No permission'))
-        return redirect('survey:survey_detail')
-    if request.method == 'POST':
+        messages.error(request, _("No permission"))
+        return redirect("survey:survey_detail")
+    if request.method == "POST":
         form = SurveyForm(request.POST, instance=survey)
         if form.is_valid():
             form.save()
-            messages.success(request, _('Survey updated'))
-            return redirect('survey:survey_detail')
+            messages.success(request, _("Survey updated"))
+            return redirect("survey:survey_detail")
     else:
         form = SurveyForm(instance=survey)
     active_questions = survey.questions.filter(deleted=False)
     deleted_questions = survey.questions.filter(deleted=True)
-    return render(request, 'survey/survey_form.html', {
-        'form': form,
-        'survey': survey,
-        'is_edit': True,
-        'active_questions': active_questions,
-        'deleted_questions': deleted_questions,
-    })
+    return render(
+        request,
+        "survey/survey_form.html",
+        {
+            "form": form,
+            "survey": survey,
+            "is_edit": True,
+            "active_questions": active_questions,
+            "deleted_questions": deleted_questions,
+        },
+    )
 
 
 @login_required
 def question_add(request):
     survey = Survey.get_main_survey()
-    if survey.state == 'closed':
-        messages.error(request, _('Cannot add questions to a closed survey'))
-        return redirect('survey:survey_detail')
-    if survey.state != 'running' and request.user != survey.creator and not request.user.is_superuser:
-        messages.error(request, _('No permission'))
-        return redirect('survey:survey_detail')
-    if request.method == 'POST':
+    if survey.state == "closed":
+        messages.error(request, _("Cannot add questions to a closed survey"))
+        return redirect("survey:survey_detail")
+    if (
+        survey.state != "running"
+        and request.user != survey.creator
+        and not request.user.is_superuser
+    ):
+        messages.error(request, _("No permission"))
+        return redirect("survey:survey_detail")
+    if request.method == "POST":
         form = QuestionForm(request.POST)
         if form.is_valid():
-            text = form.cleaned_data['text'].strip()
+            text = form.cleaned_data["text"].strip()
             existing = survey.questions.filter(text__iexact=text, deleted=False).first()
             if existing:
-                yes_count = existing.answers.filter(answer='yes').count()
-                no_count = existing.answers.filter(answer='no').count()
+                yes_count = existing.answers.filter(answer="yes").count()
+                no_count = existing.answers.filter(answer="no").count()
                 answer_count = yes_count + no_count
-                yes_label = gettext('Yes')
-                no_label = gettext('No')
+                yes_label = gettext("Yes")
+                no_label = gettext("No")
                 messages.error(
                     request,
-                    _('The question "%(text)s" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question.')
+                    _(
+                        'The question "%(text)s" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question.'
+                    )
                     % {
-                        'text': existing.text,
-                        'count': answer_count,
-                        'yes_label': yes_label,
-                        'yes': yes_count,
-                        'no_label': no_label,
-                        'no': no_count,
+                        "text": existing.text,
+                        "count": answer_count,
+                        "yes_label": yes_label,
+                        "yes": yes_count,
+                        "no_label": no_label,
+                        "no": no_count,
                     },
                 )
             else:
@@ -155,11 +171,13 @@ def question_add(request):
                 question.survey = survey
                 question.creator = request.user
                 question.save()
-                messages.success(request, _('Question added'))
-                return redirect('survey:survey_detail')
+                messages.success(request, _("Question added"))
+                return redirect("survey:survey_detail")
     else:
         form = QuestionForm()
-    return render(request, 'survey/question_form.html', {'form': form, 'survey': survey})
+    return render(
+        request, "survey/question_form.html", {"form": form, "survey": survey}
+    )
 
 
 @login_required
@@ -177,20 +195,20 @@ def question_delete(request, pk):
         or request.user.is_superuser
         or can_creator_delete
     ):
-        messages.error(request, _('No permission'))
-        return redirect('survey:survey_detail')
+        messages.error(request, _("No permission"))
+        return redirect("survey:survey_detail")
 
-    if survey.state == 'closed':
-        messages.error(request, _('Cannot remove questions from a closed survey'))
-        return redirect('survey:survey_detail')
+    if survey.state == "closed":
+        messages.error(request, _("Cannot remove questions from a closed survey"))
+        return redirect("survey:survey_detail")
 
     question.deleted = True
     question.save()
-    messages.success(request, _('Question removed'))
+    messages.success(request, _("Question removed"))
 
     if request.user == survey.creator or request.user.is_superuser:
-        return redirect('survey:survey_edit')
-    return redirect('survey:survey_detail')
+        return redirect("survey:survey_edit")
+    return redirect("survey:survey_detail")
 
 
 @login_required
@@ -198,67 +216,132 @@ def question_restore(request, pk):
     question = get_object_or_404(Question, pk=pk, deleted=True)
     survey = question.survey
     if request.user != survey.creator and not request.user.is_superuser:
-        messages.error(request, _('No permission'))
-        return redirect('survey:survey_edit')
-    if survey.state == 'closed':
-        messages.error(request, _('Cannot restore questions in a closed survey'))
-        return redirect('survey:survey_edit')
+        messages.error(request, _("No permission"))
+        return redirect("survey:survey_edit")
+    if survey.state == "closed":
+        messages.error(request, _("Cannot restore questions in a closed survey"))
+        return redirect("survey:survey_edit")
     question.deleted = False
     question.save()
-    messages.success(request, _('Question restored'))
-    return redirect('survey:survey_edit')
+    messages.success(request, _("Question restored"))
+    return redirect("survey:survey_edit")
+
+
+@login_required
+def question_edit(request, pk):
+    question = get_object_or_404(Question, pk=pk, deleted=False)
+    survey = question.survey
+
+    can_creator_edit = (
+        request.user == question.creator
+        and not question.answers.exclude(user=request.user).exists()
+    )
+
+    if not (
+        request.user == survey.creator or request.user.is_superuser or can_creator_edit
+    ):
+        messages.error(request, _("No permission"))
+        return redirect("survey:survey_detail")
+
+    if survey.state == "closed":
+        messages.error(request, _("Cannot edit questions in a closed survey"))
+        return redirect("survey:survey_detail")
+
+    if request.method == "POST":
+        form = QuestionForm(request.POST, instance=question)
+        if form.is_valid():
+            text = form.cleaned_data["text"].strip()
+            existing = (
+                survey.questions.filter(text__iexact=text, deleted=False)
+                .exclude(pk=question.pk)
+                .first()
+            )
+            if existing:
+                yes_count = existing.answers.filter(answer="yes").count()
+                no_count = existing.answers.filter(answer="no").count()
+                answer_count = yes_count + no_count
+                yes_label = gettext("Yes")
+                no_label = gettext("No")
+                messages.error(
+                    request,
+                    _(
+                        'The question "%(text)s" already exists and has %(count)d answers (%(yes_label)s %(yes)d, %(no_label)s %(no)d). Please rephrase the question.'
+                    )
+                    % {
+                        "text": existing.text,
+                        "count": answer_count,
+                        "yes_label": yes_label,
+                        "yes": yes_count,
+                        "no_label": no_label,
+                        "no": no_count,
+                    },
+                )
+            else:
+                form.save()
+                messages.success(request, _("Question updated"))
+                if request.user == survey.creator or request.user.is_superuser:
+                    return redirect("survey:survey_edit")
+                return redirect("survey:survey_detail")
+    else:
+        form = QuestionForm(instance=question)
+
+    return render(
+        request,
+        "survey/question_form.html",
+        {"form": form, "survey": survey, "is_edit": True},
+    )
 
 
 @login_required
 def answer_survey(request):
     survey = Survey.get_main_survey()
-    if survey.state == 'paused':
-        messages.error(request, _('Survey not active'))
-        return redirect('survey:survey_detail')
+    if survey.state == "paused":
+        messages.error(request, _("Survey not active"))
+        return redirect("survey:survey_detail")
     if not survey.is_active():
-        messages.error(request, _('Survey not active'))
-        return redirect('survey:survey_detail')
-    if request.method == 'POST':
+        messages.error(request, _("Survey not active"))
+        return redirect("survey:survey_detail")
+    if request.method == "POST":
         form = AnswerForm(request.POST)
         question = get_object_or_404(
             Question,
-            pk=form.data.get('question_id'),
+            pk=form.data.get("question_id"),
             survey=survey,
             deleted=False,
         )
         if form.is_valid():
-            answer_value = form.cleaned_data['answer']
+            answer_value = form.cleaned_data["answer"]
             if answer_value:
                 Answer.objects.update_or_create(
                     user=request.user,
                     question=question,
-                    defaults={'answer': answer_value},
+                    defaults={"answer": answer_value},
                 )
-                messages.success(request, _('Answer saved'))
-                return redirect('survey:answer_survey')
+                messages.success(request, _("Answer saved"))
+                return redirect("survey:answer_survey")
             else:
-                next_url = (
-                    f"{reverse('survey:answer_survey')}?skip={question.pk}"
-                )
+                next_url = f"{reverse('survey:answer_survey')}?skip={question.pk}"
                 return redirect(next_url)
     else:
         answered_questions = Answer.objects.filter(
             user=request.user,
             question__survey=survey,
-        ).values_list('question_id', flat=True)
-        remaining = survey.questions.filter(deleted=False).exclude(id__in=answered_questions)
-        skip_id = request.GET.get('skip')
+        ).values_list("question_id", flat=True)
+        remaining = survey.questions.filter(deleted=False).exclude(
+            id__in=answered_questions
+        )
+        skip_id = request.GET.get("skip")
         if skip_id:
             remaining = remaining.exclude(id=skip_id)
         question = random.choice(list(remaining)) if remaining else None
         if not question:
-            messages.info(request, _('No more questions'))
-            return redirect('survey:survey_detail')
-        form = AnswerForm(initial={'question_id': question.pk})
+            messages.info(request, _("No more questions"))
+            return redirect("survey:survey_detail")
+        form = AnswerForm(initial={"question_id": question.pk})
     return render(
         request,
-        'survey/answer_form.html',
-        {'survey': survey, 'question': question, 'form': form},
+        "survey/answer_form.html",
+        {"survey": survey, "question": question, "form": form},
     )
 
 
@@ -270,12 +353,12 @@ def answer_question(request, pk):
         survey__deleted=False,
     )
     survey = question.survey
-    if survey.state == 'paused':
-        messages.error(request, _('Survey not active'))
-        return redirect('survey:survey_detail')
+    if survey.state == "paused":
+        messages.error(request, _("Survey not active"))
+        return redirect("survey:survey_detail")
     if not survey.is_active():
-        messages.error(request, _('Survey not active'))
-        return redirect('survey:survey_detail')
+        messages.error(request, _("Survey not active"))
+        return redirect("survey:survey_detail")
 
     answer = None
     can_delete_question = False
@@ -291,33 +374,35 @@ def answer_question(request, pk):
         form = None
     else:
         answer = Answer.objects.filter(question=question, user=request.user).first()
-        if request.method == 'POST':
+        if request.method == "POST":
             form = AnswerForm(request.POST, instance=answer)
             if form.is_valid():
-                answer_value = form.cleaned_data['answer']
+                answer_value = form.cleaned_data["answer"]
                 if answer_value:
                     Answer.objects.update_or_create(
                         user=request.user,
                         question=question,
-                        defaults={'answer': answer_value},
+                        defaults={"answer": answer_value},
                     )
-                    messages.success(request, _('Answer saved'))
-                    return redirect('survey:survey_detail')
+                    messages.success(request, _("Answer saved"))
+                    return redirect("survey:survey_detail")
         else:
-            form = AnswerForm(instance=answer, initial={'question_id': question.pk})
+            form = AnswerForm(instance=answer, initial={"question_id": question.pk})
         can_delete_question = (
             request.user == question.creator
             and not question.answers.exclude(user=request.user).exists()
         )
     return render(
         request,
-        'survey/answer_form.html',
+        "survey/answer_form.html",
         {
-            'survey': survey,
-            'question': question,
-            'form': form,
-            'is_edit': answer is not None,
-            'can_delete_question': can_delete_question if request.user.is_authenticated else False,
+            "survey": survey,
+            "question": question,
+            "form": form,
+            "is_edit": answer is not None,
+            "can_delete_question": (
+                can_delete_question if request.user.is_authenticated else False
+            ),
         },
     )
 
@@ -347,17 +432,19 @@ def answer_list(request):
     )
 
     deletable_questions = []
+    editable_questions = []
     for q in questions_qs:
-        can_creator_delete = q.other_answers == 0
-        can_delete = (
+        can_creator_modify = q.other_answers == 0
+        can_modify = (
             request.user == q.survey.creator
             or request.user.is_superuser
-            or can_creator_delete
+            or can_creator_modify
         )
         if q.survey.state == "closed":
-            can_delete = False
-        if can_delete:
+            can_modify = False
+        if can_modify:
             deletable_questions.append(q.pk)
+            editable_questions.append(q.pk)
 
     return render(
         request,
@@ -366,43 +453,58 @@ def answer_list(request):
             "answers": answers,
             "questions": questions_qs,
             "deletable_questions": deletable_questions,
+            "editable_questions": editable_questions,
         },
     )
 
 
 @login_required
 def answer_edit(request, pk):
-    answer = get_object_or_404(Answer, pk=pk, user=request.user, question__survey__deleted=False, question__deleted=False)
+    answer = get_object_or_404(
+        Answer,
+        pk=pk,
+        user=request.user,
+        question__survey__deleted=False,
+        question__deleted=False,
+    )
     survey = answer.question.survey
-    if survey.state != 'running':
-        messages.error(request, _('Answer can only be edited while the survey is running'))
-        return redirect('survey:survey_detail')
-    if request.method == 'POST':
+    if survey.state != "running":
+        messages.error(
+            request, _("Answer can only be edited while the survey is running")
+        )
+        return redirect("survey:survey_detail")
+    if request.method == "POST":
         form = AnswerForm(request.POST, instance=answer)
         if form.is_valid():
             form.save()
-            messages.success(request, _('Answer updated'))
-            return redirect('survey:survey_detail')
+            messages.success(request, _("Answer updated"))
+            return redirect("survey:survey_detail")
     else:
-        form = AnswerForm(instance=answer, initial={'question_id': answer.question_id})
-    return render(request, 'survey/answer_form.html', {
-        'survey': survey,
-        'question': answer.question,
-        'form': form,
-        'is_edit': True,
-    })
+        form = AnswerForm(instance=answer, initial={"question_id": answer.question_id})
+    return render(
+        request,
+        "survey/answer_form.html",
+        {
+            "survey": survey,
+            "question": answer.question,
+            "form": form,
+            "is_edit": True,
+        },
+    )
 
 
 @login_required
 def answer_delete(request, pk):
     answer = get_object_or_404(Answer, pk=pk, user=request.user)
     survey = answer.question.survey
-    if survey.state != 'running':
-        messages.error(request, _('Answer can only be removed while the survey is running'))
-        return redirect('survey:survey_detail')
+    if survey.state != "running":
+        messages.error(
+            request, _("Answer can only be removed while the survey is running")
+        )
+        return redirect("survey:survey_detail")
     answer.delete()
-    messages.success(request, _('Answer removed'))
-    return redirect('survey:survey_detail')
+    messages.success(request, _("Answer removed"))
+    return redirect("survey:survey_detail")
 
 
 def survey_results(request):
@@ -410,10 +512,7 @@ def survey_results(request):
     questions = survey.questions.filter(deleted=False)
     data = []
     total_users = (
-        Answer.objects.filter(question__survey=survey)
-        .values('user')
-        .distinct()
-        .count()
+        Answer.objects.filter(question__survey=survey).values("user").distinct().count()
     )
 
     user_answers = {}
@@ -424,29 +523,33 @@ def survey_results(request):
         }
 
     for q in questions:
-        yes_count = q.answers.filter(answer='yes').count()
-        no_count = q.answers.filter(answer='no').count()
+        yes_count = q.answers.filter(answer="yes").count()
+        no_count = q.answers.filter(answer="no").count()
         total = yes_count + no_count
         agree_ratio = (yes_count * 100.0 / total) if total else 0
         row = {
-            'question': q,
-            'published': q.created_at,
-            'yes': yes_count,
-            'no': no_count,
-            'total': total,
-            'agree_ratio': agree_ratio,
+            "question": q,
+            "published": q.created_at,
+            "yes": yes_count,
+            "no": no_count,
+            "total": total,
+            "agree_ratio": agree_ratio,
         }
         if request.user.is_authenticated:
-            row['my_answer'] = user_answers.get(q.pk)
+            row["my_answer"] = user_answers.get(q.pk)
         data.append(row)
-    yes_label = gettext('Yes')
-    no_label = gettext('No')
-    no_answers_label = gettext('No answers')
-    return render(request, 'survey/results.html', {
-        'survey': survey,
-        'data': data,
-        'total_users': total_users,
-        'yes_label': yes_label,
-        'no_label': no_label,
-        'no_answers_label': no_answers_label,
-    })
+    yes_label = gettext("Yes")
+    no_label = gettext("No")
+    no_answers_label = gettext("No answers")
+    return render(
+        request,
+        "survey/results.html",
+        {
+            "survey": survey,
+            "data": data,
+            "total_users": total_users,
+            "yes_label": yes_label,
+            "no_label": no_label,
+            "no_answers_label": no_answers_label,
+        },
+    )


### PR DESCRIPTION
## Summary
- allow editing questions
- add question_edit URL and view
- support editing rights in user info page
- translate new strings
- expand unit tests for editing questions

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6882f4782650832eac39a4d8f908e2ed