### PR TITLE
Update AJAX handling for answer removal

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -5,6 +5,67 @@ document.addEventListener('DOMContentLoaded', () => {
     if (parts.length === 2) return parts.pop().split(';').shift();
   }
 
+  function attachDeleteQuestion(link) {
+    link.addEventListener('click', ev => {
+      ev.preventDefault();
+      fetch(link.href, {
+        method: 'POST',
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRFToken': getCookie('csrftoken') || ''
+        }
+      }).then(resp => resp.ok ? resp.json() : Promise.reject()).then(data => {
+        if (!data || !data.deleted) { window.location.reload(); return; }
+        const row = link.closest('tr');
+        if (row) row.remove();
+      }).catch(() => window.location.reload());
+    });
+  }
+
+  function ensureUnansweredTable(data, afterElem) {
+    let table = document.getElementById('unanswered-table');
+    if (!table) {
+      const header = document.createElement('h2');
+      header.id = 'unanswered-header';
+      header.className = 'mt-3';
+      header.textContent = data.unanswered_label;
+      afterElem.parentNode.insertBefore(header, afterElem);
+
+      table = document.createElement('table');
+      table.id = 'unanswered-table';
+      table.className = 'table mb-3 survey-detail-table';
+      table.innerHTML = `
+        <thead><tr>
+          <th>${data.published_label}</th>
+          <th>${data.title_label}</th>
+          <th>${data.answers_label}</th>
+          <th>${data.agree_label}</th>
+          <th></th>
+        </tr></thead><tbody></tbody>`;
+      header.insertAdjacentElement('afterend', table);
+    }
+    return table;
+  }
+
+  function addUnansweredRow(data, afterElem) {
+    const table = ensureUnansweredTable(data, afterElem);
+    const tbody = table.querySelector('tbody');
+    const tr = document.createElement('tr');
+    const editButtons = data.can_edit
+      ? `<a href="${data.edit_url}" class="btn btn-sm btn-warning me-2">${data.edit_label}</a>` +
+        `<a href="${data.delete_url}" class="btn btn-sm btn-danger ajax-delete-question">${data.remove_label}</a>`
+      : '';
+    tr.innerHTML = `
+      <td>${data.question_published}</td>
+      <td><a href="${data.question_url}">${data.question_text}</a></td>
+      <td class="total-answers">${data.total}</td>
+      <td class="agree-ratio">${data.agree_ratio}%</td>
+      <td class="text-end">${editButtons}</td>`;
+    tbody.appendChild(tr);
+    const delLink = tr.querySelector('a.ajax-delete-question');
+    if (delLink) attachDeleteQuestion(delLink);
+  }
+
   document.querySelectorAll('form.ajax-answer-form').forEach(form => {
     form.addEventListener('change', event => {
       if (event.target.name !== 'answer') return;
@@ -29,7 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  document.querySelectorAll('a.ajax-delete-answer').forEach(link => {
+  function attachDeleteAnswer(link) {
     link.addEventListener('click', ev => {
       ev.preventDefault();
       fetch(link.href, {
@@ -41,25 +102,13 @@ document.addEventListener('DOMContentLoaded', () => {
       }).then(resp => resp.ok ? resp.json() : Promise.reject()).then(data => {
         if (!data || !data.deleted) { window.location.reload(); return; }
         const row = link.closest('tr');
+        const tableElem = row ? row.closest('table') : document.getElementById('unanswered-table');
         if (row) row.remove();
+        addUnansweredRow(data, tableElem || document.body);
       }).catch(() => window.location.reload());
     });
-  });
+  }
 
-  document.querySelectorAll('a.ajax-delete-question').forEach(link => {
-    link.addEventListener('click', ev => {
-      ev.preventDefault();
-      fetch(link.href, {
-        method: 'POST',
-        headers: {
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-CSRFToken': getCookie('csrftoken') || ''
-        }
-      }).then(resp => resp.ok ? resp.json() : Promise.reject()).then(data => {
-        if (!data || !data.deleted) { window.location.reload(); return; }
-        const row = link.closest('tr');
-        if (row) row.remove();
-      }).catch(() => window.location.reload());
-    });
-  });
+  document.querySelectorAll('a.ajax-delete-answer').forEach(attachDeleteAnswer);
+  document.querySelectorAll('a.ajax-delete-question').forEach(attachDeleteQuestion);
 });

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -34,8 +34,8 @@
     {% endif %}
 {% endif %}
     {% if unanswered_questions %}
-        <h2 class="mt-3">{% translate 'Unanswered questions' %}</h2>
-      <table class="table mb-3 survey-detail-table">
+        <h2 id="unanswered-header" class="mt-3">{% translate 'Unanswered questions' %}</h2>
+      <table id="unanswered-table" class="table mb-3 survey-detail-table">
         <thead>
       <tr>
         <th>{% translate 'Published' %}</th>

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -636,12 +636,33 @@ def answer_delete(request, pk):
         yes_count = question.answers.filter(answer="yes").count()
         total = question.answers.count()
         ratio = int(yes_count * 100 / total) if total else 0
+
+        can_edit = (
+            request.user == question.creator
+            and total == 0
+            and survey.state != "closed"
+        )
+
         return JsonResponse(
             {
                 "deleted": True,
                 "yes_count": yes_count,
                 "total": total,
                 "agree_ratio": ratio,
+                "question_id": question.pk,
+                "question_text": question.text,
+                "question_published": question.created_at.strftime("%Y-%m-%d"),
+                "question_url": reverse("survey:answer_question", args=[question.pk]),
+                "can_edit": can_edit,
+                "edit_url": reverse("survey:question_edit", args=[question.pk]) if can_edit else "",
+                "delete_url": reverse("survey:question_delete", args=[question.pk]) if can_edit else "",
+                "edit_label": gettext("Edit"),
+                "remove_label": gettext("Remove question"),
+                "unanswered_label": gettext("Unanswered questions"),
+                "published_label": gettext("Published"),
+                "title_label": gettext("Title"),
+                "answers_label": gettext("Answers"),
+                "agree_label": gettext("Agree"),
             }
         )
     return redirect("survey:survey_detail")


### PR DESCRIPTION
## Summary
- return question info when deleting an answer via AJAX
- insert removed question back to unanswered list dynamically
- give the unanswered questions table stable ids

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6883e6545130832e8ce88b835a3d7a36