### PR TITLE
Set survey running on init

### DIFF
--- a/wikikysely_project/survey/models.py
+++ b/wikikysely_project/survey/models.py
@@ -25,7 +25,7 @@ class Survey(models.Model):
                 title=_('Main Survey'),
                 description='',
                 creator=None,
-                state='paused',
+                state='running',
             )
         return survey
 

--- a/wikikysely_project/survey/tests/test_post_migrate.py
+++ b/wikikysely_project/survey/tests/test_post_migrate.py
@@ -33,3 +33,5 @@ class PostMigrateSignalTests(TransactionTestCase):
         config = apps.get_app_config('survey')
         post_migrate.send(sender=config, app_config=config, using='default', plan=())
         self.assertEqual(Survey.objects.count(), 1)
+        survey = Survey.objects.first()
+        self.assertEqual(survey.state, 'running')


### PR DESCRIPTION
## Summary
- ensure the main survey is created in running state
- verify running state in post-migrate tests

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688a4b1ad2d8832e84956e1afcd4c208