### PR TITLE
Implement Vue.js updates and REST API for survey lists

### DIFF
--- a/static/js/survey_detail.js
+++ b/static/js/survey_detail.js
@@ -1,0 +1,69 @@
+const getCookie = (name) => {
+  let cookieValue = null;
+  if (document.cookie && document.cookie !== '') {
+    const cookies = document.cookie.split(';');
+    for (let cookie of cookies) {
+      cookie = cookie.trim();
+      if (cookie.substring(0, name.length + 1) === (name + '=')) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const csrfToken = getCookie('csrftoken');
+  const app = Vue.createApp({
+    data() {
+      return {
+        unanswered: [],
+        answers: [],
+        yesLabel: window.surveyYesLabel || 'Yes',
+        noLabel: window.surveyNoLabel || 'No'
+      };
+    },
+    methods: {
+      fetchData() {
+        fetch('/api/unanswered/')
+          .then(r => r.json())
+          .then(data => { this.unanswered = data.items; });
+        fetch('/api/my_answers/')
+          .then(r => r.json())
+          .then(data => { this.answers = data.items; });
+      },
+      saveAnswer(item, val) {
+        const formData = new FormData();
+        formData.append('question_id', item.question_id);
+        formData.append('answer', val);
+        fetch('/api/answer/save/', {
+          method: 'POST',
+          headers: {'X-CSRFToken': csrfToken},
+          body: formData
+        }).then(() => this.fetchData());
+      },
+      deleteQuestion(item) {
+        const formData = new FormData();
+        fetch(`/api/question/${item.id}/delete/`, {
+          method: 'POST',
+          headers: {'X-CSRFToken': csrfToken},
+          body: formData
+        }).then(() => this.fetchData());
+      },
+      deleteAnswer(item) {
+        const formData = new FormData();
+        fetch(`/api/answer/${item.answer_id}/delete/`, {
+          method: 'POST',
+          headers: {'X-CSRFToken': csrfToken},
+          body: formData
+        }).then(() => this.fetchData());
+      }
+    },
+    mounted() {
+      this.fetchData();
+    }
+  });
+  const vm = app.mount('#survey-app');
+});
+

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n static %}
 {% block title %}{{ survey.title }}{% endblock %}
 {% block content %}
 {% if survey.state == 'paused' %}
@@ -33,82 +33,73 @@
         <a href="?login_required=1" class="btn btn-primary">{% translate 'Answer survey' %}</a>
     {% endif %}
 {% endif %}
-    {% if unanswered_questions %}
+<div id="survey-app">
+    <div v-if="unanswered.length">
         <h2 class="mt-3">{% translate 'Unanswered questions' %}</h2>
-      <table class="table mb-3 survey-detail-table">
-        <thead>
-      <tr>
-        <th>{% translate 'Published' %}</th>
-        <th>{% translate 'Title' %}</th>
-        <th>{% translate 'Answers' %}</th>
-        <th>{% translate 'Agree' %}</th>
-        <th></th>
-      </tr>
-      </thead>
-      <tbody>
-      {% for q in unanswered_questions %}
-        <tr>
-        <td>{{ q.created_at | date:"Y-m-d" }}</td>
-{% if request.user.is_authenticated %}
-        <td><a href="{% url 'survey:answer_question' q.pk %}">{{ q.text }}</a></td>
-{% else %}
-        <td>{{ q.text }}</td>
-{% endif %}
-        <td>{{ q.total_answers }}</td>
-        <td>{% widthratio q.yes_count q.total_answers 100 %}%</td>
-        <td class="text-end">
-          {% if request.user.is_authenticated and request.user == q.creator and q.total_answers == 0 and survey.state != 'closed' %}
-          <a href="{% url 'survey:question_edit' q.pk %}" class="btn btn-sm btn-warning me-2">{% translate 'Edit' %}</a>
-          <a href="{% url 'survey:question_delete' q.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove question' %}</a>
-          {% endif %}
-        </td>
-        </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-    {% endif %}
+        <table class="table mb-3 survey-detail-table">
+            <thead>
+            <tr>
+                <th>{% translate 'Published' %}</th>
+                <th>{% translate 'Title' %}</th>
+                <th>{% translate 'Answers' %}</th>
+                <th>{% translate 'Agree' %}</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr v-for="q in unanswered" :key="q.id">
+                <td>{{ q.published }}</td>
+                <td>
+                    {% if request.user.is_authenticated %}
+                    <a :href="'/question/' + q.id + '/'">{{ q.text }}</a>
+                    {% else %}
+                    {{ q.text }}
+                    {% endif %}
+                </td>
+                <td>{{ q.total_answers }}</td>
+                <td>{{ q.agree_ratio }}%</td>
+                <td class="text-end">
+                    <button v-if="q.can_delete" @click="deleteQuestion(q)" class="btn btn-sm btn-danger">{% translate 'Remove question' %}</button>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
 
