### PR TITLE
Fix login after registration

### DIFF
--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -106,7 +106,14 @@ def register(request):
         form = UserCreationForm(request.POST)
         if form.is_valid():
             user = form.save()
-            login(request, user)
+            # Specify backend explicitly as multiple authentication backends are
+            # configured. Without this Django cannot determine which backend
+            # authenticated the user and raises a ValueError.
+            login(
+                request,
+                user,
+                backend="django.contrib.auth.backends.ModelBackend",
+            )
             messages.success(request, _("Registration successful"))
             next_url = request.GET.get("next") or get_login_redirect_url(request)
             return redirect(next_url)


### PR DESCRIPTION
## Summary
- specify the authentication backend when logging in newly registered users

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6887c3b7c260832e9f0eba1dc1b8be7f