### PR TITLE
Display survey secretaries

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -258,6 +258,30 @@ msgstr "Poistetut kysymykset"
 msgid "Restore"
 msgstr "Palauta"
 
+#: templates/survey/survey_form.html:19
+msgid "Secretaries"
+msgstr "Sihteerit"
+
+#: templates/survey/survey_form.html:21
+msgid "No secretaries"
+msgstr "Ei sihteereitä"
+
+#: templates/survey/survey_form.html:27
+msgid "Add secretary"
+msgstr "Lisää sihteeri"
+
+#: wikikysely_project/survey/views.py:468
+msgid "Secretary added"
+msgstr "Sihteeri lisätty"
+
+#: wikikysely_project/survey/views.py:487
+msgid "Secretary removed"
+msgstr "Sihteeri poistettu"
+
+#: wikikysely_project/survey/views.py:471 wikikysely_project/survey/views.py:490
+msgid "User not found"
+msgstr "Käyttäjää ei löytynyt"
+
 #: templates/survey/survey_list.html:3 templates/survey/survey_list.html:5
 msgid "Surveys"
 msgstr "Kyselyt"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -258,6 +258,30 @@ msgstr "Borttagna frågor"
 msgid "Restore"
 msgstr "Återställ"
 
+#: templates/survey/survey_form.html:19
+msgid "Secretaries"
+msgstr "Sekreterare"
+
+#: templates/survey/survey_form.html:21
+msgid "No secretaries"
+msgstr "Inga sekreterare"
+
+#: templates/survey/survey_form.html:27
+msgid "Add secretary"
+msgstr "Lägg till sekreterare"
+
+#: wikikysely_project/survey/views.py:468
+msgid "Secretary added"
+msgstr "Sekreterare lades till"
+
+#: wikikysely_project/survey/views.py:487
+msgid "Secretary removed"
+msgstr "Sekreterare togs bort"
+
+#: wikikysely_project/survey/views.py:471 wikikysely_project/survey/views.py:490
+msgid "User not found"
+msgstr "Användare hittades inte"
+
 #: templates/survey/survey_list.html:3 templates/survey/survey_list.html:5
 msgid "Surveys"
 msgstr "Enkäter"

--- a/templates/survey/survey_form.html
+++ b/templates/survey/survey_form.html
@@ -12,6 +12,22 @@
   {% endif %}
 </form>
 {% if is_edit %}
+  <h2 class="mt-4">{% translate 'Secretaries' %}</h2>
+  <ul class="list-group mb-3">
+    {% for u in secretaries %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span>{{ u.username }}</span>
+        <a href="{% url 'survey:secretary_remove' u.pk %}" class="btn btn-sm btn-danger">{% translate 'Remove' %}</a>
+      </li>
+    {% empty %}
+      <li class="list-group-item">{% translate 'No secretaries' %}</li>
+    {% endfor %}
+  </ul>
+  <form method="post" action="{% url 'survey:secretary_add' %}" class="d-flex mb-4">
+    {% csrf_token %}
+    {{ secretary_form.username }}
+    <button type="submit" class="btn btn-secondary ms-2">{% translate 'Add secretary' %}</button>
+  </form>
   <h2 class="mt-4">{% translate 'Questions' %}</h2>
   <ul class="list-group mb-3">
     {% for q in active_questions %}

--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -22,6 +22,10 @@ class SurveyForm(BootstrapMixin, forms.ModelForm):
         fields = ['title', 'description', 'state']
 
 
+class SecretaryAddForm(BootstrapMixin, forms.Form):
+    username = forms.CharField(label=_('Username'))
+
+
 class QuestionForm(BootstrapMixin, forms.ModelForm):
     class Meta:
         model = Question

--- a/wikikysely_project/survey/models.py
+++ b/wikikysely_project/survey/models.py
@@ -14,6 +14,12 @@ class Survey(models.Model):
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=True, blank=True
     )
+    secretaries = models.ManyToManyField(
+        settings.AUTH_USER_MODEL,
+        related_name="secretary_surveys",
+        verbose_name=_("Secretaries"),
+        blank=True,
+    )
     state = models.CharField(_('State'), max_length=7, choices=STATE_CHOICES, default='paused')
     deleted = models.BooleanField(default=False)
 

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -14,6 +14,12 @@ urlpatterns = [
     path("question/<int:pk>/hide/", views.question_hide, name="question_hide"),
     path("question/<int:pk>/delete/", views.question_delete, name="question_delete"),
     path("question/<int:pk>/show/", views.question_show, name="question_show"),
+    path("secretary/add/", views.secretary_add, name="secretary_add"),
+    path(
+        "secretary/<int:user_id>/remove/",
+        views.secretary_remove,
+        name="secretary_remove",
+    ),
     path("question/<int:pk>/", views.answer_question, name="answer_question"),
     path("answer/<int:pk>/edit/", views.answer_edit, name="answer_edit"),
     path("answer/<int:pk>/delete/", views.answer_delete, name="answer_delete"),


### PR DESCRIPTION
## Summary
- add `secretaries` to Survey model
- allow secretaries to edit survey info and question visibility
- add forms and views for adding/removing secretaries
- list secretaries on edit page
- update translations
- test secretary permissions

## Testing
- `DJANGO_SECRET=abcd DJANGO_DEV_SERVER=1 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688c5293fef8832e8cfe74626d8c316e