### PR TITLE
Fix updating consensus ratio in answer page

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -95,8 +95,8 @@
       <tr data-question-id="{{ a.question.pk }}">
         <td>{{ a.created_at|date:"Y-m-d" }}</td>
         <td><a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a></td>
-        <td>{{ a.total_answers }}</td>
-        <td>{{ a.agree_ratio|floatformat:1 }}%</td>
+        <td class="total-answers">{{ a.total_answers }}</td>
+        <td class="agree-ratio">{{ a.agree_ratio|floatformat:1 }}%</td>
         <td class="text-end">
           {% if a.question.survey.state == 'running' %}
           <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline ajax-answer-form">


### PR DESCRIPTION
## Summary
- ensure the consensus ratio updates when answers are edited
- add proper table cell classes for AJAX updates

## Testing
- `pip install -r requirements.txt`
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6887c075eb4c832eaadaa1b4eb698bdf