### PR TITLE
Update wikitext output with timestamp and bar chart tables

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -196,6 +196,10 @@ msgstr "Päivitä"
 msgid "Bar charts"
 msgstr "Palkkidiagrammit"
 
+#: templates/survey/results_wikitext.txt:4
+msgid "Generated on"
+msgstr "Luotu"
+
 #: templates/survey/survey_detail.html:6
 msgid "This survey is currently paused."
 msgstr "Tämä kysely on tauolla."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -196,6 +196,10 @@ msgstr "Uppdatera"
 msgid "Bar charts"
 msgstr "Stapeldiagram"
 
+#: templates/survey/results_wikitext.txt:4
+msgid "Generated on"
+msgstr "Skapad"
+
 #: templates/survey/survey_detail.html:6
 msgid "This survey is currently paused."
 msgstr "Den här enkäten är pausad."

--- a/templates/survey/results_wikitext.txt
+++ b/templates/survey/results_wikitext.txt
@@ -1,16 +1,18 @@
 {% load i18n %}
 == {{ survey.title }} ==
+{{ survey.description }}
+''{% translate 'Generated on' %}: {{ generated_at|date:"Y-m-d H:i" }}''
 
 === {% translate 'Bar charts' %} ===
-{| class="wikitable" style="text-align:center"
-! {% translate 'Question' %} !! {{ yes_label }} !! {{ no_label }}
 {% for row in data %}
+{| class="wikitable" style="text-align:center;margin-bottom:0.5em"
+|+ {{ row.question.text }}
+! {{ yes_label }} !! {{ no_label }}
 |-
-| {{ row.question.text }}
 | style="background-color:#cfc;height:1.25em;width:{% widthratio row.yes total_users 100 %}%" | {{ row.yes }}
 | style="background-color:#fcc;height:1.25em;width:{% widthratio row.no total_users 100 %}%" | {{ row.no }}
-{% endfor %}
 |}
+{% endfor %}
 
 === {% translate 'Answer table' %} ===
 {| class="wikitable"

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -12,6 +12,7 @@ from django.db.models import Count, Q, F, FloatField, ExpressionWrapper, Max
 from django.db.models.functions import NullIf, TruncDate, Greatest
 from django.http import JsonResponse
 from datetime import timedelta
+from django.utils import timezone
 import json
 from .models import Survey, Question, Answer
 from .forms import SurveyForm, QuestionForm, AnswerForm
@@ -813,6 +814,8 @@ def survey_results_wikitext(request):
     yes_label = gettext("Yes")
     no_label = gettext("No")
 
+    generated_at = timezone.localtime()
+
     wiki_text = render_to_string(
         "survey/results_wikitext.txt",
         {
@@ -822,6 +825,7 @@ def survey_results_wikitext(request):
             "yes_label": yes_label,
             "no_label": no_label,
             "include_personal": include_personal,
+            "generated_at": generated_at,
         },
     )
 


### PR DESCRIPTION
## Summary
- include survey description and creation timestamp in wikitext output
- display bar charts as separate tables per question
- expose timestamp in survey_results_wikitext view
- add translations for "Generated on" in Finnish and Swedish

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6884848dd6e4832e8331a28b5b1d6aa0