### PR TITLE
Fix fastText path type

### DIFF
--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -613,7 +613,7 @@ def _get_fasttext_model():
         import fasttext
     except Exception:
         raise RuntimeError("fasttext-wheel is not available")
-    return fasttext.load_model(settings.FASTTEXT_MODEL_PATH)
+    return fasttext.load_model(str(settings.FASTTEXT_MODEL_PATH))
 
 
 def _fasttext_detect_language(text: str) -> str:


### PR DESCRIPTION
## Summary
- ensure `_get_fasttext_model` passes a string path to `fasttext.load_model`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688349f5754c832ebd4aa59f96ee3a55