### PR TITLE
Add footer links and privacy policy

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -403,6 +403,18 @@ msgstr "Vastausjakauma"
 msgid "Answers over time"
 msgstr "Vastausten määrä ajan kuluessa"
 
+#: templates/base.html:72
+msgid "Project page"
+msgstr "Projektisivu"
+
+#: templates/base.html:73
+msgid "Source code"
+msgstr "Lähdekoodi"
+
+#: templates/base.html:74
+msgid "Privacy policy"
+msgstr "Tietosuojakäytäntö"
+
 #~ msgid "Start date"
 #~ msgstr "Aloituspäivä"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -403,6 +403,18 @@ msgstr "Svarsfördelning"
 msgid "Answers over time"
 msgstr "Antal svar över tid"
 
+#: templates/base.html:72
+msgid "Project page"
+msgstr "Projectsida"
+
+#: templates/base.html:73
+msgid "Source code"
+msgstr "Källkod"
+
+#: templates/base.html:74
+msgid "Privacy policy"
+msgstr "Integritetspolicy"
+
 #~ msgid "Start date"
 #~ msgstr "Startdatum"
 

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,0 +1,18 @@
+# Privacy Policy
+
+This prototype survey tool stores limited personal data to operate the site.
+
+## Account information
+- If you create an account directly on the site, your username and a hashed password are stored.
+- When signing in with Wikimedia you authorize the application via OAuth. Your Wikimedia username and authentication tokens are saved.
+
+## Survey data
+- Your submitted questions and answers are kept in the database. They may be shown publicly with your username and included in aggregated statistics or data exports.
+
+## Cookies
+- Session cookies are used to keep you logged in.
+
+## Logs
+- Standard web server logs include IP addresses and other metadata. These logs are used for debugging and are not shared.
+
+All data is stored on servers managed by the project maintainers and may be removed at any time as this is a prototype.

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,8 +67,15 @@
             {% endif %}
         {% endfor %}
     {% endif %}
-    {% block content %}{% endblock %}
+  {% block content %}{% endblock %}
 </div>
+<footer class="footer fixed-bottom bg-light text-center py-2">
+  <small>
+    <a href="https://fi.wikipedia.org/wiki/Wikiprojekti:Wikikysely_2025" target="_blank">{% translate 'Project page' %}</a> |
+    <a href="https://github.com/Wikimedia-Suomi/wikikysely" target="_blank">{% translate 'Source code' %}</a> |
+    <a href="https://github.com/Wikimedia-Suomi/wikikysely/blob/main/privacy-policy.md" target="_blank">{% translate 'Privacy policy' %}</a>
+  </small>
+</footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 <script src="{% static 'js/langswitch.js' %}"></script>


### PR DESCRIPTION
## Summary
- include a fixed footer with links to project page, source code and privacy policy
- translate new footer text to Finnish and Swedish
- add an English `privacy-policy.md` describing stored data

## Testing
- `python3 manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688832014a5c832ebb5abc78bc6d3c21