### PR TITLE
Fix stacked table display on small screens

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -71,21 +71,21 @@ body {
 }
 @media (max-width: 576px) {
   .stacked-table thead {
-    display: none;
+    display: none !important;
   }
   .stacked-table,
   .stacked-table tbody,
   .stacked-table tr,
   .stacked-table td {
-    display: block;
-    width: 100%;
+    display: block !important;
+    width: 100% !important;
   }
   .stacked-table tr {
     margin-bottom: 1rem;
     border-bottom: 1px solid var(--bs-table-border-color, #dee2e6);
   }
   .stacked-table td {
-    display: flex;
+    display: flex !important;
     justify-content: space-between;
   }
   .stacked-table td::before {

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -277,7 +277,7 @@ class SurveyFlowTests(TransactionTestCase):
         response = self.client.get(reverse("survey:survey_answers"))
         self.assertContains(
             response,
-            "<td>Yes</td>",
+            '<td data-label="My answer">Yes</td>',
             html=True,
         )
 


### PR DESCRIPTION
## Summary
- ensure custom stacked table CSS overrides Bootstrap
- update test expectation for 'My answer' column

## Testing
- `DJANGO_SECRET=foo DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688b924eaa5c832ea966fd8dcd5e7045