### PR TITLE
Add timestamped filename for user exports

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -333,6 +333,9 @@ class SurveyFlowTests(TransactionTestCase):
 
         response = self.client.get(reverse("survey:userinfo_download"))
         self.assertEqual(response.status_code, 200)
+        cd_header = response["Content-Disposition"]
+        pattern = rf"attachment; filename={self.user.username}_\d{{14}}\.json"
+        self.assertRegex(cd_header, pattern)
         data = json.loads(response.content.decode())
         self.assertEqual(data["user"]["username"], self.user.username)
         self.assertEqual(len(data["answers"]), 1)

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -744,8 +744,13 @@ def userinfo_download(request):
             for a in answers
         ],
     }
-    response = JsonResponse(data, json_dumps_params={"indent": 2, "ensure_ascii": False})
-    response["Content-Disposition"] = "attachment; filename=userinfo.json"
+    response = JsonResponse(
+        data,
+        json_dumps_params={"indent": 2, "ensure_ascii": False},
+    )
+    timestamp = timezone.now().strftime("%Y%m%d%H%M%S")
+    filename = f"{user.username}_{timestamp}.json"
+    response["Content-Disposition"] = f"attachment; filename={filename}"
     return response
 
 


### PR DESCRIPTION
## Summary
- export user info JSON with timestamped filename
- test content-disposition header uses username and timestamp

## Testing
- `python manage.py test -v 2 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6888c0ea0114832ea0e7422a16223289