### PR TITLE
Fix embedding model initialization

### DIFF
--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -585,8 +585,11 @@ def question_similar(request):
 @lru_cache(maxsize=1)
 def _get_embedding_model():
     from sentence_transformers import SentenceTransformer
-
-    return SentenceTransformer("paraphrase-multilingual-MiniLM-L12-v2")
+    # Avoid PyTorch meta tensor issues by disabling low_cpu_mem_usage.
+    return SentenceTransformer(
+        "paraphrase-multilingual-MiniLM-L12-v2",
+        model_kwargs={"low_cpu_mem_usage": False},
+    )
 
 
 def _simple_detect_language(text: str) -> str:


### PR DESCRIPTION
## Summary
- avoid meta tensor errors by passing `low_cpu_mem_usage=False` when loading the SentenceTransformer model

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688359d3df0c832eb0ba7da2c7f0edd8