### PR TITLE
Add export results as wikitext

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -176,6 +176,26 @@ msgstr "Yhteensä"
 msgid "Agree"
 msgstr "Yksimielisyys"
 
+#: templates/survey/results_wikitext.html:3 templates/survey/results_wikitext.html:5
+msgid "Results as wikitext"
+msgstr "Tulokset wikitekstinä"
+
+#: templates/survey/results.html:16 templates/survey/results.html:21
+msgid "Print wikitext"
+msgstr "Tulosta wikiteksti"
+
+#: templates/survey/results_wikitext.html:8
+msgid "Include my answers"
+msgstr "Sisällytä omat vastaukset"
+
+#: templates/survey/results_wikitext.html:10
+msgid "Update"
+msgstr "Päivitä"
+
+#: templates/survey/results_wikitext.txt:3
+msgid "Bar charts"
+msgstr "Palkkidiagrammit"
+
 #: templates/survey/survey_detail.html:6
 msgid "This survey is currently paused."
 msgstr "Tämä kysely on tauolla."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -176,6 +176,26 @@ msgstr "Totalt"
 msgid "Agree"
 msgstr "Instämmande"
 
+#: templates/survey/results_wikitext.html:3 templates/survey/results_wikitext.html:5
+msgid "Results as wikitext"
+msgstr "Resultat som wikikod"
+
+#: templates/survey/results.html:16 templates/survey/results.html:21
+msgid "Print wikitext"
+msgstr "Skriv ut wikikod"
+
+#: templates/survey/results_wikitext.html:8
+msgid "Include my answers"
+msgstr "Inkludera mina svar"
+
+#: templates/survey/results_wikitext.html:10
+msgid "Update"
+msgstr "Uppdatera"
+
+#: templates/survey/results_wikitext.txt:3
+msgid "Bar charts"
+msgstr "Stapeldiagram"
+
 #: templates/survey/survey_detail.html:6
 msgid "This survey is currently paused."
 msgstr "Den här enkäten är pausad."

--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -12,14 +12,16 @@
 {% endif %}
 <p>{{ survey.description }}</p>
 {% if request.user.is_authenticated %}
-  {% if data and survey.state == 'running' %}
-    <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary mb-3">{% translate 'Answer survey' %}</a>
+    {% if data and survey.state == 'running' %}
+      <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary mb-3 me-2">{% translate 'Answer survey' %}</a>
+      <a href="{% url 'survey:results_wikitext' %}" class="btn btn-secondary mb-3">{% translate 'Print wikitext' %}</a>
+    {% endif %}
+  {% else %}
+    {% if data %}
+      <a href="?login_required=1" class="btn btn-primary mb-3 me-2">{% translate 'Answer survey' %}</a>
+      <a href="{% url 'survey:results_wikitext' %}" class="btn btn-secondary mb-3">{% translate 'Print wikitext' %}</a>
+    {% endif %}
   {% endif %}
-{% else %}
-  {% if data %}
-    <a href="?login_required=1" class="btn btn-primary mb-3">{% translate 'Answer survey' %}</a>
-  {% endif %}
-{% endif %}
 <h1>{% translate 'Results' %}</h1>
 <div class="mb-3">
   <div class="form-check form-check-inline">

--- a/templates/survey/results_wikitext.html
+++ b/templates/survey/results_wikitext.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% translate 'Results as wikitext' %}{% endblock %}
+{% block content %}
+<h1>{% translate 'Results as wikitext' %}</h1>
+<form method="get" class="mb-3">
+{% if request.user.is_authenticated %}
+  <div class="form-check mb-2">
+    <input class="form-check-input" type="checkbox" id="includePersonal" name="include_personal" value="1"{% if include_personal %} checked{% endif %}>
+    <label class="form-check-label" for="includePersonal">{% translate 'Include my answers' %}</label>
+  </div>
+  <button type="submit" class="btn btn-primary">{% translate 'Update' %}</button>
+{% endif %}
+</form>
+<textarea class="form-control" rows="20" readonly>{{ wiki_text }}</textarea>
+{% endblock %}

--- a/templates/survey/results_wikitext.txt
+++ b/templates/survey/results_wikitext.txt
@@ -1,0 +1,22 @@
+== {{ survey.title }} ==
+
+=== {% translate 'Bar charts' %} ===
+{% for row in data %}
+==== {{ row.question.text }} ====
+{% templatetag openvariable %}Graph:Chart|width=400|height=200|type=bar|x=answer|y=count|legend=none|data=
+answer,count
+{{ yes_label }},{{ row.yes }}
+{{ no_label }},{{ row.no }}
+{% templatetag closevariable %}
+{% endfor %}
+
+=== {% translate 'Answer table' %} ===
+{| class="wikitable"
+! {% translate 'Published' %} !! {% translate 'Question' %}{% if include_personal %} !! {% translate 'My answer' %}{% endif %} !! {{ yes_label }} !! {{ no_label }} !! {% translate 'Total' %} !! {% translate 'Agree' %}
+{% for row in data %}
+|-
+| {{ row.published|date:"Y-m-d" }} || {{ row.question.text }}{% if include_personal %} || {{ row.my_answer|default:"" }}{% endif %} || {{ row.yes }} || {{ row.no }} || {{ row.total }} || {{ row.agree_ratio|floatformat:1 }}%
+{% endfor %}
+|}
+
+''{% translate 'Total respondents' %}: {{ total_users }}''

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     path("answer/<int:pk>/delete/", views.answer_delete, name="answer_delete"),
     path("answers/", views.answer_list, name="answer_list"),
     path("results/", views.survey_results, name="survey_results"),
+    path("results/wikitext/", views.survey_results_wikitext, name="results_wikitext"),
 ]


### PR DESCRIPTION
## Summary
- enable exporting results page as wikitext
- show new button on results page
- add view, templates and translations for wikitext output

## Testing
- `python manage.py compilemessages`
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6884773aa7a8832eae83b6cba538c093