### PR TITLE
Add default survey creation on database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Guide is for Linux and OS X. With Windows you need to create and activate virtua
    python manage.py makemigrations
    python manage.py migrate
    ```
+   The initial migration automatically creates a default survey.
 8. Create a superuser:
    ```bash
    python manage.py createsuperuser

--- a/wikikysely_project/survey/apps.py
+++ b/wikikysely_project/survey/apps.py
@@ -1,6 +1,27 @@
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
 
 
 class SurveyConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'wikikysely_project.survey'
+
+    def ready(self):
+        def create_default_survey(sender, **kwargs):
+            if kwargs.get('plan') is None:
+                # Skip post_migrate calls from flush
+                return
+            from django.db import OperationalError
+            from django.db import connection
+            from .models import Survey
+
+            try:
+                # Skip if the table does not yet exist
+                if 'survey_survey' not in connection.introspection.table_names():
+                    return
+                Survey.get_main_survey()
+            except OperationalError:
+                # Table doesn't exist during initial migrate
+                pass
+
+        post_migrate.connect(create_default_survey, sender=self, weak=False)

--- a/wikikysely_project/survey/tests/test_post_migrate.py
+++ b/wikikysely_project/survey/tests/test_post_migrate.py
@@ -1,0 +1,35 @@
+from django.test import TransactionTestCase
+from django.apps import apps
+from django.db import connection
+from django.db.models.signals import post_migrate
+
+from ..models import Survey
+
+
+class PostMigrateSignalTests(TransactionTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        connection.disable_constraint_checking()
+        try:
+            with connection.schema_editor(atomic=False) as schema_editor:
+                schema_editor.create_model(Survey)
+        finally:
+            connection.enable_constraint_checking()
+
+    @classmethod
+    def tearDownClass(cls):
+        connection.disable_constraint_checking()
+        try:
+            with connection.schema_editor(atomic=False) as schema_editor:
+                schema_editor.delete_model(Survey)
+        finally:
+            connection.enable_constraint_checking()
+        super().tearDownClass()
+
+    def test_default_survey_created_after_migrate(self):
+        self.assertEqual(Survey.objects.count(), 0)
+        config = apps.get_app_config('survey')
+        post_migrate.send(sender=config, app_config=config, using='default', plan=())
+        self.assertEqual(Survey.objects.count(), 1)


### PR DESCRIPTION
## Summary
- ensure a default survey exists after migrations via post_migrate signal
- document that a default survey is created automatically
- test post_migrate signal

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6888c444e8f0832ead446ac6a87fd400