-{% if user_answers %}
-<h2 class="mt-4">{% translate 'My answers' %}</h2>
-<table class="table mb-3 survey-detail-table">
-  <thead>
-  <tr>
-    <th>{% translate 'Published' %}</th>
-    <th>{% translate 'Title' %}</th>
-    <th>{% translate 'Answers' %}</th>
-    <th>{% translate 'Agree' %}</th>
-    <th></th>
-  </tr>
-  </thead>
-  <tbody>
-  {% for a in user_answers %}
-    <tr>
-      <td>{{ a.question.created_at|date:"Y-m-d" }}</td>
-      <td>
-        <a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a>
-      </td>
-      <td>{{ a.total_answers }}</td>
-      <td>{% widthratio a.yes_count a.total_answers 100 %}%</td>
-      <td class="text-end">
-        {% if a.question.survey.state == 'running' %}
-        <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline">
-          {% csrf_token %}
-          <input type="hidden" name="question_id" value="{{ a.question.pk }}">
-          <div class="btn-group" role="group" aria-label="{% translate 'Answer' %}">
-            <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-yes" value="yes" onchange="this.form.submit()"{% if a.answer == 'yes' %} checked{% endif %}>
-            <label class="btn btn-sm btn-outline-success" for="answer-{{ a.pk }}-yes">{% translate 'Yes' %}</label>
-            <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-no" value="no" onchange="this.form.submit()"{% if a.answer == 'no' %} checked{% endif %}>
-            <label class="btn btn-sm btn-outline-danger" for="answer-{{ a.pk }}-no">{% translate 'No' %}</label>
-          </div>
-        </form>
-        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ms-2">{% translate 'Remove answer' %}</a>
-        {% endif %}
-      </td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
-{% endif %}
+    <div v-if="answers.length">
+        <h2 class="mt-4">{% translate 'My answers' %}</h2>
+        <table class="table mb-3 survey-detail-table">
+            <thead>
+            <tr>
+                <th>{% translate 'Published' %}</th>
+                <th>{% translate 'Title' %}</th>
+                <th>{% translate 'Answers' %}</th>
+                <th>{% translate 'Agree' %}</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr v-for="a in answers" :key="a.answer_id">
+                <td>{{ a.published }}</td>
+                <td><a :href="'/question/' + a.question_id + '/'">{{ a.text }}</a></td>
+                <td>{{ a.total_answers }}</td>
+                <td>{{ a.agree_ratio }}%</td>
+                <td class="text-end">
+                    <div v-if="a.survey_state === 'running'" class="d-inline">
+                        <div class="btn-group" role="group">
+                            <input type="radio" class="btn-check" :id="'answer-' + a.answer_id + '-yes'" value="yes" :checked="a.answer === 'yes'" @change="saveAnswer(a, 'yes')">
+                            <label class="btn btn-sm btn-outline-success" :for="'answer-' + a.answer_id + '-yes'">{{ yesLabel }}</label>
+                            <input type="radio" class="btn-check" :id="'answer-' + a.answer_id + '-no'" value="no" :checked="a.answer === 'no'" @change="saveAnswer(a, 'no')">
+                            <label class="btn btn-sm btn-outline-danger" :for="'answer-' + a.answer_id + '-no'">{{ noLabel }}</label>
+                        </div>
+                        <button @click="deleteAnswer(a)" class="btn btn-sm btn-danger ms-2">{% translate 'Remove answer' %}</button>
+                    </div>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
 {% if can_edit %}
    <a href="{% url 'survey:survey_edit' %}" class="btn btn-warning ms-2">{% translate 'Edit survey' %}</a>
 {% endif %}
@@ -166,4 +157,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 </script>
+<script src="https://cdn.jsdelivr.net/npm/vue@3.4.15/dist/vue.global.prod.js"></script>
+<script>
+window.surveyYesLabel = '{{ yes_label|escapejs }}';
+window.surveyNoLabel = '{{ no_label|escapejs }}';
+</script>
+<script src="{% static 'js/survey_detail.js' %}"></script>
 {% endblock %}

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -17,4 +17,9 @@ urlpatterns = [
     path("answer/<int:pk>/delete/", views.answer_delete, name="answer_delete"),
     path("answers/", views.answer_list, name="answer_list"),
     path("results/", views.survey_results, name="survey_results"),
+    path("api/unanswered/", views.api_unanswered_questions, name="api_unanswered_questions"),
+    path("api/my_answers/", views.api_my_answers, name="api_my_answers"),
+    path("api/answer/save/", views.api_save_answer, name="api_save_answer"),
+    path("api/question/<int:pk>/delete/", views.api_delete_question, name="api_question_delete"),
+    path("api/answer/<int:pk>/delete/", views.api_delete_answer, name="api_answer_delete"),
 ]


### PR DESCRIPTION
## Summary
- add REST API endpoints for unanswered questions and user answers
- implement Vue-based lists for survey detail page
- include new `survey_detail.js` for AJAX interactions
- expose API operations to save and delete answers or questions
- include Vue.js library in survey detail template

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6883a4732530832e9a30acb945decada