### PR TITLE
Fix pie chart alignment

### DIFF
--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -63,7 +63,7 @@
 </table>
 </div>
 <div id="pieChartsContainer" style="display:none">
-  <div id="pieCharts" class="d-flex flex-wrap gap-4 mt-4">
+  <div id="pieCharts" class="d-flex flex-wrap gap-4 mt-4 justify-content-center">
 {% for row in data %}
   <div class="pie-chart text-center" data-yes="{{ row.yes }}" data-no="{{ row.no }}" data-total="{{ row.total }}">
     <canvas></canvas>


### PR DESCRIPTION
## Summary
- center pie charts on the results page

## Testing
- `DJANGO_DEV_SERVER=1 DJANGO_SECRET=devsecret python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688bc6762e64832e854dc859d98ca640