### PR TITLE
Update answer UI

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -361,7 +361,7 @@ msgstr "Vastaus poistettu"
 
 #: templates/survey/answer_form.html:37
 msgid "Answer details"
-msgstr "Vastaustiedot"
+msgstr "Muiden vastaukset"
 
 #: templates/survey/answer_form.html:60
 msgid "Answer distribution"

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -20,12 +20,10 @@
   {% endfor %}
   <div class="answer-buttons mb-2" role="group" aria-label="{% translate 'Answer' %}">
     <div class="btn-group me-2" role="group">
-      <input type="radio" class="btn-check" name="answer" id="answerYes" onchange="this.form.submit()"
-             value="yes"{% if form.answer.value == 'yes' %} checked{% endif %}>
-      <label class="btn {% if form.answer.value and is_edit %}{% if form.answer.value == 'yes' %}btn-success{% else %}btn-outline-success{% endif %}{% else %}btn-success{% endif %}" for="answerYes">{% translate 'Yes' %}</label>
-      <input type="radio" class="btn-check" name="answer" id="answerNo" onchange="this.form.submit()"
-             value="no"{% if form.answer.value == 'no' %} checked{% endif %}>
-      <label class="btn {% if form.answer.value and is_edit %}{% if form.answer.value == 'no' %}btn-danger{% else %}btn-outline-danger{% endif %}{% else %}btn-danger{% endif %}" for="answerNo">{% translate 'No' %}</label>
+      <button type="submit" name="answer" value="yes"
+              class="btn {% if form.answer.value and is_edit %}{% if form.answer.value == 'yes' %}btn-success{% else %}btn-outline-success{% endif %}{% else %}btn-success{% endif %}">{% translate 'Yes' %}</button>
+      <button type="submit" name="answer" value="no"
+              class="btn {% if form.answer.value and is_edit %}{% if form.answer.value == 'no' %}btn-danger{% else %}btn-outline-danger{% endif %}{% else %}btn-danger{% endif %}">{% translate 'No' %}</button>
     </div>
     {% if is_edit %}
       {% if survey.state == 'running' %}


### PR DESCRIPTION
## Summary
- replace radio buttons for yes/no answers with regular buttons
- adjust Finnish translation for answer details

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688452d341e4832ea925bdfddcc0d534