### PR TITLE
Adjust chart colors and update Finnish translation

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -148,7 +148,7 @@ msgstr "Piirakkadiagrammi"
 
 #: templates/survey/results.html:13
 msgid "Bar chart"
-msgstr "Pylväsdiagrammi"
+msgstr "Palkkidiagrammi"
 
 #: templates/survey/results.html:53
 msgid "Total respondents"

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -161,6 +161,7 @@ const successColor = getComputedStyle(document.documentElement).getPropertyValue
 const dangerColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-danger').trim() || 'red';
 const placeholderColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary-bg').trim() ||
     getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary').trim() || 'gray';
+const primaryColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-primary').trim() || 'blue';
 const yesCount = {{ question_stats.yes|default:0 }};
 const noCount = {{ question_stats.no|default:0 }};
 const totalCount = {{ question_stats.total|default:0 }};
@@ -196,8 +197,8 @@ if (tlCtx) {
             datasets: [{
                 label: '{{ Answers|escapejs }}',
                 data: timelineData.map(d => d.count),
-                backgroundColor: successColor,
-                borderColor: successColor
+                backgroundColor: primaryColor,
+                borderColor: primaryColor
             }]
         },
         options: {


### PR DESCRIPTION
## Summary
- update timeline chart to use a neutral colour instead of the yes/no colours
- change Finnish translation for "Bar chart" to "Palkkidiagrammi"

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688389a9e448832ebbfdc3e61df83ffa