### PR TITLE
Add chart captions

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -363,6 +363,14 @@ msgstr "Vastaus poistettu"
 msgid "Answer details"
 msgstr "Vastaustiedot"
 
+#: templates/survey/answer_form.html:60
+msgid "Answer distribution"
+msgstr "Vastausjakauma"
+
+#: templates/survey/answer_form.html:61
+msgid "Answers over time"
+msgstr "Vastausten määrä ajan kuluessa"
+
 #~ msgid "Start date"
 #~ msgstr "Aloituspäivä"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -363,6 +363,14 @@ msgstr "Svar borttaget"
 msgid "Answer details"
 msgstr "Svarsinformation"
 
+#: templates/survey/answer_form.html:60
+msgid "Answer distribution"
+msgstr "Svarsfördelning"
+
+#: templates/survey/answer_form.html:61
+msgid "Answers over time"
+msgstr "Antal svar över tid"
+
 #~ msgid "Start date"
 #~ msgstr "Startdatum"
 

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -57,8 +57,14 @@
     </tbody>
   </table>
   <div class="row mb-4">
-    <div class="col-md-6"><canvas id="answerPieChart"></canvas></div>
-    <div class="col-md-6"><canvas id="answerTimelineChart"></canvas></div>
+    <div class="col-md-6 text-center">
+      <canvas id="answerPieChart"></canvas>
+      <p class="mt-2">{% translate 'Answer distribution' %}</p>
+    </div>
+    <div class="col-md-6 text-center">
+      <canvas id="answerTimelineChart"></canvas>
+      <p class="mt-2">{% translate 'Answers over time' %}</p>
+    </div>
   </div>
 {% endif %}
   <h2 class="mt-4">{% translate 'My answers' %}</h2>


### PR DESCRIPTION
## Summary
- describe chart purpose for pie and bar charts
- localize new captions in Finnish and Swedish translations

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68838bf9c898832ebece81b7bcdd125e