### PR TITLE
Fix redirect when editing answer with same-page next parameter

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -179,6 +179,21 @@ class SurveyFlowTests(TransactionTestCase):
             fetch_redirect_response=False,
         )
 
+    def test_redirects_to_next_unanswered_when_next_same_page(self):
+        survey = self._create_survey()
+        questions = self._create_questions(survey, 2)
+        Answer.objects.create(question=questions[0], user=self.user, answer="yes")
+        edit_url = reverse("survey:answer_question", args=[questions[0].pk])
+        response = self.client.post(
+            f"{edit_url}?next={edit_url}",
+            {"question_id": questions[0].pk, "answer": "no"},
+        )
+        self.assertRedirects(
+            response,
+            reverse("survey:answer_survey"),
+            fetch_redirect_response=False,
+        )
+
     def test_results_view(self):
         survey = self._create_survey()
         question = self._create_question(survey)

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -498,7 +498,10 @@ def answer_question(request, pk):
                             }
                         )
                     if answer is not None and next_url:
-                        return redirect(next_url)
+                        from urllib.parse import urlparse
+
+                        if urlparse(next_url).path != request.path:
+                            return redirect(next_url)
                     return redirect("survey:answer_survey")
                 else:
                     skip_url = f"{reverse('survey:answer_survey')}?skip={question.pk}"


### PR DESCRIPTION
## Summary
- ensure editing an answer does not redirect back to the same page when the `next` parameter points there
- add regression test for this case

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68846093808c832eb5096defab58a00c