### PR TITLE
Adjust yes/no mobile spacing

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -105,3 +105,16 @@ body {
     gap: 0.5rem;
   }
 }
+
+@media (max-width: 800px) {
+  .yes-no-group {
+    display: flex !important;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: stretch;
+  }
+  .yes-no-group > .btn,
+  .yes-no-group > label.btn {
+    width: 100%;
+  }
+}

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -19,7 +19,7 @@
     {{ field }}
   {% endfor %}
   <div class="answer-buttons mb-2" role="group" aria-label="{% translate 'Answer' %}">
-    <div class="btn-group me-2" role="group">
+    <div class="btn-group yes-no-group me-2" role="group">
       <button type="submit" name="answer" value="yes"
               class="btn {% if form.answer.value and is_edit %}{% if form.answer.value == 'yes' %}btn-success{% else %}btn-outline-success{% endif %}{% else %}btn-success{% endif %}">{% translate 'Yes' %}</button>
       <button type="submit" name="answer" value="no"
@@ -106,7 +106,7 @@
           <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline ajax-answer-form">
             {% csrf_token %}
             <input type="hidden" name="question_id" value="{{ a.question.pk }}">
-            <div class="btn-group" role="group" aria-label="{% translate 'Answer' %}">
+            <div class="btn-group yes-no-group" role="group" aria-label="{% translate 'Answer' %}">
               <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-yes" value="yes"{% if a.answer == 'yes' %} checked{% endif %}>
               <label class="btn btn-sm btn-outline-success" for="answer-{{ a.pk }}-yes">{% translate 'Yes' %}</label>
               <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-no" value="no"{% if a.answer == 'no' %} checked{% endif %}>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -101,7 +101,7 @@
         <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline ajax-answer-form">
           {% csrf_token %}
           <input type="hidden" name="question_id" value="{{ a.question.pk }}">
-          <div class="btn-group" role="group" aria-label="{% translate 'Answer' %}">
+          <div class="btn-group yes-no-group" role="group" aria-label="{% translate 'Answer' %}">
             <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-yes" value="yes"{% if a.answer == 'yes' %} checked{% endif %}>
             <label class="btn btn-sm btn-outline-success" for="answer-{{ a.pk }}-yes">{% translate 'Yes' %}</label>
             <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-no" value="no"{% if a.answer == 'no' %} checked{% endif %}>


### PR DESCRIPTION
## Summary
- add `.yes-no-group` class to yes/no button groups
- stack buttons vertically on small screens so they're easier to tap

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688bac4bffdc832e8f95b0d3e0dc1488