### PR TITLE
Update unanswered count on AJAX answer deletion

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -75,6 +75,10 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         }
         if (row) row.remove();
+        const navCount = document.getElementById('unanswered-count');
+        if (navCount && typeof data.unanswered_count !== 'undefined') {
+          navCount.textContent = data.unanswered_count;
+        }
         if (!reloadNeeded) {
           const tbody = unansweredTable.tBodies[0];
           if (tbody) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,9 +22,9 @@
       <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
         {% if unanswered_count %}
-        <li class="nav-item"><a class="nav-link{% if request.path == answer_survey_url %} active{% endif %}" href="{{ answer_survey_url }}">{% translate 'Answer survey' %} ({{ unanswered_count }})</a></li>
+        <li class="nav-item"><a class="nav-link{% if request.path == answer_survey_url %} active{% endif %}" href="{{ answer_survey_url }}">{% translate 'Answer survey' %} (<span id="unanswered-count">{{ unanswered_count }}</span>)</a></li>
         {% else %}
-        <li class="nav-item"><span class="nav-link text-secondary">{% translate 'Answer survey' %} (0)</span></li>
+        <li class="nav-item"><span class="nav-link text-secondary">{% translate 'Answer survey' %} (<span id="unanswered-count">0</span>)</span></li>
         {% endif %}
         <li class="nav-item"><a class="nav-link{% if request.path == survey_results_url %} active{% endif %}" href="{{ survey_results_url }}">{% translate 'Results' %}</a></li>
       </ul>

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -669,6 +669,12 @@ def answer_delete(request, pk):
         yes_count = question.answers.filter(answer="yes").count()
         total = question.answers.count()
         ratio = int(yes_count * 100 / total) if total else 0
+        # updated unanswered count after deleting the answer
+        answered_ids = Answer.objects.filter(
+            user=request.user,
+            question__survey=survey,
+        ).values_list("question_id", flat=True)
+        unanswered_count = survey.questions.filter(deleted=False).exclude(id__in=answered_ids).count()
 
         can_edit = (
             request.user == question.creator
@@ -692,6 +698,7 @@ def answer_delete(request, pk):
                 "edit_label": gettext("Edit"),
                 "remove_label": gettext("Remove question"),
                 "unanswered_label": gettext("Unanswered questions"),
+                "unanswered_count": unanswered_count,
                 "published_label": gettext("Published"),
                 "title_label": gettext("Title"),
                 "answers_label": gettext("Answers"),


### PR DESCRIPTION
## Summary
- expose updated unanswered count when deleting an answer via AJAX
- update nav bar count dynamically

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688463f38e94832e8002899f5490dca5