### PR TITLE
Update answer page timeline graph

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -190,15 +190,14 @@ const timelineData = {{ timeline_data|safe }};
 const tlCtx = document.getElementById('answerTimelineChart');
 if (tlCtx) {
     new Chart(tlCtx, {
-        type: 'line',
+        type: 'bar',
         data: {
             labels: timelineData.map(d => d.date),
             datasets: [{
                 label: '{{ Answers|escapejs }}',
                 data: timelineData.map(d => d.count),
-                fill: false,
-                borderColor: successColor,
-                tension: 0.1
+                backgroundColor: successColor,
+                borderColor: successColor
             }]
         },
         options: {


### PR DESCRIPTION
## Summary
- switch the answer timeline from a line chart to a bar chart

## Testing
- `python manage.py test --verbosity 2`


------
https://chatgpt.com/codex/tasks/task_e_6883886a5a08832e8d557ceabaf9ebde