### PR TITLE
Change results URLs to answers

### DIFF
--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -15,7 +15,11 @@ urlpatterns = [
     path("question/<int:pk>/", views.answer_question, name="answer_question"),
     path("answer/<int:pk>/edit/", views.answer_edit, name="answer_edit"),
     path("answer/<int:pk>/delete/", views.answer_delete, name="answer_delete"),
-    path("answers/", views.answer_list, name="answer_list"),
-    path("results/", views.survey_results, name="survey_results"),
-    path("results/wikitext/", views.survey_results_wikitext, name="results_wikitext"),
+    path("my_answers/", views.answer_list, name="answer_list"),
+    path("answers/", views.survey_results, name="survey_results"),
+    path(
+        "answers/wikitext/",
+        views.survey_results_wikitext,
+        name="results_wikitext",
+    ),
 ]


### PR DESCRIPTION
## Summary
- rename survey results endpoint to `/answers/`
- move user's answer list to `/my_answers/`

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6887ba73cde4832e9a743fdc576441c2