### PR TITLE
Add dynamic question suggestions

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -359,6 +359,10 @@ msgstr "Vastauksen voi poistaa vain, kun kysely on käynnissä"
 msgid "Answer removed"
 msgstr "Vastaus poistettu"
 
+#: templates/survey/question_form.html:17
+msgid "Similar questions"
+msgstr "Samankaltaiset kysymykset"
+
 #~ msgid "Start date"
 #~ msgstr "Aloituspäivä"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -359,6 +359,10 @@ msgstr "Svar kan tas bort endast när enkäten är igång"
 msgid "Answer removed"
 msgstr "Svar borttaget"
 
+#: templates/survey/question_form.html:17
+msgid "Similar questions"
+msgstr "Liknande frågor"
+
 #~ msgid "Start date"
 #~ msgstr "Startdatum"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django==4.2
+sentence-transformers

--- a/static/js/question_suggestions.js
+++ b/static/js/question_suggestions.js
@@ -1,0 +1,39 @@
+function suggestionsSetup(url) {
+    const input = document.getElementById('id_text');
+    const container = document.getElementById('suggestions');
+    if (!input || !container) return;
+    let timer = null;
+    input.addEventListener('input', () => {
+        clearTimeout(timer);
+        const text = input.value.trim();
+        if (!text) {
+            container.innerHTML = '';
+            return;
+        }
+        timer = setTimeout(() => {
+            fetch(url + '?q=' + encodeURIComponent(text))
+                .then(resp => resp.json())
+                .then(data => {
+                    container.innerHTML = '';
+                    if (!data.results || !data.results.length) {
+                        return;
+                    }
+                    const heading = document.createElement('h3');
+                    heading.textContent = container.dataset.heading;
+                    container.appendChild(heading);
+                    const ul = document.createElement('ul');
+                    ul.className = 'list-group';
+                    data.results.forEach(item => {
+                        const li = document.createElement('li');
+                        li.className = 'list-group-item';
+                        li.textContent = item.text;
+                        ul.appendChild(li);
+                    });
+                    container.appendChild(ul);
+                })
+                .catch(() => {
+                    container.innerHTML = '';
+                });
+        }, 300);
+    });
+}

--- a/templates/survey/question_form.html
+++ b/templates/survey/question_form.html
@@ -14,6 +14,14 @@
   <p>{% translate "Add any question related to the survey's topic, but phrase it so it can only be answered 'Yes' or 'No'. You may also add a statement, provided the respondent can similarly answer whether they agree or disagree - yes or no." %}</p>
   <p>{% translate "You can edit or delete the question you added as long as nobody has answered it." %}</p>
   <p><a href="https://fi.wikipedia.org/wiki/Wikiprojekti:Wikikysely_2025/ohjeet" target="_blank">{% translate 'Read more instructions' %}</a></p>
+  <div id="suggestions" class="mt-3" data-heading="{% translate 'Similar questions' %}"></div>
   {% endif %}
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="{% static 'js/question_suggestions.js' %}"></script>
+<script>
+  suggestionsSetup("{% url 'survey:question_similar' %}");
+</script>
 {% endblock %}

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     path("answer/<int:pk>/delete/", views.answer_delete, name="answer_delete"),
     path("answers/", views.answer_list, name="answer_list"),
     path("results/", views.survey_results, name="survey_results"),
+    path("question/similar/", views.question_similar, name="question_similar"),
 ]


### PR DESCRIPTION
## Summary
- add new JS to query similar questions while typing
- display similar questions when adding new ones
- provide API endpoint using sentence-transformers model
- expose endpoint in URLs
- document new dependency
- update translations

## Testing
- `python manage.py test -v 2`
- `pip install -q sentence-transformers` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68830dad39d4832e9c5d137758c95709