### PR TITLE
Keep yes/no buttons in one row

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -108,13 +108,9 @@ body {
 
 @media (max-width: 800px) {
   .yes-no-group {
-    display: flex !important;
-    flex-direction: column;
+    display: inline-flex !important;
+    flex-direction: row;
     gap: 0.5rem;
-    align-items: stretch;
-  }
-  .yes-no-group > .btn,
-  .yes-no-group > label.btn {
-    width: 100%;
+    align-items: center;
   }
 }


### PR DESCRIPTION
## Summary
- adjust `.yes-no-group` mobile styles so yes/no buttons are horizontal

## Testing
- `DJANGO_SECRET=foo DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688baf827684832ea3c89c7b01cfd7ca