### PR TITLE
Rename results page to Answers

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -17,8 +17,9 @@ msgstr "Vastaa"
 
 #: templates/base.html:29 templates/survey/results.html:3
 #: templates/survey/results.html:5 templates/survey/survey_detail.html:26
-msgid "Results"
-msgstr "Tulokset"
+#: templates/survey/survey_detail.html:43 templates/survey/survey_detail.html:78
+msgid "Answers"
+msgstr "Vastaukset"
 
 #: templates/base.html:47
 msgid "Logout"
@@ -229,11 +230,6 @@ msgstr "Vastaamattomat kysymykset"
 #: wikikysely_project/survey/models.py:12
 msgid "Title"
 msgstr "Otsikko"
-
-#: templates/survey/survey_detail.html:43
-#: templates/survey/survey_detail.html:78
-msgid "Answers"
-msgstr "Vastaukset"
 
 # UI strings
 #: templates/survey/survey_detail.html:113 templates/survey/survey_form.html:3

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -17,8 +17,9 @@ msgstr "Svara"
 
 #: templates/base.html:29 templates/survey/results.html:3
 #: templates/survey/results.html:5 templates/survey/survey_detail.html:26
-msgid "Results"
-msgstr "Resultat"
+#: templates/survey/survey_detail.html:43 templates/survey/survey_detail.html:78
+msgid "Answers"
+msgstr "Svar"
 
 #: templates/base.html:47
 msgid "Logout"
@@ -229,11 +230,6 @@ msgstr "Obesvarade frågor"
 #: wikikysely_project/survey/models.py:12
 msgid "Title"
 msgstr "Titel"
-
-#: templates/survey/survey_detail.html:43
-#: templates/survey/survey_detail.html:78
-msgid "Answers"
-msgstr "Svar"
 
 # UI strings
 #: templates/survey/survey_detail.html:113 templates/survey/survey_form.html:3

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,7 +26,7 @@
         {% else %}
         <li class="nav-item"><span class="nav-link text-secondary">{% translate 'Answer survey' %} (<span id="unanswered-count">0</span>)</span></li>
         {% endif %}
-        <li class="nav-item"><a class="nav-link{% if request.path == survey_results_url %} active{% endif %}" href="{{ survey_results_url }}">{% translate 'Results' %}</a></li>
+        <li class="nav-item"><a class="nav-link{% if request.path == survey_results_url %} active{% endif %}" href="{{ survey_results_url }}">{% translate 'Answers' %}</a></li>
       </ul>
       <ul id="userbar" class="navbar-nav ms-auto">
       <li class="nav-item">

--- a/templates/survey/results.html
+++ b/templates/survey/results.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{% translate 'Results' %}{% endblock %}
+{% block title %}{% translate 'Answers' %}{% endblock %}
 {% block content %}
 {% if not request.user.is_authenticated and data %}
   {% if request.GET.login_required %}
@@ -24,7 +24,7 @@
       <a href="{% url 'survey:results_wikitext' %}" class="btn btn-secondary mb-3">{% translate 'Print wikitext' %}</a>
     {% endif %}
   {% endif %}
-<h1>{% translate 'Results' %}</h1>
+<h1>{% translate 'Answers' %}</h1>
 <div class="mb-3">
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="chartType" id="pieChartRadio" value="pie" checked>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -23,7 +23,7 @@
       <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary">{% translate 'Answer survey' %}</a>
     {% else %}
       {% if questions %}
-        <a href="{% url 'survey:survey_results' %}" class="btn btn-info">{% translate 'Results' %}</a>
+        <a href="{% url 'survey:survey_results' %}" class="btn btn-info">{% translate 'Answers' %}</a>
       {% endif %}
     {% endif %}
     <a href="{% url 'survey:question_add' %}" class="btn btn-secondary">{% translate 'Add question' %}</a>


### PR DESCRIPTION
## Summary
- rename Results page navigation and headings to **Answers**
- update Finnish and Swedish translations accordingly

## Testing
- `django_secret=testing_secret python manage.py compilemessages`
- `django_secret=testing_secret python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6887b79b339c832e9ee1997c0656577e