### PR TITLE
Show default sort arrow

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -163,6 +163,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 sortTable(i, current);
             });
         });
+
+        // Indicate default sorting by the Published column
+        directions[0] = 'desc';
+        headers[0].textContent = baseTexts[0] + ' \u2193';
+        sortTable(0, 'desc');
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- show an arrow next to Published headers on the survey detail page to indicate
  default sorting by publication date

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6887a6d01ebc832e887b70251efb30b1