### PR TITLE
Add mobile list sorting

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -94,3 +94,14 @@ body {
     margin-right: 1rem;
   }
 }
+
+.mobile-sort {
+  display: none;
+}
+@media (max-width: 800px) {
+  .mobile-sort {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+}

--- a/static/js/sort_tables.js
+++ b/static/js/sort_tables.js
@@ -1,0 +1,72 @@
+function initSortableTables(selector, defaultIndex = 0, defaultDirection = 'desc') {
+    document.querySelectorAll(selector).forEach(table => {
+        const headers = table.querySelectorAll('th');
+        if (!headers.length) return;
+        const baseTexts = Array.from(headers, h => h.textContent.trim());
+        const directions = Array.from(headers, () => null);
+        const mobileButtons = [];
+        const container = document.createElement('div');
+        container.className = 'mobile-sort mb-2';
+
+        function updateLabels() {
+            headers.forEach((h, i) => {
+                const arrow = directions[i] === 'asc' ? ' \u2191' : directions[i] === 'desc' ? ' \u2193' : '';
+                h.textContent = baseTexts[i] + arrow;
+                if (mobileButtons[i]) mobileButtons[i].textContent = baseTexts[i] + arrow;
+            });
+        }
+
+        function sortTable(index, direction) {
+            const tbody = table.tBodies[0];
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+            const multiplier = direction === 'asc' ? 1 : -1;
+            rows.sort((a, b) => {
+                const aText = a.children[index].textContent.trim();
+                const bText = b.children[index].textContent.trim();
+                const aDate = Date.parse(aText);
+                const bDate = Date.parse(bText);
+                if (!isNaN(aDate) && !isNaN(bDate)) {
+                    return (aDate - bDate) * multiplier;
+                }
+                const aNum = parseFloat(aText);
+                const bNum = parseFloat(bText);
+                if (!isNaN(aNum) && !isNaN(bNum)) {
+                    return (aNum - bNum) * multiplier;
+                }
+                return aText.localeCompare(bText, undefined, {numeric: true}) * multiplier;
+            });
+            rows.forEach(r => tbody.appendChild(r));
+        }
+
+        function toggleSort(i) {
+            const current = directions[i] === 'asc' ? 'desc' : 'asc';
+            directions.fill(null);
+            directions[i] = current;
+            updateLabels();
+            sortTable(i, current);
+        }
+
+        headers.forEach((header, i) => {
+            header.style.cursor = 'pointer';
+            header.addEventListener('click', () => toggleSort(i));
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'btn btn-outline-secondary btn-sm me-2';
+            btn.textContent = baseTexts[i];
+            btn.addEventListener('click', () => toggleSort(i));
+            container.appendChild(btn);
+            mobileButtons.push(btn);
+        });
+
+        table.parentNode.insertBefore(container, table);
+
+        if (defaultIndex < headers.length) {
+            directions[defaultIndex] = defaultDirection;
+            updateLabels();
+            sortTable(defaultIndex, defaultDirection);
+        }
+    });
+}
+if (typeof window !== 'undefined') {
+    window.initSortableTables = initSortableTables;
+}

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -127,60 +127,10 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="{% static 'js/sort_tables.js' %}"></script>
 <script>
-// Enable sorting on survey detail tables
-document.addEventListener('DOMContentLoaded', () => {
-    const tables = document.querySelectorAll('.survey-detail-table');
-    tables.forEach(table => {
-        const headers = table.querySelectorAll('th');
-        const directions = Array.from(headers, () => null);
-        const baseTexts = Array.from(headers, h => h.textContent.trim());
-
-        function clearArrows() {
-            headers.forEach((h, i) => {
-                h.textContent = baseTexts[i];
-            });
-        }
-
-        function sortTable(index, direction) {
-            const tbody = table.tBodies[0];
-            const rows = Array.from(tbody.querySelectorAll('tr'));
-            const multiplier = direction === 'asc' ? 1 : -1;
-            rows.sort((a, b) => {
-                const aText = a.children[index].textContent.trim();
-                const bText = b.children[index].textContent.trim();
-                const aDate = Date.parse(aText);
-                const bDate = Date.parse(bText);
-                if (!isNaN(aDate) && !isNaN(bDate)) {
-                    return (aDate - bDate) * multiplier;
-                }
-                const aNum = parseFloat(aText);
-                const bNum = parseFloat(bText);
-                if (!isNaN(aNum) && !isNaN(bNum)) {
-                    return (aNum - bNum) * multiplier;
-                }
-                return aText.localeCompare(bText, undefined, {numeric: true}) * multiplier;
-            });
-            rows.forEach(r => tbody.appendChild(r));
-        }
-
-        headers.forEach((header, i) => {
-            header.style.cursor = 'pointer';
-            header.addEventListener('click', () => {
-                const current = directions[i] === 'asc' ? 'desc' : 'asc';
-                directions.fill(null);
-                directions[i] = current;
-                clearArrows();
-                header.textContent = baseTexts[i] + (current === 'asc' ? ' \u2191' : ' \u2193');
-                sortTable(i, current);
-            });
-        });
-
-        // Indicate default sorting by the Answer date column
-        directions[0] = 'desc';
-        headers[0].textContent = baseTexts[0] + ' \u2193';
-        sortTable(0, 'desc');
-    });
+document.addEventListener("DOMContentLoaded", () => {
+    initSortableTables(".survey-detail-table");
 });
 </script>
 <script>

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n static %}
 {% block title %}{% translate 'Answers' %}{% endblock %}
 {% block content %}
 {% if not request.user.is_authenticated and data %}
@@ -189,59 +189,10 @@ document.querySelectorAll('input[name="chartType"]').forEach(radio => {
     });
 });
 </script>
