### PR TITLE
Update account deletion messages

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -355,8 +355,14 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertTrue(Question.objects.filter(pk=q2.pk).exists())
         User = get_user_model()
         self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
-        self.assertContains(response, "Could not remove 1 questions")
-        self.assertContains(response, "Account not removed")
+        self.assertContains(
+            response,
+            "Could not remove 1 questions because they already had answers."
+        )
+        self.assertContains(
+            response,
+            "Account not removed because all your questions could not be deleted."
+        )
 
     def test_user_data_delete_removes_account_when_no_references(self):
         survey = self._create_survey()
@@ -367,4 +373,4 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertRedirects(response, reverse("survey:survey_detail"))
         User = get_user_model()
         self.assertFalse(User.objects.filter(pk=self.user.pk).exists())
-        self.assertContains(response, "Account removed")
+        self.assertContains(response, "Account removed.")

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -761,6 +761,7 @@ def user_data_delete(request):
     answers_qs = Answer.objects.filter(user=user)
     removed_answers = answers_qs.count()
     answers_qs.delete()
+    total_answers = removed_answers
 
     removed_questions = 0
     kept_questions = 0
@@ -772,25 +773,30 @@ def user_data_delete(request):
             removed_questions += 1
         else:
             kept_questions += 1
+    total_questions = removed_questions + kept_questions
 
     # If nothing references the user anymore, remove the account
     has_questions = Question.objects.filter(creator=user).exists()
 
     lines = [
-        _("Removed %(count)d answers") % {"count": removed_answers},
-        _("Removed %(count)d questions") % {"count": removed_questions},
+        _("Removed %(removed)d/%(total)d answers.")
+        % {"removed": removed_answers, "total": total_answers},
+        _("Removed %(removed)d/%(total)d questions.")
+        % {"removed": removed_questions, "total": total_questions},
     ]
 
     if kept_questions:
         lines.append(
-            _("Could not remove %(count)d questions because they already had answers")
+            _(
+                "Could not remove %(count)d questions because they already had answers."
+            )
             % {"count": kept_questions}
         )
 
     if not has_questions:
         logout(request)
         user.delete()
-        lines.append(_("Account removed"))
+        lines.append(_("Account removed."))
         message = format_html(
             "<ul>{}</ul>",
             format_html_join("", "<li>{}</li>", ((line,) for line in lines)),
@@ -800,7 +806,7 @@ def user_data_delete(request):
 
     lines.append(
         _(
-            "Account not removed because your questions could not be deleted"
+            "Account not removed because all your questions could not be deleted."
         )
     )
 


### PR DESCRIPTION
## Summary
- show how many answers/questions were removed out of total
- clarify account removal message and add punctuation
- adjust tests for new messages

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6888a71cbe0c832e8c96e6478ee92471