### PR TITLE
Add JSON export alongside wikitext

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -180,6 +180,10 @@ msgstr "Yksimielisyys"
 msgid "Results as wikitext"
 msgstr "Tulokset wikitekstinä"
 
+#: templates/survey/results_wikitext.html:16
+msgid "Results as JSON"
+msgstr "Tulokset JSON-muodossa"
+
 #: templates/survey/results.html:16 templates/survey/results.html:21
 msgid "Print wikitext"
 msgstr "Tulosta wikitekstinä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -180,6 +180,10 @@ msgstr "Instämmande"
 msgid "Results as wikitext"
 msgstr "Resultat som wikikod"
 
+#: templates/survey/results_wikitext.html:16
+msgid "Results as JSON"
+msgstr "Resultat som JSON"
+
 #: templates/survey/results.html:16 templates/survey/results.html:21
 msgid "Print wikitext"
 msgstr "Skriv ut wikikod"

--- a/templates/survey/results_wikitext.html
+++ b/templates/survey/results_wikitext.html
@@ -12,5 +12,7 @@
   <button type="submit" class="btn btn-primary">{% translate 'Update' %}</button>
 {% endif %}
 </form>
-<textarea class="form-control" rows="20" readonly>{{ wiki_text }}</textarea>
+<textarea class="form-control mb-3" rows="20" readonly>{{ wiki_text }}</textarea>
+<h2>{% translate 'Results as JSON' %}</h2>
+<textarea class="form-control" rows="20" readonly>{{ json_text }}</textarea>
 {% endblock %}

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -2,6 +2,7 @@ from django.test import TransactionTestCase
 from django.urls import reverse
 from django.utils.translation import activate
 from django.contrib.auth import get_user_model
+import json
 
 from ..models import Survey, Question, Answer
 
@@ -238,6 +239,17 @@ class SurveyFlowTests(TransactionTestCase):
             "<td>Yes</td>",
             html=True,
         )
+
+    def test_results_wikitext_contains_json(self):
+        survey = self._create_survey()
+        question = self._create_question(survey)
+        Answer.objects.create(question=question, user=self.user, answer="yes")
+        response = self.client.get(reverse("survey:results_wikitext"))
+        self.assertEqual(response.status_code, 200)
+        json_text = response.context["json_text"]
+        data = json.loads(json_text)
+        self.assertEqual(data["survey"]["title"], survey.title)
+        self.assertEqual(len(data["data"]), 1)
 
     def test_answer_saved_to_correct_question_and_user(self):
         survey = self._create_survey()

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -855,12 +855,35 @@ def survey_results_wikitext(request):
         },
     )
 
+    json_data = {
+        "survey": {"title": survey.title, "description": survey.description},
+        "generated_at": generated_at.isoformat(),
+        "include_personal": include_personal,
+        "total_users": total_users,
+        "full_users": full_users,
+        "data": [
+            {
+                **{
+                    k: (v.text if k == "question" else v)
+                    for k, v in row.items()
+                    if k != "question"
+                },
+                "question": row["question"].text,
+                **({"my_answer": row["my_answer"]} if "my_answer" in row else {}),
+                "published": row["published"].isoformat(),
+            }
+            for row in data
+        ],
+    }
+    json_text = json.dumps(json_data, indent=2, ensure_ascii=False)
+
     return render(
         request,
         "survey/results_wikitext.html",
         {
             "survey": survey,
             "wiki_text": wiki_text,
+            "json_text": json_text,
             "include_personal": include_personal,
         },
     )


### PR DESCRIPTION
## Summary
- include JSON output in wikitext results view
- show JSON in the results wikitext template
- localise new "Results as JSON" string
- test that JSON is generated correctly

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68867c205e1c832e9af0cf30d7560281