### PR TITLE
Change Finnish label for print wikitext button

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -182,7 +182,7 @@ msgstr "Tulokset wikitekstinä"
 
 #: templates/survey/results.html:16 templates/survey/results.html:21
 msgid "Print wikitext"
-msgstr "Tulosta wikiteksti"
+msgstr "Tulosta wikitekstinä"
 
 #: templates/survey/results_wikitext.html:8
 msgid "Include my answers"


### PR DESCRIPTION
## Summary
- update Finnish translation for the "Print wikitext" button on the results page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688497d72024832eb1101511c1a34081