### PR TITLE
Improve mobile table layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -69,3 +69,28 @@ body {
     width: auto !important;
   }
 }
+@media (max-width: 576px) {
+  .stacked-table thead {
+    display: none;
+  }
+  .stacked-table,
+  .stacked-table tbody,
+  .stacked-table tr,
+  .stacked-table td {
+    display: block;
+    width: 100%;
+  }
+  .stacked-table tr {
+    margin-bottom: 1rem;
+    border-bottom: 1px solid var(--bs-table-border-color, #dee2e6);
+  }
+  .stacked-table td {
+    display: flex;
+    justify-content: space-between;
+  }
+  .stacked-table td::before {
+    content: attr(data-label);
+    font-weight: bold;
+    margin-right: 1rem;
+  }
+}

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -55,7 +55,7 @@
     </div>
   </div-->
   <div class="table-responsive">
-  <table class="table mb-3">
+  <table class="table mb-3 stacked-table">
     <thead>
       <tr>
         <th>{% translate 'Published' %}</th>
@@ -67,11 +67,11 @@
     </thead>
     <tbody>
       <tr>
-        <td>{{ question_stats.published|date:"Y-m-d" }}</td>
-        <td>{{ question_stats.yes }}</td>
-        <td>{{ question_stats.no }}</td>
-        <td>{{ question_stats.total }}</td>
-        <td>{{ question_stats.agree_ratio|floatformat:1 }}%</td>
+        <td data-label="{% translate 'Published' %}">{{ question_stats.published|date:"Y-m-d" }}</td>
+        <td data-label="{% translate 'Yes' %}">{{ question_stats.yes }}</td>
+        <td data-label="{% translate 'No' %}">{{ question_stats.no }}</td>
+        <td data-label="{% translate 'Total' %}">{{ question_stats.total }}</td>
+        <td data-label="{% translate 'Agree' %}">{{ question_stats.agree_ratio|floatformat:1 }}%</td>
       </tr>
     </tbody>
   </table>
@@ -84,7 +84,7 @@
   </h2>
   <div id="myAnswers" class="collapse">
   <div class="table-responsive">
-  <table class="table mb-3 survey-detail-table">
+  <table class="table mb-3 survey-detail-table stacked-table">
     <thead>
       <tr>
         <th>{% translate 'Answer date' %}</th>
@@ -97,11 +97,11 @@
     <tbody>
       {% for a in user_answers %}
       <tr data-question-id="{{ a.question.pk }}">
-        <td>{{ a.created_at|date:"Y-m-d" }}</td>
-        <td><a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a></td>
-        <td class="total-answers">{{ a.total_answers }}</td>
-        <td class="agree-ratio">{{ a.agree_ratio|floatformat:1 }}%</td>
-        <td class="text-end">
+        <td data-label="{% translate 'Answer date' %}">{{ a.created_at|date:"Y-m-d" }}</td>
+        <td data-label="{% translate 'Title' %}"><a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a></td>
+        <td class="total-answers" data-label="{% translate 'Answers' %}">{{ a.total_answers }}</td>
+        <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ a.agree_ratio|floatformat:1 }}%</td>
+        <td class="text-end" data-label="">
           {% if a.question.survey.state == 'running' %}
           <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline ajax-answer-form">
             {% csrf_token %}

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -81,7 +81,7 @@
 <p class="mt-3">{% translate 'Total respondents' %}: {{ total_users }}</p>
 <h2>{% translate 'Answer table' %}</h2>
 <div class="table-responsive">
-<table id="answerTable" class="table">
+<table id="answerTable" class="table stacked-table">
 <thead>
 <tr>
   <th>{% translate 'Published' %}</th>
@@ -98,8 +98,8 @@
 <tbody>
 {% for row in data %}
 <tr>
