### PR TITLE
Replace fastText with CLD3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ Guide is for Linux and OS X. With Windows you need to create and activate virtua
    ```bash
    pip install -r requirements.txt
    ```
-   The language detection relies on the fastText model `lid.176.ftz`. Download it
-   from <https://fasttext.cc/docs/en/language-identification.html> and place the
-   file in the project root.
+   Language detection relies on the CLD3 library via `pycld3` and does not
+   require any additional model files.
 4. Apply migrations:
    ```bash
    python manage.py makemigrations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django==4.2
 sentence-transformers
-fasttext-wheel
+pycld3

--- a/wikikysely_project/settings.py
+++ b/wikikysely_project/settings.py
@@ -95,10 +95,6 @@ MESSAGE_TAGS = {
     message_constants.ERROR: 'danger',
 }
 
-# Path to fastText language identification model. The model should be downloaded
-# separately as it is not included in the repository.
-FASTTEXT_MODEL_PATH = BASE_DIR / 'lid.176.ftz'
-
 # Minimum probability for accepting detected language. Lower probabilities are
-# treated as gibberish.
-FASTTEXT_LANG_THRESHOLD = 0.5
+# treated as gibberish when using CLD3.
+CLD3_LANG_THRESHOLD = 0.5


### PR DESCRIPTION
## Summary
- switch language detection to CLD3
- update docs and requirements

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68835174fc60832e99313f8548efab60