### PR TITLE
Add survey editor user list and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Guide is for Linux and OS X. With Windows you need to create and activate virtua
    export MEDIAWIKI_KEY="very-secret-mediawiki-key"
    export MEDIAWIKI_SECRET="very-secret-mediawiki-secret"
    export MEDIAWIKI_CALLBACK="http://127.0.0.1:8080/oauth/complete/mediawiki/"
+   export SURVEY_EDITOR_USERNAMES="user1,user2"
    export DJANGO_DEV_SERVER=1
    ```
 6. Initialize virtualenv 

--- a/wikikysely_project/settings.py
+++ b/wikikysely_project/settings.py
@@ -117,3 +117,13 @@ SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['groups']
 SOCIAL_AUTH_MEDIAWIKI_KEY = os.environ.get('MEDIAWIKI_KEY')
 SOCIAL_AUTH_MEDIAWIKI_SECRET = os.environ.get('MEDIAWIKI_SECRET')
 SOCIAL_AUTH_MEDIAWIKI_CALLBACK = os.environ.get('MEDIAWIKI_CALLBACK')
+
+# Comma separated list of Wikipedia OAuth usernames that are allowed to edit
+# survey data even if they are not the original creator. These users have the
+# same rights as the survey creator when modifying survey questions and
+# settings.
+SURVEY_EDITOR_USERNAMES = [
+    u.strip()
+    for u in os.environ.get("SURVEY_EDITOR_USERNAMES", "").split(",")
+    if u.strip()
+]


### PR DESCRIPTION
## Summary
- add `SURVEY_EDITOR_USERNAMES` setting to list extra survey editors
- centralize permission check with `is_survey_editor`
- allow users listed in the setting to manage survey content
- document new setting in README
- test survey editing as authorized user

## Testing
- `DJANGO_SECRET=tmpsecret DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688bdadc1618832eae256255a178372d