### PR TITLE
Fix data deletion message grammar

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -450,18 +450,24 @@ msgstr "Poista tietoni"
 
 #: wikikysely_project/survey/views.py:782
 #, python-format
-msgid "Removed %(removed)d/%(total)d answers."
-msgstr "Poistettu %(removed)d/%(total)d vastausta."
+msgid "Removed %(removed)d/%(total)d answer."
+msgid_plural "Removed %(removed)d/%(total)d answers."
+msgstr[0] "Poistettu %(removed)d/%(total)d vastaus."
+msgstr[1] "Poistettu %(removed)d/%(total)d vastausta."
 
 #: wikikysely_project/survey/views.py:784
 #, python-format
-msgid "Removed %(removed)d/%(total)d questions."
-msgstr "Poistettu %(removed)d/%(total)d kysymystä."
+msgid "Removed %(removed)d/%(total)d question."
+msgid_plural "Removed %(removed)d/%(total)d questions."
+msgstr[0] "Poistettu %(removed)d/%(total)d kysymys."
+msgstr[1] "Poistettu %(removed)d/%(total)d kysymystä."
 
 #: wikikysely_project/survey/views.py:791
 #, python-format
-msgid "Could not remove %(count)d questions because they already had answers."
-msgstr "Ei voitu poistaa %(count)d kysymystä, koska niihin oli jo vastauksia."
+msgid "Could not remove %(count)d question because it already had answers."
+msgid_plural "Could not remove %(count)d questions because they already had answers."
+msgstr[0] "Ei voitu poistaa %(count)d kysymystä, koska siihen oli jo vastauksia."
+msgstr[1] "Ei voitu poistaa %(count)d kysymystä, koska niihin oli jo vastauksia."
 
 #: wikikysely_project/survey/views.py:799
 msgid "Account removed."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -450,18 +450,24 @@ msgstr "Ta bort mina uppgifter"
 
 #: wikikysely_project/survey/views.py:782
 #, python-format
-msgid "Removed %(removed)d/%(total)d answers."
-msgstr "Tog bort %(removed)d/%(total)d svar."
+msgid "Removed %(removed)d/%(total)d answer."
+msgid_plural "Removed %(removed)d/%(total)d answers."
+msgstr[0] "Tog bort %(removed)d/%(total)d svar."
+msgstr[1] "Tog bort %(removed)d/%(total)d svar."
 
 #: wikikysely_project/survey/views.py:784
 #, python-format
-msgid "Removed %(removed)d/%(total)d questions."
-msgstr "Tog bort %(removed)d/%(total)d frågor."
+msgid "Removed %(removed)d/%(total)d question."
+msgid_plural "Removed %(removed)d/%(total)d questions."
+msgstr[0] "Tog bort %(removed)d/%(total)d fråga."
+msgstr[1] "Tog bort %(removed)d/%(total)d frågor."
 
 #: wikikysely_project/survey/views.py:791
 #, python-format
-msgid "Could not remove %(count)d questions because they already had answers."
-msgstr "Kunde inte ta bort %(count)d frågor eftersom de redan hade svar."
+msgid "Could not remove %(count)d question because it already had answers."
+msgid_plural "Could not remove %(count)d questions because they already had answers."
+msgstr[0] "Kunde inte ta bort %(count)d fråga eftersom den redan hade svar."
+msgstr[1] "Kunde inte ta bort %(count)d frågor eftersom de redan hade svar."
 
 #: wikikysely_project/survey/views.py:799
 msgid "Account removed."

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -357,7 +357,7 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
         self.assertContains(
             response,
-            "Could not remove 1 questions because they already had answers."
+            "Could not remove 1 question because it already had answers."
         )
         self.assertContains(
             response,

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.views import LoginView
 from django.shortcuts import render, get_object_or_404, redirect
 from django.template.loader import render_to_string
-from django.utils.translation import gettext_lazy as _, gettext
+from django.utils.translation import gettext_lazy as _, gettext, ngettext
 from django.utils.html import format_html, format_html_join
 from django.db.models import Count, Q, F, FloatField, ExpressionWrapper, Max
 from django.db.models.functions import NullIf, TruncDate, Greatest
@@ -779,16 +779,26 @@ def user_data_delete(request):
     has_questions = Question.objects.filter(creator=user).exists()
 
     lines = [
-        _("Removed %(removed)d/%(total)d answers.")
+        ngettext(
+            "Removed %(removed)d/%(total)d answer.",
+            "Removed %(removed)d/%(total)d answers.",
+            total_answers,
+        )
         % {"removed": removed_answers, "total": total_answers},
-        _("Removed %(removed)d/%(total)d questions.")
+        ngettext(
+            "Removed %(removed)d/%(total)d question.",
+            "Removed %(removed)d/%(total)d questions.",
+            total_questions,
+        )
         % {"removed": removed_questions, "total": total_questions},
     ]
 
     if kept_questions:
         lines.append(
-            _(
-                "Could not remove %(count)d questions because they already had answers."
+            ngettext(
+                "Could not remove %(count)d question because it already had answers.",
+                "Could not remove %(count)d questions because they already had answers.",
+                kept_questions,
             )
             % {"count": kept_questions}
         )


### PR DESCRIPTION
## Summary
- use `ngettext` to handle singular/plural forms in data deletion messages
- update Finnish and Swedish translations for these messages
- adjust tests for updated English messages

## Testing
- `django_secret=testsecret python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6888ab67b844832e8b26985b8917d156