-  <td>{{ row.published|date:"Y-m-d" }}</td>
-  <td>
+  <td data-label="{% translate 'Published' %}">{{ row.published|date:"Y-m-d" }}</td>
+  <td data-label="{% translate 'Question' %}">
     {% if request.user.is_authenticated %}
       <a href="{% url 'survey:answer_question' row.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ row.question.text }}</a>
     {% else %}
@@ -107,12 +107,12 @@
     {% endif %}
   </td>
   {% if request.user.is_authenticated %}
-  <td>{{ row.my_answer | default:""}}</td>
+  <td data-label="{% translate 'My answer' %}">{{ row.my_answer | default:""}}</td>
   {% endif %}
-  <td>{{ row.yes }}</td>
-  <td>{{ row.no }}</td>
-  <td>{{ row.total }}</td>
-  <td>{{ row.agree_ratio|floatformat:1 }}%</td>
+  <td data-label="{% translate 'Yes' %}">{{ row.yes }}</td>
+  <td data-label="{% translate 'No' %}">{{ row.no }}</td>
+  <td data-label="{% translate 'Total' %}">{{ row.total }}</td>
+  <td data-label="{% translate 'Agree' %}">{{ row.agree_ratio|floatformat:1 }}%</td>
 </tr>
 {% endfor %}
 </tbody>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -40,7 +40,7 @@
     {% if unanswered_questions %}
         <h2 id="unanswered-header" class="mt-3">{% translate 'Unanswered questions' %}</h2>
       <div class="table-responsive">
-      <table id="unanswered-table" class="table mb-3 survey-detail-table">
+      <table id="unanswered-table" class="table mb-3 survey-detail-table stacked-table">
         <thead>
       <tr>
         <th>{% translate 'Published' %}</th>
@@ -53,15 +53,15 @@
       <tbody>
       {% for q in unanswered_questions %}
         <tr>
-        <td>{{ q.created_at | date:"Y-m-d" }}</td>
+        <td data-label="{% translate 'Published' %}">{{ q.created_at | date:"Y-m-d" }}</td>
 {% if request.user.is_authenticated %}
-        <td><a href="{% url 'survey:answer_question' q.pk %}?next={{ request.get_full_path|urlencode }}">{{ q.text }}</a></td>
+        <td data-label="{% translate 'Title' %}"><a href="{% url 'survey:answer_question' q.pk %}?next={{ request.get_full_path|urlencode }}">{{ q.text }}</a></td>
 {% else %}
-        <td>{{ q.text }}</td>
+        <td data-label="{% translate 'Title' %}">{{ q.text }}</td>
 {% endif %}
-        <td class="total-answers">{{ q.total_answers }}</td>
-        <td class="agree-ratio">{{ q.agree_ratio|floatformat:1 }}%</td>
-        <td class="text-end">
+        <td class="total-answers" data-label="{% translate 'Answers' %}">{{ q.total_answers }}</td>
+        <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ q.agree_ratio|floatformat:1 }}%</td>
+        <td class="text-end" data-label="">
           {% if request.user.is_authenticated and request.user == q.creator and q.total_answers == 0 and survey.state != 'closed' %}
           <a href="{% url 'survey:question_edit' q.pk %}" class="btn btn-sm btn-warning me-2">{% translate 'Edit' %}</a>
           <a href="{% url 'survey:question_delete' q.pk %}" class="btn btn-sm btn-danger ajax-delete-question">{% translate 'Remove question' %}</a>
@@ -77,7 +77,7 @@
 {% if user_answers %}
 <h2 class="mt-4">{% translate 'My answers' %}</h2>
 <div class="table-responsive">
-<table class="table mb-3 survey-detail-table">
+<table class="table mb-3 survey-detail-table stacked-table">
   <thead>
   <tr>
     <th>{% translate 'Published' %}</th>
@@ -90,13 +90,13 @@
   <tbody>
   {% for a in user_answers %}
     <tr>
-      <td>{{ a.question.created_at|date:"Y-m-d" }}</td>
-      <td>
+      <td data-label="{% translate 'Published' %}">{{ a.question.created_at|date:"Y-m-d" }}</td>
+      <td data-label="{% translate 'Title' %}">
         <a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a>
       </td>
