### PR TITLE
Add login info box on results

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -4,6 +4,14 @@
 {% block content %}
 <h1>{% translate 'Results' %}</h1>
 <p>{{ survey.description }}</p>
+{% if not request.user.is_authenticated and data %}
+  {% if request.GET.login_required %}
+    <p class="alert alert-info">
+      {% translate 'You must be logged in to answer questions' %}.
+      <a href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a>
+    </p>
+  {% endif %}
+{% endif %}
 {% if request.user.is_authenticated %}
   {% if data and survey.state == 'running' %}
     <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary mb-3">{% translate 'Answer survey' %}</a>


### PR DESCRIPTION
## Summary
- show login required info message on results page

## Testing
- `python3 manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688394189ff8832eab70464e9226bdbd