### PR TITLE
Add FI and SV translations for data deletion

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -448,6 +448,29 @@ msgstr "Lataa tietoni (JSON)"
 msgid "Delete my data"
 msgstr "Poista tietoni"
 
+#: wikikysely_project/survey/views.py:782
+#, python-format
+msgid "Removed %(removed)d/%(total)d answers."
+msgstr "Poistettu %(removed)d/%(total)d vastausta."
+
+#: wikikysely_project/survey/views.py:784
+#, python-format
+msgid "Removed %(removed)d/%(total)d questions."
+msgstr "Poistettu %(removed)d/%(total)d kysymystä."
+
+#: wikikysely_project/survey/views.py:791
+#, python-format
+msgid "Could not remove %(count)d questions because they already had answers."
+msgstr "Ei voitu poistaa %(count)d kysymystä, koska niihin oli jo vastauksia."
+
+#: wikikysely_project/survey/views.py:799
+msgid "Account removed."
+msgstr "Tili poistettu."
+
+#: wikikysely_project/survey/views.py:809
+msgid "Account not removed because all your questions could not be deleted."
+msgstr "Tiliä ei poistettu, koska kaikkia kysymyksiäsi ei voitu poistaa."
+
 #~ msgid "Start date"
 #~ msgstr "Aloituspäivä"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -448,6 +448,29 @@ msgstr "Ladda ner mina uppgifter (JSON)"
 msgid "Delete my data"
 msgstr "Ta bort mina uppgifter"
 
+#: wikikysely_project/survey/views.py:782
+#, python-format
+msgid "Removed %(removed)d/%(total)d answers."
+msgstr "Tog bort %(removed)d/%(total)d svar."
+
+#: wikikysely_project/survey/views.py:784
+#, python-format
+msgid "Removed %(removed)d/%(total)d questions."
+msgstr "Tog bort %(removed)d/%(total)d frågor."
+
+#: wikikysely_project/survey/views.py:791
+#, python-format
+msgid "Could not remove %(count)d questions because they already had answers."
+msgstr "Kunde inte ta bort %(count)d frågor eftersom de redan hade svar."
+
+#: wikikysely_project/survey/views.py:799
+msgid "Account removed."
+msgstr "Konto borttaget."
+
+#: wikikysely_project/survey/views.py:809
+msgid "Account not removed because all your questions could not be deleted."
+msgstr "Konto togs inte bort eftersom alla dina frågor inte kunde tas bort."
+
 #~ msgid "Start date"
 #~ msgstr "Startdatum"
 


### PR DESCRIPTION
## Summary
- add Finnish and Swedish translations for user info deletion messages

## Testing
- `python manage.py compilemessages`
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6888a9002220832eacc6a6c5582cee89