### PR TITLE
Support return to previous page when editing answers

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -9,6 +9,9 @@
 {% if request.user.is_authenticated %}
 <form method="post" action="{% url 'survey:answer_question' question.pk %}" class="text-center">
   {% csrf_token %}
+  {% if next %}
+  <input type="hidden" name="next" value="{{ next }}">
+  {% endif %}
   {% if form.non_field_errors %}
     <div class="alert alert-danger">{{ form.non_field_errors }}</div>
   {% endif %}
@@ -26,10 +29,10 @@
     </div>
     {% if is_edit %}
       {% if survey.state == 'running' %}
-      <a href="{% url 'survey:answer_delete' form.instance.pk %}" class="btn btn-danger me-2" data-question-id="{{ question.pk }}">{% translate 'Remove answer' %}</a>
+      <a href="{% url 'survey:answer_delete' form.instance.pk %}?next={{ next|urlencode }}" class="btn btn-danger me-2" data-question-id="{{ question.pk }}">{% translate 'Remove answer' %}</a>
       {% endif %}
       {% if can_delete_question %}
-      <a href="{% url 'survey:question_delete' question.pk %}" class="btn btn-danger">{% translate 'Remove question' %}</a>
+      <a href="{% url 'survey:question_delete' question.pk %}?next={{ next|urlencode }}" class="btn btn-danger">{% translate 'Remove question' %}</a>
       {% endif %}
     {% else %}
       <button type="submit" name="answer" value="" class="btn btn-secondary">{% translate 'Skip' %}</button>

--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -37,7 +37,7 @@
   <tr>
     <td class="bar-chart-question">
     {% if request.user.is_authenticated %}
-      <a href="{% url 'survey:answer_question' row.question.pk %}">{{ row.question.text }}</a>
+      <a href="{% url 'survey:answer_question' row.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ row.question.text }}</a>
     {% else %}
       {{ row.question.text }}
     {% endif %}
@@ -59,7 +59,7 @@
     <canvas></canvas>
     <p class="mt-2">
     {% if request.user.is_authenticated %}
-      <a href="{% url 'survey:answer_question' row.question.pk %}">{{ row.question.text }}</a>
+      <a href="{% url 'survey:answer_question' row.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ row.question.text }}</a>
     {% else %}
       {{ row.question.text }}
     {% endif %}
@@ -90,7 +90,7 @@
   <td>{{ row.published|date:"Y-m-d" }}</td>
   <td>
     {% if request.user.is_authenticated %}
-      <a href="{% url 'survey:answer_question' row.question.pk %}">{{ row.question.text }}</a>
+      <a href="{% url 'survey:answer_question' row.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ row.question.text }}</a>
     {% else %}
       {{ row.question.text }}
     {% endif %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -50,7 +50,7 @@
         <tr>
         <td>{{ q.created_at | date:"Y-m-d" }}</td>
 {% if request.user.is_authenticated %}
-        <td><a href="{% url 'survey:answer_question' q.pk %}">{{ q.text }}</a></td>
+        <td><a href="{% url 'survey:answer_question' q.pk %}?next={{ request.get_full_path|urlencode }}">{{ q.text }}</a></td>
 {% else %}
         <td>{{ q.text }}</td>
 {% endif %}
@@ -85,7 +85,7 @@
     <tr>
       <td>{{ a.question.created_at|date:"Y-m-d" }}</td>
       <td>
-        <a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a>
+        <a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a>
       </td>
       <td class="total-answers">{{ a.total_answers }}</td>
       <td class="agree-ratio">{% widthratio a.yes_count a.total_answers 100 %}%</td>


### PR DESCRIPTION
## Summary
- track origin page when displaying the answer form
- use the saved URL to redirect back after editing or deleting
- include the origin URL in links

## Testing
- `python manage.py test -v 0`


------
https://chatgpt.com/codex/tasks/task_e_68844f7a8120832eb503fd0621da60fa