### PR TITLE
Improve logout redirect

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -477,6 +477,10 @@ msgstr "Tili poistettu."
 msgid "Account not removed because all your questions could not be deleted."
 msgstr "Tiliä ei poistettu, koska kaikkia kysymyksiäsi ei voitu poistaa."
 
+#: wikikysely_project/survey/views.py:150
+msgid "Logged out"
+msgstr "Kirjauduit ulos"
+
 #~ msgid "Start date"
 #~ msgstr "Aloituspäivä"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -477,6 +477,10 @@ msgstr "Konto borttaget."
 msgid "Account not removed because all your questions could not be deleted."
 msgstr "Konto togs inte bort eftersom alla dina frågor inte kunde tas bort."
 
+#: wikikysely_project/survey/views.py:150
+msgid "Logged out"
+msgstr "Du loggades ut"
+
 #~ msgid "Start date"
 #~ msgstr "Startdatum"
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,7 +48,7 @@
       </li>
         {% if request.user.is_authenticated %}
           <li class="nav-item"><a class="nav-link ms-3{% if request.path == userinfo_url %} active{% endif %}" href="{{ userinfo_url }}">{{ request.user.username }}</a></li>
-        <li class="nav-item"><a class="nav-link ms-3" href="{% url 'logout' %}?next={{ request.path }}">{% translate 'Logout' %}</a></li>
+        <li class="nav-item"><a class="nav-link ms-3" href="{% url 'survey_logout' %}?next={{ request.path }}">{% translate 'Logout' %}</a></li>
       {% else %}
         {% if local_login_enabled %}
         <li class="nav-item"><a class="nav-link ms-3" href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a></li>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -377,3 +377,12 @@ class SurveyFlowTests(TransactionTestCase):
         User = get_user_model()
         self.assertFalse(User.objects.filter(pk=self.user.pk).exists())
         self.assertContains(response, "Account removed.")
+
+    def test_logout_from_protected_page_redirects_to_answers(self):
+        self._create_survey()
+        url = reverse("survey:survey_edit")
+        response = self.client.get(
+            reverse("survey_logout") + f"?next={url}", follow=True
+        )
+        self.assertRedirects(response, reverse("survey:survey_answers"))
+        self.assertContains(response, "Logged out")

--- a/wikikysely_project/urls.py
+++ b/wikikysely_project/urls.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import path, include
-from wikikysely_project.survey.views import SurveyLoginView
+from wikikysely_project.survey.views import SurveyLoginView, survey_logout
 from django.views.i18n import set_language
 
 urlpatterns = [
@@ -13,6 +13,7 @@ urlpatterns += i18n_patterns(
     path('admin/', admin.site.urls),
     path('oauth/', include('social_django.urls', namespace='social')),
     path('accounts/login/', SurveyLoginView.as_view(), name='login'),
+    path('accounts/logout/', survey_logout, name='survey_logout'),
     path('accounts/', include('django.contrib.auth.urls')),
     path('', include('wikikysely_project.survey.urls')),
 )


### PR DESCRIPTION
## Summary
- add logout redirect logic when leaving protected pages
- show logout message in multiple languages
- adjust navigation to use new logout URL
- cover new behavior with a test
- revert compiled translation changes

## Testing
- `DJANGO_SECRET=foo DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_688bd8a6c3f0832eb98221571fbb6baa