### PR TITLE
Switch to Wikimedia CDN

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}WikiKysely{% endblock %}</title>
     <!-- Bootswatch theme for nicer default styling -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/flatly/bootstrap.min.css">
+    <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/bootswatch/5.3.2/flatly/bootstrap.min.css">
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
 </head>
 <body>
@@ -75,8 +75,8 @@
     <a href="https://github.com/Wikimedia-Suomi/wikikysely/blob/main/privacy-policy.md" target="_blank">{% translate 'Privacy policy' %}</a>
   </small>
 </footer>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js"></script>
+<script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
 <script src="{% static 'js/langswitch.js' %}"></script>
 {% block scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- use tools-static.wmflabs.org CDN for Bootswatch, Bootstrap and Chart.js

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688a588555c0832ea3dae11bad56e180