### PR TITLE
Show sort indicator on my answers by default

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -169,6 +169,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 sortTable(i, current);
             });
         });
+
+        // Indicate default sorting by the Answer date column
+        directions[0] = 'desc';
+        headers[0].textContent = baseTexts[0] + ' \u2193';
+        sortTable(0, 'desc');
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- show descending sort arrow on the "My answers" table

## Testing
- `django_secret=dummy python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6887bec2606c832ebef9245fd544e5fc