### PR TITLE
Implement consensus ratio

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -70,7 +70,7 @@
         <td>{{ question_stats.yes }}</td>
         <td>{{ question_stats.no }}</td>
         <td>{{ question_stats.total }}</td>
-        <td>{% widthratio question_stats.yes question_stats.total 100 %}%</td>
+        <td>{{ question_stats.agree_ratio|floatformat:1 }}%</td>
       </tr>
     </tbody>
   </table>
@@ -96,7 +96,7 @@
         <td>{{ a.question.created_at|date:"Y-m-d" }}</td>
         <td><a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a></td>
         <td>{{ a.total_answers }}</td>
-        <td>{% widthratio a.yes_count a.total_answers 100 %}%</td>
+        <td>{{ a.agree_ratio|floatformat:1 }}%</td>
         <td class="text-end">
           {% if a.question.survey.state == 'running' %}
           <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline ajax-answer-form">

--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -101,7 +101,7 @@
   <td>{{ row.yes }}</td>
   <td>{{ row.no }}</td>
   <td>{{ row.total }}</td>
-  <td>{% widthratio row.yes row.total 100 %}%</td>
+  <td>{{ row.agree_ratio|floatformat:1 }}%</td>
 </tr>
 {% endfor %}
 </tbody>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -55,7 +55,7 @@
         <td>{{ q.text }}</td>
 {% endif %}
         <td class="total-answers">{{ q.total_answers }}</td>
-        <td class="agree-ratio">{% widthratio q.yes_count q.total_answers 100 %}%</td>
+        <td class="agree-ratio">{{ q.agree_ratio|floatformat:1 }}%</td>
         <td class="text-end">
           {% if request.user.is_authenticated and request.user == q.creator and q.total_answers == 0 and survey.state != 'closed' %}
           <a href="{% url 'survey:question_edit' q.pk %}" class="btn btn-sm btn-warning me-2">{% translate 'Edit' %}</a>
@@ -88,7 +88,7 @@
         <a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a>
       </td>
       <td class="total-answers">{{ a.total_answers }}</td>
-      <td class="agree-ratio">{% widthratio a.yes_count a.total_answers 100 %}%</td>
+      <td class="agree-ratio">{{ a.agree_ratio|floatformat:1 }}%</td>
       <td class="text-end">
         {% if a.question.survey.state == 'running' %}
         <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline ajax-answer-form">


### PR DESCRIPTION
## Summary
- compute consensus as the share of respondents who voted the same
- use Greatest in query annotations
- show consensus percentage in templates
- test that the new consensus ratio works

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688470b3f9b0832e9a578914dd65b30d