### PR TITLE
Show default sorting indicator

### DIFF
--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -229,6 +229,11 @@ document.addEventListener('DOMContentLoaded', () => {
             sortTable(i, current);
         });
     });
+
+    // Indicate default sorting by the Published column
+    directions[0] = 'desc';
+    headers[0].textContent = baseTexts[0] + ' \u2193';
+    sortTable(0, 'desc');
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show an arrow on the results table on initial page load

## Testing
- `django_secret=mysecret python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6887aa115cd8832eb4b8583fcd724cd3