### PR TITLE
Update AJAX answer deletion

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -56,6 +56,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function attachDeleteAnswer(link) {
     link.addEventListener('click', ev => {
       ev.preventDefault();
+      const reloadNeeded = !document.getElementById('unanswered-header');
       fetch(link.href, {
         method: 'POST',
         headers: {
@@ -71,7 +72,10 @@ document.addEventListener('DOMContentLoaded', () => {
             row = document.querySelector(`tr[data-question-id="${qid}"]`);
           }
         }
-          if (row) row.remove();
+        if (row) row.remove();
+        if (reloadNeeded) {
+          window.location.reload();
+        }
       }).catch(() => window.location.reload());
     });
   }


### PR DESCRIPTION
## Summary
- reload the survey details page when removing an answer and no unanswered questions were shown

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68845af54708832e86213a1274786559