### PR TITLE
Disable unanswered list update on answer removal

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -22,49 +22,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  function ensureUnansweredTable(data, afterElem) {
-    let table = document.getElementById('unanswered-table');
-    if (!table) {
-      const header = document.createElement('h2');
-      header.id = 'unanswered-header';
-      header.className = 'mt-3';
-      header.textContent = data.unanswered_label;
-      afterElem.parentNode.insertBefore(header, afterElem);
-
-      table = document.createElement('table');
-      table.id = 'unanswered-table';
-      table.className = 'table mb-3 survey-detail-table';
-      table.innerHTML = `
-        <thead><tr>
-          <th>${data.published_label}</th>
-          <th>${data.title_label}</th>
-          <th>${data.answers_label}</th>
-          <th>${data.agree_label}</th>
-          <th></th>
-        </tr></thead><tbody></tbody>`;
-      header.insertAdjacentElement('afterend', table);
-    }
-    return table;
-  }
-
-  function addUnansweredRow(data, afterElem) {
-    const table = ensureUnansweredTable(data, afterElem);
-    const tbody = table.querySelector('tbody');
-    const tr = document.createElement('tr');
-    const editButtons = data.can_edit
-      ? `<a href="${data.edit_url}" class="btn btn-sm btn-warning me-2">${data.edit_label}</a>` +
-        `<a href="${data.delete_url}" class="btn btn-sm btn-danger ajax-delete-question">${data.remove_label}</a>`
-      : '';
-    tr.innerHTML = `
-      <td>${data.question_published}</td>
-      <td><a href="${data.question_url}">${data.question_text}</a></td>
-      <td class="total-answers">${data.total}</td>
-      <td class="agree-ratio">${data.agree_ratio}%</td>
-      <td class="text-end">${editButtons}</td>`;
-    tbody.appendChild(tr);
-    const delLink = tr.querySelector('a.ajax-delete-question');
-    if (delLink) attachDeleteQuestion(delLink);
-  }
 
   document.querySelectorAll('form.ajax-answer-form').forEach(form => {
     form.addEventListener('change', event => {
@@ -114,9 +71,7 @@ document.addEventListener('DOMContentLoaded', () => {
             row = document.querySelector(`tr[data-question-id="${qid}"]`);
           }
         }
-        const tableElem = row ? row.closest('table') : document.getElementById('unanswered-table');
-        if (row) row.remove();
-        addUnansweredRow(data, tableElem || document.body);
+          if (row) row.remove();
       }).catch(() => window.location.reload());
     });
   }


### PR DESCRIPTION
## Summary
- adjust survey detail JS to avoid adding the related question back to "unanswered questions" when deleting an answer

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6884597e8558832ea301313a08619a22