### PR TITLE
Disable sorting for empty table headers

### DIFF
--- a/static/js/sort_tables.js
+++ b/static/js/sort_tables.js
@@ -47,6 +47,10 @@ function initSortableTables(selector, defaultIndex = 0, defaultDirection = 'desc
         }
 
         headers.forEach((header, i) => {
+            if (!baseTexts[i]) {
+                mobileButtons.push(null);
+                return;
+            }
             header.style.cursor = 'pointer';
             header.addEventListener('click', () => toggleSort(i));
             const btn = document.createElement('button');
@@ -60,7 +64,7 @@ function initSortableTables(selector, defaultIndex = 0, defaultDirection = 'desc
 
         table.parentNode.insertBefore(container, table);
 
-        if (defaultIndex < headers.length) {
+        if (defaultIndex < headers.length && baseTexts[defaultIndex]) {
             directions[defaultIndex] = defaultDirection;
             updateLabels();
             sortTable(defaultIndex, defaultDirection);


### PR DESCRIPTION
## Summary
- skip adding sort behavior for table columns that have empty headers
- avoid default sorting when the target header is empty

## Testing
- `python3 manage.py test` *(fails: test_login_redirects_to_detail_when_no_unanswered, test_login_redirects_to_unanswered)*

------
https://chatgpt.com/codex/tasks/task_e_688bd6400a10832e9c02d5b856e0e37c