### PR TITLE
Fix missing i18n tag

### DIFF
--- a/templates/survey/results_wikitext.txt
+++ b/templates/survey/results_wikitext.txt
@@ -1,3 +1,4 @@
+{% load i18n %}
 == {{ survey.title }} ==
 
 === {% translate 'Bar charts' %} ===


### PR DESCRIPTION
## Summary
- include i18n tag library in wikitext results template

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68847cb26bd8832e97da8ce2c031da5d