### PR TITLE
Add question language detection and minimum word validation

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -363,6 +363,18 @@ msgstr "Vastaus poistettu"
 msgid "Similar questions"
 msgstr "Samankaltaiset kysymykset"
 
+msgid "Detected language: %s"
+msgstr "Tunnistettu kieli: %s"
+
+msgid "The question must contain at least five words."
+msgstr "Kysymyksen on oltava vähintään viiden sanan mittainen."
+
+msgid "Minimum length is %(min)d words."
+msgstr "Vähimmäispituus on %(min)d sanaa."
+
+msgid "Question must contain at least %(min)d words."
+msgstr "Kysymyksen tulee sisältää vähintään %(min)d sanaa."
+
 #~ msgid "Start date"
 #~ msgstr "Aloituspäivä"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -363,6 +363,18 @@ msgstr "Svar borttaget"
 msgid "Similar questions"
 msgstr "Liknande frågor"
 
+msgid "Detected language: %s"
+msgstr "Upptäckt språk: %s"
+
+msgid "The question must contain at least five words."
+msgstr "Frågan måste bestå av minst fem ord."
+
+msgid "Minimum length is %(min)d words."
+msgstr "Minimilängden är %(min)d ord."
+
+msgid "Question must contain at least %(min)d words."
+msgstr "Frågan måste innehålla minst %(min)d ord."
+
 #~ msgid "Start date"
 #~ msgstr "Startdatum"
 

--- a/static/js/language_detect.js
+++ b/static/js/language_detect.js
@@ -1,0 +1,28 @@
+function languageDetectSetup(url) {
+    const input = document.getElementById('id_text');
+    const target = document.getElementById('language-detection');
+    if (!input || !target) return;
+    let timer = null;
+    input.addEventListener('input', () => {
+        clearTimeout(timer);
+        const text = input.value.trim();
+        if (!text) {
+            target.textContent = '';
+            return;
+        }
+        timer = setTimeout(() => {
+            fetch(url + '?q=' + encodeURIComponent(text))
+                .then(resp => resp.json())
+                .then(data => {
+                    if (!data.language) {
+                        target.textContent = '';
+                    } else {
+                        target.textContent = target.dataset.label.replace('%s', data.language);
+                    }
+                })
+                .catch(() => {
+                    target.textContent = '';
+                });
+        }, 300);
+    });
+}

--- a/templates/survey/question_form.html
+++ b/templates/survey/question_form.html
@@ -6,12 +6,14 @@
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
+    <div id="language-detection" class="form-text" data-label="{% translate 'Detected language: %s' %}"></div>
     <button type="submit" class="btn btn-primary me-2">{% translate 'Save' %}</button>
     <a href="{% url 'survey:survey_detail' %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
   </form>
   {% if not is_edit %}
   <hr>
   <p>{% translate "Add any question related to the survey's topic, but phrase it so it can only be answered 'Yes' or 'No'. You may also add a statement, provided the respondent can similarly answer whether they agree or disagree - yes or no." %}</p>
+  <p>{% translate "The question must contain at least five words." %}</p>
   <p>{% translate "You can edit or delete the question you added as long as nobody has answered it." %}</p>
   <p><a href="https://fi.wikipedia.org/wiki/Wikiprojekti:Wikikysely_2025/ohjeet" target="_blank">{% translate 'Read more instructions' %}</a></p>
   <div id="suggestions" class="mt-3" data-heading="{% translate 'Similar questions' %}"></div>
@@ -20,7 +22,9 @@
 
 {% block scripts %}
 <script src="{% static 'js/question_suggestions.js' %}"></script>
+<script src="{% static 'js/language_detect.js' %}"></script>
 <script>
   suggestionsSetup("{% url 'survey:question_similar' %}");
+  languageDetectSetup("{% url 'survey:question_detect_language' %}");
 </script>
 {% endblock %}

--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -2,6 +2,8 @@ from django import forms
 from .models import Survey, Question, Answer
 from django.utils.translation import gettext_lazy as _
 
+MIN_QUESTION_WORDS = 5
+
 
 class BootstrapMixin:
     """Apply basic Bootstrap classes to form fields."""
@@ -23,12 +25,26 @@ class SurveyForm(BootstrapMixin, forms.ModelForm):
 
 
 class QuestionForm(BootstrapMixin, forms.ModelForm):
+
     class Meta:
         model = Question
         fields = ['text']
         labels = {
             'text': _('Text'),
         }
