### PR TITLE
Implement AJAX deletion for My answers

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -58,7 +58,8 @@ document.addEventListener('DOMContentLoaded', () => {
       ev.preventDefault();
       const unansweredHeader = document.getElementById('unanswered-header');
       const unansweredTable = document.getElementById('unanswered-table');
-      const reloadNeeded = !unansweredHeader || !unansweredTable;
+      const updateUnanswered = unansweredHeader && unansweredTable;
+      const noReload = link.dataset.noReload !== undefined;
       fetch(link.href, {
         method: 'POST',
         headers: {
@@ -79,7 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (navCount && typeof data.unanswered_count !== 'undefined') {
           navCount.textContent = data.unanswered_count;
         }
-        if (!reloadNeeded) {
+        if (updateUnanswered) {
           const tbody = unansweredTable.tBodies[0];
           if (tbody) {
             const tr = document.createElement('tr');
@@ -127,7 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             tbody.appendChild(tr);
           }
-        } else {
+        } else if (!noReload) {
           window.location.reload();
         }
       }).catch(() => window.location.reload());

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -109,7 +109,7 @@
               <label class="btn btn-sm btn-outline-danger" for="answer-{{ a.pk }}-no">{% translate 'No' %}</label>
             </div>
           </form>
-          <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ms-2 ajax-delete-answer" data-question-id="{{ a.question.pk }}">{% translate 'Remove answer' %}</a>
+          <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ms-2 ajax-delete-answer" data-question-id="{{ a.question.pk }}" data-no-reload="true">{% translate 'Remove answer' %}</a>
           {% endif %}
         </td>
       </tr>

--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n static %}
 {% block title %}{{ request.user.username }}{% endblock %}
 {% block content %}
 <h2>{% translate 'My data' %}</h2>
@@ -62,7 +62,7 @@
     <td class="text-end">
       {% if answer.question.survey.state == 'running' %}
       <a href="{% url 'survey:answer_edit' answer.pk %}" class="btn btn-sm btn-warning">{% translate 'Edit' %}</a>
-      <a href="{% url 'survey:answer_delete' answer.pk %}" class="btn btn-sm btn-danger ms-2">{% translate 'Remove answer' %}</a>
+      <a href="{% url 'survey:answer_delete' answer.pk %}" class="btn btn-sm btn-danger ms-2 ajax-delete-answer" data-no-reload="true">{% translate 'Remove answer' %}</a>
       {% endif %}
     </td>
   </tr>
@@ -71,4 +71,8 @@
 {% endfor %}
 </tbody>
 </table>
+{% endblock %}
+
+{% block scripts %}
+<script src="{% static 'js/survey_detail_ajax.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enhance delete logic in `survey_detail_ajax.js` to support non-reload links
- mark delete links with `data-no-reload` on `answer_form.html` and `userinfo.html`
- load ajax script on the user info page

## Testing
- `django_secret=testsecret python manage.py test -v 1`

------
https://chatgpt.com/codex/tasks/task_e_68889e9010cc832eaba59a9cfed17de9