### PR TITLE
Update answer list to show submission date

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -168,6 +168,10 @@ msgstr "Vastaustaulukko"
 msgid "Published"
 msgstr "Julkaistu"
 
+#: templates/survey/answer_form.html:88
+msgid "Answer date"
+msgstr "Vastauspäivä"
+
 #: templates/survey/results.html:61
 msgid "My answer"
 msgstr "Oma vastaus"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -168,6 +168,10 @@ msgstr "Svarstabell"
 msgid "Published"
 msgstr "Publicerad"
 
+#: templates/survey/answer_form.html:88
+msgid "Answer date"
+msgstr "Svarstid"
+
 #: templates/survey/results.html:61
 msgid "My answer"
 msgstr "Mitt svar"

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -83,7 +83,7 @@
   <table class="table mb-3 survey-detail-table">
     <thead>
       <tr>
-        <th>{% translate 'Published' %}</th>
+        <th>{% translate 'Answer date' %}</th>
         <th>{% translate 'Title' %}</th>
         <th>{% translate 'Answers' %}</th>
         <th>{% translate 'Agree' %}</th>
@@ -93,7 +93,7 @@
     <tbody>
       {% for a in user_answers %}
       <tr data-question-id="{{ a.question.pk }}">
-        <td>{{ a.question.created_at|date:"Y-m-d" }}</td>
+        <td>{{ a.created_at|date:"Y-m-d" }}</td>
         <td><a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a></td>
         <td>{{ a.total_answers }}</td>
         <td>{{ a.agree_ratio|floatformat:1 }}%</td>


### PR DESCRIPTION
## Summary
- show the actual answer date in the "My answers" table
- translate new "Answer date" header in Finnish and Swedish

## Testing
- `django_secret=testsecret python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6887bc7dd64c832ea17efe9c14a9c165