### PR TITLE
Implement user data deletion button

### DIFF
--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -11,6 +11,10 @@
 </ul>
 <p>
   <a href="{% url 'survey:userinfo_download' %}" class="btn btn-primary">{% translate 'Download my data (JSON)' %}</a>
+  <form method="post" action="{% url 'survey:user_data_delete' %}" class="d-inline" onsubmit="return confirm('{% translate 'This action cannot be undone. Delete your data?' %}');">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-warning ms-2">{% translate 'Delete my data' %}</button>
+  </form>
 </p>
 {% if can_delete_account %}
 <form method="post" action="{% url 'survey:user_delete' %}" onsubmit="return confirm('{% translate 'This action cannot be undone. Delete your account?' %}');">

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path("answer/<int:pk>/delete/", views.answer_delete, name="answer_delete"),
     path("my_answers/", views.userinfo, name="userinfo"),
     path("my_answers/download/", views.userinfo_download, name="userinfo_download"),
+    path("my_answers/delete_data/", views.user_data_delete, name="user_data_delete"),
     path("my_answers/delete_account/", views.user_delete, name="user_delete"),
     path("answers/", views.survey_answers, name="survey_answers"),
     path(


### PR DESCRIPTION
## Summary
- add helper view to delete user data in one go
- expose the new action on the user info page
- wire up route for deleting data
- test user data deletion workflow

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68888a544900832e8b7fdccdf006cc95