### PR TITLE
Implement user data export and deletion

### DIFF
--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -2,7 +2,26 @@
 {% load i18n %}
 {% block title %}{{ request.user.username }}{% endblock %}
 {% block content %}
-<h2>{% translate 'My questions' %}</h2>
+<h2>{% translate 'My data' %}</h2>
+<ul>
+  <li>{% translate 'Username' %}: {{ request.user.username }}</li>
+  <li>{% translate 'Date joined' %}: {{ request.user.date_joined|date:'Y-m-d' }}</li>
+  <li>{% blocktrans with n=total_questions %}{{ n }} questions{% endblocktrans %}</li>
+  <li>{% blocktrans with n=total_answers %}{{ n }} answers{% endblocktrans %}</li>
+</ul>
+<p>
+  <a href="{% url 'survey:userinfo_download' %}" class="btn btn-primary">{% translate 'Download my data (JSON)' %}</a>
+</p>
+{% if can_delete_account %}
+<form method="post" action="{% url 'survey:user_delete' %}" onsubmit="return confirm('{% translate 'This action cannot be undone. Delete your account?' %}');">
+  {% csrf_token %}
+  <button type="submit" class="btn btn-danger">{% translate 'Delete my account' %}</button>
+</form>
+{% else %}
+<p class="text-muted">{% translate 'You must remove your questions and answers before deleting your account.' %}</p>
+{% endif %}
+
+<h2 class="mt-4">{% translate 'My questions' %}</h2>
 <table class="table mb-4">
   <thead>
     <tr>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -305,3 +305,32 @@ class SurveyFlowTests(TransactionTestCase):
 
         response = self.client.get(reverse("survey:survey_detail"))
         self.assertContains(response, "This survey is currently paused.")
+
+    def test_userinfo_download_returns_json(self):
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        Answer.objects.create(question=q, user=self.user, answer="yes")
+
+        response = self.client.get(reverse("survey:userinfo_download"))
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode())
+        self.assertEqual(data["user"]["username"], self.user.username)
+        self.assertEqual(len(data["answers"]), 1)
+        self.assertEqual(len(data["questions"]), 1)
+
+    def test_user_delete_requires_no_references(self):
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        Answer.objects.create(question=q, user=self.user, answer="yes")
+
+        response = self.client.post(reverse("survey:user_delete"))
+        self.assertEqual(response.status_code, 302)
+        User = get_user_model()
+        self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
+
+    def test_user_delete_success(self):
+        response = self.client.post(reverse("survey:user_delete"))
+        self.assertRedirects(response, reverse("survey:survey_detail"))
+        User = get_user_model()
+        self.assertFalse(User.objects.filter(pk=self.user.pk).exists())
+        self.assertNotIn("_auth_user_id", self.client.session)

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -16,6 +16,8 @@ urlpatterns = [
     path("answer/<int:pk>/edit/", views.answer_edit, name="answer_edit"),
     path("answer/<int:pk>/delete/", views.answer_delete, name="answer_delete"),
     path("my_answers/", views.userinfo, name="userinfo"),
+    path("my_answers/download/", views.userinfo_download, name="userinfo_download"),
+    path("my_answers/delete_account/", views.user_delete, name="user_delete"),
     path("answers/", views.survey_answers, name="survey_answers"),
     path(
         "answers/wikitext/",


### PR DESCRIPTION
## Summary
- show summary of stored user data on userinfo page
- allow downloading personal data as JSON
- allow removing account when it has no questions or answers
- test user data export and account removal

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688841ced978832ea82e0f4f0a9a936a