### PR TITLE
Redirect to answer page after login

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -68,6 +68,27 @@ class SurveyFlowTests(TransactionTestCase):
             for i in range(1, count + 1)
         ]
 
+    def test_login_redirects_to_unanswered(self):
+        survey = self._create_survey()
+        self._create_question(survey)
+        self.client.logout()
+        response = self.client.post(
+            reverse("login"),
+            {"username": self.user.username, "password": "pass"},
+        )
+        self.assertRedirects(response, reverse("survey:answer_survey"))
+
+    def test_login_redirects_to_detail_when_no_unanswered(self):
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        Answer.objects.create(question=q, user=self.user, answer="yes")
+        self.client.logout()
+        response = self.client.post(
+            reverse("login"),
+            {"username": self.user.username, "password": "pass"},
+        )
+        self.assertRedirects(response, reverse("survey:survey_detail"))
+
     def test_survey_edit(self):
         survey = self._create_survey()
         data = {

--- a/wikikysely_project/urls.py
+++ b/wikikysely_project/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import path, include
+from wikikysely_project.survey.views import SurveyLoginView
 from django.views.i18n import set_language
 
 urlpatterns = [
@@ -11,6 +12,7 @@ urlpatterns = [
 urlpatterns += i18n_patterns(
     path('admin/', admin.site.urls),
     path('oauth/', include('social_django.urls', namespace='social')),
+    path('accounts/login/', SurveyLoginView.as_view(), name='login'),
     path('accounts/', include('django.contrib.auth.urls')),
     path('', include('wikikysely_project.survey.urls')),
 )


### PR DESCRIPTION
## Summary
- add custom login view that redirects to survey answer page when there are unanswered questions
- update registration flow to use the same logic
- expose the custom login view in the URL config
- test login redirection behaviour

## Testing
- `python -m pip install -r requirements.txt`
- `django_secret=abc python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6887c0b5c1e4832eb3abafc45304393e