### PR TITLE
Switch to fasttext-wheel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django==4.2
 sentence-transformers
-fasttext
+fasttext-wheel

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -612,7 +612,7 @@ def _get_fasttext_model():
     try:
         import fasttext
     except Exception:
-        raise RuntimeError("fasttext is not available")
+        raise RuntimeError("fasttext-wheel is not available")
     return fasttext.load_model(settings.FASTTEXT_MODEL_PATH)
 
 


### PR DESCRIPTION
## Summary
- replace `fasttext` dependency with `fasttext-wheel`
- update runtime error message for missing dependency

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_688346f8e8f0832e95fa5c30d2f31e2d