### PR TITLE
Remove account deletion button

### DIFF
--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -15,15 +15,8 @@
     {% csrf_token %}
     <button type="submit" class="btn btn-warning ms-2">{% translate 'Delete my data' %}</button>
   </form>
+
 </p>
-{% if can_delete_account %}
-<form method="post" action="{% url 'survey:user_delete' %}" onsubmit="return confirm('{% translate 'This action cannot be undone. Delete your account?' %}');">
-  {% csrf_token %}
-  <button type="submit" class="btn btn-danger">{% translate 'Delete my account' %}</button>
-</form>
-{% else %}
-<p class="text-muted">{% translate 'You must remove your questions and answers before deleting your account.' %}</p>
-{% endif %}
 
 <h2 class="mt-4">{% translate 'My questions' %}</h2>
 <table class="table mb-4">

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -338,22 +338,6 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(len(data["answers"]), 1)
         self.assertEqual(len(data["questions"]), 1)
 
-    def test_user_delete_requires_no_references(self):
-        survey = self._create_survey()
-        q = self._create_question(survey)
-        Answer.objects.create(question=q, user=self.user, answer="yes")
-
-        response = self.client.post(reverse("survey:user_delete"))
-        self.assertEqual(response.status_code, 302)
-        User = get_user_model()
-        self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
-
-    def test_user_delete_success(self):
-        response = self.client.post(reverse("survey:user_delete"))
-        self.assertRedirects(response, reverse("survey:survey_detail"))
-        User = get_user_model()
-        self.assertFalse(User.objects.filter(pk=self.user.pk).exists())
-        self.assertNotIn("_auth_user_id", self.client.session)
 
     def test_user_data_delete_removes_answers_and_questions(self):
         survey = self._create_survey()

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -19,7 +19,6 @@ urlpatterns = [
     path("my_answers/", views.userinfo, name="userinfo"),
     path("my_answers/download/", views.userinfo_download, name="userinfo_download"),
     path("my_answers/delete_data/", views.user_data_delete, name="user_data_delete"),
-    path("my_answers/delete_account/", views.user_delete, name="user_delete"),
     path("answers/", views.survey_answers, name="survey_answers"),
     path(
         "answers/wikitext/",

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -698,7 +698,6 @@ def userinfo(request):
             "editable_questions": editable_questions,
             "total_answers": total_answers,
             "total_questions": total_questions,
-            "can_delete_account": total_answers == 0 and total_questions == 0,
         },
     )
 
@@ -778,29 +777,6 @@ def user_data_delete(request):
 
     messages.success(request, _("Data removed"))
     return redirect("survey:userinfo")
-
-
-@login_required
-def user_delete(request):
-    """Delete the current user account if no references exist."""
-    if request.method != "POST":
-        return redirect("survey:userinfo")
-
-    user = request.user
-    has_answers = Answer.objects.filter(user=user).exists()
-    has_questions = Question.objects.filter(creator=user).exists()
-
-    if has_answers or has_questions:
-        messages.error(
-            request,
-            _("Account cannot be removed while there are answers or questions referencing it."),
-        )
-        return redirect("survey:userinfo")
-
-    logout(request)
-    user.delete()
-    messages.success(request, _("Account removed"))
-    return redirect("survey:survey_detail")
 
 
 @login_required


### PR DESCRIPTION
## Summary
- drop `Delete my account` form from the personal data page
- drop the related `user_delete` view and URL
- tidy tests after removing account deletion

## Testing
- `django_secret=abc python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68888e7a8278832e9ad23699e9a9380d