### PR TITLE
Prevent deleting survey with questions

### DIFF
--- a/wikikysely_project/survey/models.py
+++ b/wikikysely_project/survey/models.py
@@ -36,7 +36,9 @@ class Survey(models.Model):
 
 
 class Question(models.Model):
-    survey = models.ForeignKey(Survey, related_name='questions', on_delete=models.CASCADE)
+    survey = models.ForeignKey(
+        Survey, related_name="questions", on_delete=models.PROTECT
+    )
     text = models.CharField(max_length=500)
     creator = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -2,6 +2,7 @@ from django.test import TransactionTestCase
 from django.urls import reverse
 from django.utils.translation import activate
 from django.contrib.auth import get_user_model
+from django.db.models import ProtectedError
 import json
 
 from ..models import Survey, Question, Answer
@@ -423,3 +424,9 @@ class SurveyFlowTests(TransactionTestCase):
         )
         self.assertRedirects(response, reverse("survey:survey_answers"))
         self.assertContains(response, "Logged out")
+
+    def test_cannot_delete_survey_with_questions(self):
+        survey = self._create_survey()
+        self._create_question(survey)
+        with self.assertRaises(ProtectedError):
+            survey.delete()


### PR DESCRIPTION
## Summary
- prevent deleting a survey that still has questions
- test that deleting surveys with questions raises an error

## Testing
- `DJANGO_SECRET=abc DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688c5e82cdb4832ea3f1587c77014042