+        help_texts = {
+            'text': _('Minimum length is %(min)d words.') % {'min': MIN_QUESTION_WORDS},
+        }
+
+    def clean_text(self):
+        text = self.cleaned_data['text']
+        word_count = len(text.strip().split())
+        if word_count < MIN_QUESTION_WORDS:
+            raise forms.ValidationError(
+                _('Question must contain at least %(min)d words.')
+                % {'min': MIN_QUESTION_WORDS}
+            )
+        return text
 
 
 class AnswerForm(BootstrapMixin, forms.ModelForm):

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -82,11 +82,11 @@ class SurveyFlowTests(TransactionTestCase):
 
     def test_add_question(self):
         survey = self._create_survey()
-        data = {"text": "What do you think?"}
+        data = {"text": "What do you think about this?"}
         response = self.client.post(reverse("survey:question_add"), data)
         self.assertEqual(survey.questions.filter(deleted=False).count(), 1)
         question = survey.questions.first()
-        self.assertEqual(question.text, "What do you think?")
+        self.assertEqual(question.text, "What do you think about this?")
         self.assertRedirects(response, reverse("survey:survey_detail"))
 
     def test_delete_and_restore_question(self):
@@ -110,13 +110,13 @@ class SurveyFlowTests(TransactionTestCase):
     def test_edit_question(self):
         survey = self._create_survey()
         question = self._create_question(survey)
-        data = {"text": "Updated question?"}
+        data = {"text": "Updated question text for testing?"}
         response = self.client.post(
             reverse("survey:question_edit", kwargs={"pk": question.pk}),
             data,
         )
         question.refresh_from_db()
-        self.assertEqual(question.text, "Updated question?")
+        self.assertEqual(question.text, "Updated question text for testing?")
         self.assertRedirects(response, reverse("survey:survey_edit"))
 
     def test_cannot_edit_question_answered_by_others(self):
@@ -128,7 +128,7 @@ class SurveyFlowTests(TransactionTestCase):
             survey=survey, text="Original?", creator=self.user
         )
         Answer.objects.create(question=question, user=other_user, answer="yes")
-        data = {"text": "Updated?"}
+        data = {"text": "Updated question text for testing?"}
         response = self.client.post(
             reverse("survey:question_edit", kwargs={"pk": question.pk}),
             data,

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -18,4 +18,9 @@ urlpatterns = [
     path("answers/", views.answer_list, name="answer_list"),
     path("results/", views.survey_results, name="survey_results"),
     path("question/similar/", views.question_similar, name="question_similar"),
+    path(
+        "question/detect-language/",
+        views.question_detect_language,
+        name="question_detect_language",
+    ),
 ]

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -12,6 +12,7 @@ from django.db.models.functions import NullIf
 from django.http import JsonResponse
 from functools import lru_cache
 from .models import Survey, Question, Answer
+from django.conf import settings
 from .forms import SurveyForm, QuestionForm, AnswerForm
 
 
@@ -586,3 +587,29 @@ def _get_embedding_model():
     from sentence_transformers import SentenceTransformer
 
     return SentenceTransformer("paraphrase-multilingual-MiniLM-L12-v2")
+
+
+def _simple_detect_language(text: str) -> str:
+    """Very small heuristic language detector for fi, sv and en."""
+    text = text.lower()
+    if not text:
+        return ""
+    if "å" in text:
+        return "sv"
+    finnish_words = [" ja ", " ei ", " että ", " se ", " on "]
+    swedish_words = [" och ", " inte ", " det ", " att ", " är "]
+    fi_score = sum(w in text for w in finnish_words)
+    sv_score = sum(w in text for w in swedish_words)
+    if fi_score > sv_score:
+        return "fi"
+    if sv_score > fi_score:
+        return "sv"
+    return "en"
+
+
+def question_detect_language(request):
+    """Return detected language for given query text."""
+    query = request.GET.get("q", "")
+    code = _simple_detect_language(query)
+    lang_map = dict(settings.LANGUAGES)
+    return JsonResponse({"language": lang_map.get(code, "")})


### PR DESCRIPTION
## Summary
- detect question language on the add question page
- enforce a minimum of five words for questions
- document the minimum length requirement
- update tests for new validation

## Testing
- `python manage.py test -v 0`

------
https://chatgpt.com/codex/tasks/task_e_688317d8d8dc832e98180bfaacbe6e35