### PR TITLE
Enable local login only via env flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Guide is for Linux and OS X. With Windows you need to create and activate virtua
    ```
 11. Run the development server:
    ```bash
-   python manage.py runserver
+   DJANGO_DEV_SERVER=1 python manage.py runserver
    ```
+   Setting `DJANGO_DEV_SERVER=1` enables debug mode and local username/password logins.
 11. Access the site at `http://localhost:8000/`.
 
 The UI supports Finnish, Swedish and English. You can change the language from the menu.
@@ -67,7 +68,7 @@ Unit tests use Django's built-in test runner. After installing the dependencies
 and setting up the virtual environment, run:
 
 ```bash
-python manage.py test -v 2
+DJANGO_DEV_SERVER=1 python manage.py test -v 2
 ```
 
 The command will create a temporary database and execute the test suite.

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,9 +47,11 @@
           <li class="nav-item"><a class="nav-link ms-3{% if request.path == userinfo_url %} active{% endif %}" href="{{ userinfo_url }}">{{ request.user.username }}</a></li>
         <li class="nav-item"><a class="nav-link ms-3" href="{% url 'logout' %}?next={{ request.path }}">{% translate 'Logout' %}</a></li>
       {% else %}
+        {% if local_login_enabled %}
         <li class="nav-item"><a class="nav-link ms-3" href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a></li>
-        <li class="nav-item"><a class="nav-link ms-3" href="{% url 'social:begin' 'mediawiki' %}?next={{ request.path }}">{% translate 'Login with Wikimedia' %}</a></li>
         <li class="nav-item"><a class="nav-link ms-3" href="{% url 'survey:register' %}?next={{ request.path }}">{% translate 'Register' %}</a></li>
+        {% endif %}
+        <li class="nav-item"><a class="nav-link ms-3" href="{% url 'social:begin' 'mediawiki' %}?next={{ request.path }}">{% translate 'Login with Wikimedia' %}</a></li>
       {% endif %}
       </ul>
 

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -6,7 +6,11 @@
   {% if request.GET.login_required %}
     <p class="alert alert-info">
       {% translate 'You must be logged in to answer questions' %}.
+      {% if local_login_enabled %}
       <a href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a>
+      {% else %}
+      <a href="{% url 'social:begin' 'mediawiki' %}?next={{ request.path }}">{% translate 'Login with Wikimedia' %}</a>
+      {% endif %}
     </p>
   {% endif %}
 {% endif %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -12,7 +12,11 @@
   {% if request.GET.login_required %}
     <p class="alert alert-info">
       {% translate 'You must be logged in to answer questions' %}.
+      {% if local_login_enabled %}
       <a href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a>
+      {% else %}
+      <a href="{% url 'social:begin' 'mediawiki' %}?next={{ request.path }}">{% translate 'Login with Wikimedia' %}</a>
+      {% endif %}
     </p>
   {% endif %}
 {% endif %}

--- a/wikikysely_project/settings.py
+++ b/wikikysely_project/settings.py
@@ -1,11 +1,19 @@
 from pathlib import Path
 import os
+import sys
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = os.environ.get('DJANGO_SECRET')
 
-DEBUG = True
+# Toggle development features via an environment variable
+DEV_SERVER = os.environ.get("DJANGO_DEV_SERVER") == "1"
+
+# DEBUG defaults to False but can be enabled by setting DJANGO_DEV_SERVER=1
+DEBUG = DEV_SERVER
+
+# Allow username/password logins only when the development server flag is set.
+LOCAL_LOGIN_ENABLED = DEV_SERVER
 
 ALLOWED_HOSTS = ['wikikysely.toolforge.org']
 
@@ -80,7 +88,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 # Use a separate collection directory for production builds
-STATIC_ROOT = BASE_DIR / 'static'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 # Allow the development server to find project level static assets
 STATICFILES_DIRS = [BASE_DIR / 'static']
 

--- a/wikikysely_project/survey/context_processors.py
+++ b/wikikysely_project/survey/context_processors.py
@@ -1,14 +1,19 @@
+from django.conf import settings
 from .models import Survey, Answer
 
 
 def unanswered_count(request):
     """Return number of unanswered questions for the logged-in user."""
     if not request.user.is_authenticated:
-        return {}
+        return {"local_login_enabled": settings.LOCAL_LOGIN_ENABLED}
     survey = Survey.get_main_survey()
     answered_ids = Answer.objects.filter(
         user=request.user,
         question__survey=survey,
     ).values_list('question_id', flat=True)
-    count = survey.questions.filter(visible=True).exclude(id__in=answered_ids).count()
-    return {'unanswered_count': count}
+    count = (
+        survey.questions.filter(visible=True)
+        .exclude(id__in=answered_ids)
+        .count()
+    )
+    return {"unanswered_count": count, "local_login_enabled": settings.LOCAL_LOGIN_ENABLED}

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -6,6 +6,8 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.views import LoginView
 from django.shortcuts import render, get_object_or_404, redirect
+from django.conf import settings
+from django.http import Http404
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _, gettext, ngettext
 from django.utils.html import format_html, format_html_join
@@ -102,6 +104,8 @@ def get_login_redirect_url(request):
 
 
 def register(request):
+    if not settings.LOCAL_LOGIN_ENABLED:
+        raise Http404()
     if request.method == "POST":
         form = UserCreationForm(request.POST)
         if form.is_valid():
@@ -124,6 +128,11 @@ def register(request):
 
 class SurveyLoginView(LoginView):
     """Login view that redirects to unanswered questions if any."""
+
+    def dispatch(self, request, *args, **kwargs):
+        if not settings.LOCAL_LOGIN_ENABLED:
+            raise Http404()
+        return super().dispatch(request, *args, **kwargs)
 
     def get_success_url(self):
         url = self.get_redirect_url()


### PR DESCRIPTION
## Summary
- remove automatic local-login toggle for tests
- document `DJANGO_DEV_SERVER=1` for running tests

## Testing
- `DJANGO_SECRET=foobar DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688a5f90ab08832e9cd8d7c233ffc655