### PR TITLE
Improve user data deletion feedback

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -348,20 +348,23 @@ class SurveyFlowTests(TransactionTestCase):
         Answer.objects.create(question=q2, user=self.user, answer="yes")
         Answer.objects.create(question=q2, user=other, answer="yes")
 
-        response = self.client.post(reverse("survey:user_data_delete"))
+        response = self.client.post(reverse("survey:user_data_delete"), follow=True)
         self.assertRedirects(response, reverse("survey:userinfo"))
         self.assertFalse(Answer.objects.filter(user=self.user).exists())
         self.assertFalse(Question.objects.filter(pk=q1.pk).exists())
         self.assertTrue(Question.objects.filter(pk=q2.pk).exists())
         User = get_user_model()
         self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
+        self.assertContains(response, "Could not remove 1 questions")
+        self.assertContains(response, "Account not removed")
 
     def test_user_data_delete_removes_account_when_no_references(self):
         survey = self._create_survey()
         q = self._create_question(survey)
         Answer.objects.create(question=q, user=self.user, answer="yes")
 
-        response = self.client.post(reverse("survey:user_data_delete"))
+        response = self.client.post(reverse("survey:user_data_delete"), follow=True)
         self.assertRedirects(response, reverse("survey:survey_detail"))
         User = get_user_model()
         self.assertFalse(User.objects.filter(pk=self.user.pk).exists())
+        self.assertContains(response, "Account removed")


### PR DESCRIPTION
## Summary
- show detailed summary of which data was removed and why some data could not be deleted
- verify summary messages in tests

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68889f4ee568832eaf78911d12acad23