### PR TITLE
Add Wikimedia OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ description, manage questions and change the state (running, paused or closed).
 ## Requirements
 - Python 3.11
 - Django 4.x
+- social-auth-app-django
 
 ## Setup
 Guide is for Linux and OS X. With Windows you need to create and activate virtualenv differently
@@ -23,7 +24,12 @@ Guide is for Linux and OS X. With Windows you need to create and activate virtua
    ```   
 3. Install dependencies (requires internet access):
    ```bash
-   pip install django==4.2
+   pip install -r requirements.txt
+   ```
+   Create a Wikimedia OAuth consumer and set the following environment variables before running the server:
+   ```bash
+   export SOCIAL_AUTH_MEDIAWIKI_KEY=<consumer key>
+   export SOCIAL_AUTH_MEDIAWIKI_SECRET=<consumer secret>
    ```
 4. Apply migrations:
    ```bash

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -30,6 +30,10 @@ msgstr "Kirjaudu ulos"
 msgid "Login"
 msgstr "Kirjaudu sisään"
 
+#: templates/base.html:49 templates/registration/login.html:13
+msgid "Login with Wikimedia"
+msgstr "Kirjaudu Wikimedian tunnuksilla"
+
 #: templates/base.html:50 templates/registration/register.html:3
 #: templates/registration/register.html:5
 #: templates/registration/register.html:10

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -30,6 +30,10 @@ msgstr "Logga ut"
 msgid "Login"
 msgstr "Logga in"
 
+#: templates/base.html:49 templates/registration/login.html:13
+msgid "Login with Wikimedia"
+msgstr "Logga in med Wikimedia"
+
 #: templates/base.html:50 templates/registration/register.html:3
 #: templates/registration/register.html:5
 #: templates/registration/register.html:10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django==4.2
+social-auth-app-django==5.4.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,6 +47,7 @@
         <li class="nav-item"><a class="nav-link ms-3" href="{% url 'logout' %}?next={{ request.path }}">{% translate 'Logout' %}</a></li>
       {% else %}
         <li class="nav-item"><a class="nav-link ms-3" href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a></li>
+        <li class="nav-item"><a class="nav-link ms-3" href="{% url 'social:begin' 'mediawiki' %}?next={{ request.path }}">{% translate 'Login with Wikimedia' %}</a></li>
         <li class="nav-item"><a class="nav-link ms-3" href="{% url 'survey:register' %}?next={{ request.path }}">{% translate 'Register' %}</a></li>
       {% endif %}
       </ul>

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -9,4 +9,7 @@
   <input type="hidden" name="next" value="{{ next }}" />
   <button type="submit" class="btn btn-primary">{% translate 'Login' %}</button>
 </form>
+<p class="mt-3">
+  <a class="btn btn-secondary" href="{% url 'social:begin' 'mediawiki' %}?next={{ next }}">{% translate 'Login with Wikimedia' %}</a>
+</p>
 {% endblock %}

--- a/wikikysely_project/settings.py
+++ b/wikikysely_project/settings.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -15,6 +16,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'social_django',
     'wikikysely_project.survey',
 ]
 
@@ -25,6 +27,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'social_django.middleware.SocialAuthExceptionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -43,6 +46,8 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'wikikysely_project.survey.context_processors.unanswered_count',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
         },
     },
@@ -92,3 +97,13 @@ from django.contrib.messages import constants as message_constants
 MESSAGE_TAGS = {
     message_constants.ERROR: 'danger',
 }
+
+# Social-auth settings for Wikimedia OAuth1 login
+AUTHENTICATION_BACKENDS = [
+    'social_core.backends.mediawiki.MediaWikiOAuth',
+    'django.contrib.auth.backends.ModelBackend',
+]
+
+SOCIAL_AUTH_MEDIAWIKI_URL = 'https://meta.wikimedia.org'
+SOCIAL_AUTH_MEDIAWIKI_KEY = os.environ.get('SOCIAL_AUTH_MEDIAWIKI_KEY', '')
+SOCIAL_AUTH_MEDIAWIKI_SECRET = os.environ.get('SOCIAL_AUTH_MEDIAWIKI_SECRET', '')

--- a/wikikysely_project/urls.py
+++ b/wikikysely_project/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
 
 urlpatterns += i18n_patterns(
     path('admin/', admin.site.urls),
+    path('oauth/', include('social_django.urls', namespace='social')),
     path('accounts/', include('django.contrib.auth.urls')),
     path('', include('wikikysely_project.survey.urls')),
 )


### PR DESCRIPTION
## Summary
- enable login using Wikimedia OAuth via social-auth-app-django
- add login button in templates
- document OAuth setup in README
- add social-auth-app-django to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement social-auth-app-django==5.4.0)*
- `python manage.py compilemessages` *(fails: ModuleNotFoundError: No module named 'social_django')*
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'social_django')*

------
https://chatgpt.com/codex/tasks/task_e_68872747002c832eac14c2a38a28c366