### PR TITLE
Improve mobile tables

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -59,3 +59,13 @@ body {
   gap: 0.5rem;
   justify-content: center;
 }
+
+/* Allow tables to shrink on small screens */
+@media (max-width: 576px) {
+  .survey-detail-table th,
+  .survey-detail-table td,
+  #answerTable th,
+  #answerTable td {
+    width: auto !important;
+  }
+}

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -54,6 +54,7 @@
       <canvas id="answerTimelineChart"></canvas>
     </div>
   </div-->
+  <div class="table-responsive">
   <table class="table mb-3">
     <thead>
       <tr>
@@ -75,12 +76,14 @@
     </tbody>
   </table>
   </div>
+  </div>
 {% endif %}
 {% if user_answers %}
   <h2 class="mt-4">
     <a class="text-decoration-none" data-bs-toggle="collapse" href="#myAnswers" role="button" aria-expanded="false" aria-controls="myAnswers">{% translate 'My answers' %}</a>
   </h2>
   <div id="myAnswers" class="collapse">
+  <div class="table-responsive">
   <table class="table mb-3 survey-detail-table">
     <thead>
       <tr>
@@ -117,6 +120,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
   </div>
 {% endif %}
 {% endif %}

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -39,6 +39,7 @@
     <label class="form-check-label" for="barChartRadio">{% translate 'Bar chart' %}</label>
   </div>
 </div>
+<div class="table-responsive">
 <table id="barChartTable" class="table" style="display:none">
   <tbody>
   {% for row in data %}
@@ -60,6 +61,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 <div id="pieChartsContainer" style="display:none">
   <div id="pieCharts" class="d-flex flex-wrap gap-4 mt-4">
 {% for row in data %}
@@ -78,6 +80,7 @@
 </div>
 <p class="mt-3">{% translate 'Total respondents' %}: {{ total_users }}</p>
 <h2>{% translate 'Answer table' %}</h2>
+<div class="table-responsive">
 <table id="answerTable" class="table">
 <thead>
 <tr>
@@ -114,6 +117,7 @@
 {% endfor %}
 </tbody>
 </table>
+</div>
 {% endblock %}
 {% block scripts %}
 <script>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -39,6 +39,7 @@
 {% endif %}
     {% if unanswered_questions %}
         <h2 id="unanswered-header" class="mt-3">{% translate 'Unanswered questions' %}</h2>
+      <div class="table-responsive">
       <table id="unanswered-table" class="table mb-3 survey-detail-table">
         <thead>
       <tr>
@@ -70,10 +71,12 @@
         {% endfor %}
         </tbody>
       </table>
+      </div>
     {% endif %}
 
 {% if user_answers %}
 <h2 class="mt-4">{% translate 'My answers' %}</h2>
+<div class="table-responsive">
 <table class="table mb-3 survey-detail-table">
   <thead>
   <tr>
@@ -112,6 +115,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endif %}
 {% if can_edit %}
    <a href="{% url 'survey:survey_edit' %}" class="btn btn-warning ms-2">{% translate 'Edit survey' %}</a>

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -3,6 +3,7 @@
 {% block title %}{% translate 'Surveys' %}{% endblock %}
 {% block content %}
 <h1>{% translate 'Surveys' %}</h1>
+<div class="table-responsive">
 <table class="table">
 <thead><tr><th>{% translate 'Title' %}</th><th>{% translate 'State' %}</th></tr></thead>
 <tbody>
@@ -13,6 +14,7 @@
 {% endfor %}
 </tbody>
 </table>
+</div>
 {% if request.user.is_authenticated %}
 <a href="{% url 'survey:survey_edit' %}" class="btn btn-primary mt-3">{% translate 'Edit survey' %}</a>
 {% endif %}

--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -19,7 +19,8 @@
 </p>
 
 <h2 class="mt-4">{% translate 'My questions' %}</h2>
-<table class="table mb-4">
+<div class="table-responsive mb-4">
+<table class="table mb-0">
   <thead>
     <tr>
       <th>{% translate 'Question' %}</th>
@@ -44,9 +45,11 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 
 <h2>{% translate 'My answers' %}</h2>
-<table class="table">
+<div class="table-responsive">
+<table class="table mb-0">
 <thead>
   <tr>
     <th>{% translate 'Question' %}</th>
@@ -76,6 +79,7 @@
 {% endfor %}
 </tbody>
 </table>
+</div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- make all tables responsive in survey templates
- override survey table column widths on small screens

## Testing
- `DJANGO_SECRET=devsecret DJANGO_DEV_SERVER=1 python manage.py test -v 0`

------
https://chatgpt.com/codex/tasks/task_e_688b84f43a98832ea777ea3fcabcbe12