### PR TITLE
Stop auto-creating initial survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Guide is for Linux and OS X. With Windows you need to create and activate virtua
    python manage.py makemigrations
    python manage.py migrate
    ```
-   The initial migration automatically creates a default survey.
+   After applying migrations open the site and create a survey.
 9. Create a superuser:
    ```bash
    python manage.py createsuperuser

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -16,6 +16,10 @@
 </table>
 </div>
 {% if request.user.is_authenticated %}
-<a href="{% url 'survey:survey_edit' %}" class="btn btn-primary mt-3">{% translate 'Edit survey' %}</a>
+  {% if surveys %}
+    <a href="{% url 'survey:survey_edit' %}" class="btn btn-primary mt-3">{% translate 'Edit survey' %}</a>
+  {% else %}
+    <a href="{% url 'survey:survey_create' %}" class="btn btn-primary mt-3">{% translate 'Create survey' %}</a>
+  {% endif %}
 {% endif %}
 {% endblock %}

--- a/wikikysely_project/survey/context_processors.py
+++ b/wikikysely_project/survey/context_processors.py
@@ -7,6 +7,8 @@ def unanswered_count(request):
     if not request.user.is_authenticated:
         return {"local_login_enabled": settings.LOCAL_LOGIN_ENABLED}
     survey = Survey.get_main_survey()
+    if survey is None:
+        return {"unanswered_count": 0, "local_login_enabled": settings.LOCAL_LOGIN_ENABLED}
     answered_ids = Answer.objects.filter(
         user=request.user,
         question__survey=survey,

--- a/wikikysely_project/survey/management/commands/create_test_data.py
+++ b/wikikysely_project/survey/management/commands/create_test_data.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from django.utils.translation import gettext_lazy as _
 import random
 
 from wikikysely_project.survey.models import Survey, Question, Answer
@@ -24,9 +25,17 @@ class Command(BaseCommand):
 
             # ensure main survey exists and has a creator
             survey = Survey.get_main_survey()
-            survey.creator = users[0]
-            survey.state = "running"
-            survey.save()
+            if survey is None:
+                survey = Survey.objects.create(
+                    title=_('Main Survey'),
+                    description='',
+                    creator=users[0],
+                    state='running',
+                )
+            else:
+                survey.creator = users[0]
+                survey.state = "running"
+                survey.save()
 
             question_texts = [
                 "Are elephants found in Asia?",

--- a/wikikysely_project/survey/models.py
+++ b/wikikysely_project/survey/models.py
@@ -19,15 +19,8 @@ class Survey(models.Model):
 
     @classmethod
     def get_main_survey(cls):
-        survey = cls.objects.filter(deleted=False).first()
-        if not survey:
-            survey = cls.objects.create(
-                title=_('Main Survey'),
-                description='',
-                creator=None,
-                state='running',
-            )
-        return survey
+        """Return the first non-deleted survey if it exists."""
+        return cls.objects.filter(deleted=False).first()
 
     def is_active(self):
         return self.state == 'running' and not self.deleted

--- a/wikikysely_project/survey/tests/test_post_migrate.py
+++ b/wikikysely_project/survey/tests/test_post_migrate.py
@@ -28,10 +28,8 @@ class PostMigrateSignalTests(TransactionTestCase):
             connection.enable_constraint_checking()
         super().tearDownClass()
 
-    def test_default_survey_created_after_migrate(self):
+    def test_no_survey_created_after_migrate(self):
         self.assertEqual(Survey.objects.count(), 0)
         config = apps.get_app_config('survey')
         post_migrate.send(sender=config, app_config=config, using='default', plan=())
-        self.assertEqual(Survey.objects.count(), 1)
-        survey = Survey.objects.first()
-        self.assertEqual(survey.state, 'running')
+        self.assertEqual(Survey.objects.count(), 0)

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -5,6 +5,7 @@ app_name = "survey"
 
 urlpatterns = [
     path("", views.survey_detail, name="survey_detail"),
+    path("survey/create/", views.survey_create, name="survey_create"),
     path("register/", views.register, name="register"),
     path("survey/edit/", views.survey_edit, name="survey_edit"),
     path("survey/answer/", views.answer_survey, name="answer_survey"),


### PR DESCRIPTION
## Summary
- avoid automatic creation of surveys
- add a view for creating a survey
- prompt logged in users to create the first survey when none exist
- update management command, context processor, tests and documentation

## Testing
- `DJANGO_SECRET=testsecret DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688c4bd4b650832e8803abeaaa6dd2d8