+<script src="{% static 'js/sort_tables.js' %}"></script>
 <script>
-// Sorting for answer table
-document.addEventListener('DOMContentLoaded', () => {
-    const table = document.getElementById('answerTable');
-    if (!table) return;
-    const headers = table.querySelectorAll('th');
-    const directions = Array.from(headers, () => null);
-    const baseTexts = Array.from(headers, h => h.textContent.trim());
-
-    function clearArrows() {
-        headers.forEach((h, i) => {
-            h.textContent = baseTexts[i];
-        });
-    }
-
-    function sortTable(index, direction) {
-        const tbody = table.tBodies[0];
-        const rows = Array.from(tbody.querySelectorAll('tr'));
-        const multiplier = direction === 'asc' ? 1 : -1;
-        rows.sort((a, b) => {
-            const aText = a.children[index].textContent.trim();
-            const bText = b.children[index].textContent.trim();
-            const aDate = Date.parse(aText);
-            const bDate = Date.parse(bText);
-            if (!isNaN(aDate) && !isNaN(bDate)) {
-                return (aDate - bDate) * multiplier;
-            }
-            const aNum = parseFloat(aText);
-            const bNum = parseFloat(bText);
-            if (!isNaN(aNum) && !isNaN(bNum)) {
-                return (aNum - bNum) * multiplier;
-            }
-            return aText.localeCompare(bText, undefined, {numeric: true}) * multiplier;
-        });
-        rows.forEach(r => tbody.appendChild(r));
-    }
-
-    headers.forEach((header, i) => {
-        header.style.cursor = 'pointer';
-        header.addEventListener('click', () => {
-            const current = directions[i] === 'asc' ? 'desc' : 'asc';
-            directions.fill(null);
-            directions[i] = current;
-            clearArrows();
-            header.textContent = baseTexts[i] + (current === 'asc' ? ' \u2191' : ' \u2193');
-            sortTable(i, current);
-        });
-    });
-
-    // Indicate default sorting by the Published column
-    directions[0] = 'desc';
-    headers[0].textContent = baseTexts[0] + ' \u2193';
-    sortTable(0, 'desc');
+document.addEventListener("DOMContentLoaded", () => {
+    initSortableTables("#answerTable");
 });
 </script>
 {% endblock %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -123,60 +123,10 @@
 
 {% endblock %}
 {% block scripts %}
+<script src="{% static 'js/sort_tables.js' %}"></script>
 <script>
-// Enable sorting on survey detail tables
-document.addEventListener('DOMContentLoaded', () => {
-    const tables = document.querySelectorAll('.survey-detail-table');
-    tables.forEach(table => {
-        const headers = table.querySelectorAll('th');
-        const directions = Array.from(headers, () => null);
-        const baseTexts = Array.from(headers, h => h.textContent.trim());
-
-        function clearArrows() {
-            headers.forEach((h, i) => {
-                h.textContent = baseTexts[i];
-            });
-        }
-
-        function sortTable(index, direction) {
-            const tbody = table.tBodies[0];
-            const rows = Array.from(tbody.querySelectorAll('tr'));
-            const multiplier = direction === 'asc' ? 1 : -1;
-            rows.sort((a, b) => {
-                const aText = a.children[index].textContent.trim();
-                const bText = b.children[index].textContent.trim();
-                const aDate = Date.parse(aText);
-                const bDate = Date.parse(bText);
-                if (!isNaN(aDate) && !isNaN(bDate)) {
-                    return (aDate - bDate) * multiplier;
-                }
-                const aNum = parseFloat(aText);
-                const bNum = parseFloat(bText);
-                if (!isNaN(aNum) && !isNaN(bNum)) {
-                    return (aNum - bNum) * multiplier;
-                }
-                return aText.localeCompare(bText, undefined, {numeric: true}) * multiplier;
-            });
-            rows.forEach(r => tbody.appendChild(r));
-        }
-
-        headers.forEach((header, i) => {
-            header.style.cursor = 'pointer';
-            header.addEventListener('click', () => {
-                const current = directions[i] === 'asc' ? 'desc' : 'asc';
-                directions.fill(null);
-                directions[i] = current;
-                clearArrows();
-                header.textContent = baseTexts[i] + (current === 'asc' ? ' \u2191' : ' \u2193');
-                sortTable(i, current);
-            });
-        });
-
-        // Indicate default sorting by the Published column
-        directions[0] = 'desc';
-        headers[0].textContent = baseTexts[0] + ' \u2193';
-        sortTable(0, 'desc');
-    });
+document.addEventListener("DOMContentLoaded", () => {
+    initSortableTables(".survey-detail-table");
 });
 </script>
 <script src="{% static 'js/survey_detail_ajax.js' %}"></script>


### PR DESCRIPTION
## Summary
- add a reusable `initSortableTables` helper for sorting tables
- show sorting buttons on mobile
- load new helper from survey templates

## Testing
- `DJANGO_SECRET=devsecret DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688ba83cc548832e984cc05787ab76ff