### PR TITLE
Update wikitext output for bar charts

### DIFF
--- a/templates/survey/results_wikitext.txt
+++ b/templates/survey/results_wikitext.txt
@@ -1,14 +1,15 @@
 == {{ survey.title }} ==
 
 === {% translate 'Bar charts' %} ===
+{| class="wikitable" style="text-align:center"
+! {% translate 'Question' %} !! {{ yes_label }} !! {{ no_label }}
 {% for row in data %}
-==== {{ row.question.text }} ====
-{% templatetag openvariable %}Graph:Chart|width=400|height=200|type=bar|x=answer|y=count|legend=none|data=
-answer,count
-{{ yes_label }},{{ row.yes }}
-{{ no_label }},{{ row.no }}
-{% templatetag closevariable %}
+|-
+| {{ row.question.text }}
+| style="background-color:#cfc;height:1.25em;width:{% widthratio row.yes total_users 100 %}%" | {{ row.yes }}
+| style="background-color:#fcc;height:1.25em;width:{% widthratio row.no total_users 100 %}%" | {{ row.no }}
 {% endfor %}
+|}
 
 === {% translate 'Answer table' %} ===
 {| class="wikitable"


### PR DESCRIPTION
## Summary
- remove usage of Graph:Chart
- implement bar charts using a wikitext table with styled cells

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68847ee2595c832ebe341ff46c774f93