-      <td class="total-answers">{{ a.total_answers }}</td>
-      <td class="agree-ratio">{{ a.agree_ratio|floatformat:1 }}%</td>
-      <td class="text-end">
+      <td class="total-answers" data-label="{% translate 'Answers' %}">{{ a.total_answers }}</td>
+      <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ a.agree_ratio|floatformat:1 }}%</td>
+      <td class="text-end" data-label="">
         {% if a.question.survey.state == 'running' %}
         <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline ajax-answer-form">
           {% csrf_token %}

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -4,13 +4,13 @@
 {% block content %}
 <h1>{% translate 'Surveys' %}</h1>
 <div class="table-responsive">
-<table class="table">
+<table class="table stacked-table">
 <thead><tr><th>{% translate 'Title' %}</th><th>{% translate 'State' %}</th></tr></thead>
 <tbody>
 {% for survey in surveys %}
-<tr><td><a href="{% url 'survey:survey_detail' %}">{{ survey.title }}</a></td><td>{{ survey.get_state_display }}</td></tr>
+<tr><td data-label="{% translate 'Title' %}"><a href="{% url 'survey:survey_detail' %}">{{ survey.title }}</a></td><td data-label="{% translate 'State' %}">{{ survey.get_state_display }}</td></tr>
 {% empty %}
-<tr><td colspan="2">{% translate 'No surveys' %}</td></tr>
+<tr><td colspan="2" data-label="">{% translate 'No surveys' %}</td></tr>
 {% endfor %}
 </tbody>
 </table>

--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -20,7 +20,7 @@
 
 <h2 class="mt-4">{% translate 'My questions' %}</h2>
 <div class="table-responsive mb-4">
-<table class="table mb-0">
+<table class="table mb-0 stacked-table">
   <thead>
     <tr>
       <th>{% translate 'Question' %}</th>
@@ -30,8 +30,8 @@
   <tbody>
   {% for question in questions %}
     <tr>
-      <td>{{ question.text }}</td>
-      <td class="text-end">
+      <td data-label="{% translate 'Question' %}">{{ question.text }}</td>
+      <td class="text-end" data-label="">
         {% if question.pk in editable_questions %}
         <a href="{% url 'survey:question_edit' question.pk %}" class="btn btn-sm btn-warning me-2">{% translate 'Edit' %}</a>
         {% endif %}
@@ -49,7 +49,7 @@
 
 <h2>{% translate 'My answers' %}</h2>
 <div class="table-responsive">
-<table class="table mb-0">
+<table class="table mb-0 stacked-table">
 <thead>
   <tr>
     <th>{% translate 'Question' %}</th>
@@ -60,15 +60,15 @@
 <tbody>
 {% for answer in answers %}
   <tr>
-    <td>
+    <td data-label="{% translate 'Question' %}">
       {% if answer.question.survey.state == 'running' %}
         <a href="{% url 'survey:answer_question' answer.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ answer.question.text }}</a>
       {% else %}
         {{ answer.question.text }}
       {% endif %}
     </td>
-    <td>{{ answer.get_answer_display }}</td>
-    <td class="text-end">
+    <td data-label="{% translate 'Answer' %}">{{ answer.get_answer_display }}</td>
+    <td class="text-end" data-label="">
       {% if answer.question.survey.state == 'running' %}
       <a href="{% url 'survey:answer_delete' answer.pk %}" class="btn btn-sm btn-danger ms-2 ajax-delete-answer" data-no-reload="true">{% translate 'Remove answer' %}</a>
       {% endif %}


### PR DESCRIPTION
## Summary
- stack table rows vertically on small screens
- add stacked-table class and data-label attributes for responsive design

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2` *(fails: SECRET_KEY setting must not be empty)*

------
https://chatgpt.com/codex/tasks/task_e_688b8c9855d4832e813bdf2feb85f650