### PR TITLE
Notify about changed answers

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -383,6 +383,11 @@ msgstr "Vastauksen voi muokata vain, kun kysely on käynnissä"
 msgid "Answer updated"
 msgstr "Vastaus päivitetty"
 
+#: wikikysely_project/survey/views.py:553
+#, python-format
+msgid "The answer to question \"%(question)s\" was changed from %(old)s to %(new)s."
+msgstr "Kysymyksen \"%(question)s\" vastaus muutettiin arvosta %(old)s arvoon %(new)s."
+
 #: wikikysely_project/survey/views.py:502
 msgid "Answer can only be removed while the survey is running"
 msgstr "Vastauksen voi poistaa vain, kun kysely on käynnissä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -383,6 +383,11 @@ msgstr "Svar kan redigeras endast när enkäten är igång"
 msgid "Answer updated"
 msgstr "Svar uppdaterat"
 
+#: wikikysely_project/survey/views.py:553
+#, python-format
+msgid "The answer to question \"%(question)s\" was changed from %(old)s to %(new)s."
+msgstr "Svaret på frågan \"%(question)s\" ändrades från %(old)s till %(new)s."
+
 #: wikikysely_project/survey/views.py:502
 msgid "Answer can only be removed while the survey is running"
 msgstr "Svar kan tas bort endast när enkäten är igång"

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -538,11 +538,26 @@ def answer_question(request, pk):
             if form.is_valid():
                 answer_value = form.cleaned_data["answer"]
                 if answer_value:
+                    old_value = answer.answer if answer else None
+                    old_display = answer.get_answer_display() if answer else None
                     Answer.objects.update_or_create(
                         user=request.user,
                         question=question,
                         defaults={"answer": answer_value},
                     )
+                    new_display = dict(Answer.ANSWER_CHOICES).get(answer_value)
+                    if old_value is not None and old_value != answer_value:
+                        messages.info(
+                            request,
+                            _(
+                                'The answer to question "%(question)s" was changed from %(old)s to %(new)s.'
+                            )
+                            % {
+                                "question": question.text,
+                                "old": old_display,
+                                "new": new_display,
+                            },
+                        )
                     messages.success(request, _("Answer saved"))
                     if request.headers.get("X-Requested-With") == "XMLHttpRequest":
                         yes_count = question.answers.filter(answer="yes").count()


### PR DESCRIPTION
## Summary
- show an info-level alert when changing an answer on the question page
- translate the new message in Finnish and Swedish

## Testing
- `python manage.py compilemessages`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6887c68e2854832e878f6bc71b105d47