### PR TITLE
Remove empty surveys when deleting user data

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -486,6 +486,20 @@ msgid_plural "Removed %(removed)d/%(total)d questions."
 msgstr[0] "Poistettu %(removed)d/%(total)d kysymys."
 msgstr[1] "Poistettu %(removed)d/%(total)d kysymystä."
 
+#: wikikysely_project/survey/views.py:934
+#, python-format
+msgid "Removed %(removed)d/%(total)d survey."
+msgid_plural "Removed %(removed)d/%(total)d surveys."
+msgstr[0] "Poistettu %(removed)d/%(total)d kysely."
+msgstr[1] "Poistettu %(removed)d/%(total)d kyselyä."
+
+#: wikikysely_project/survey/views.py:951
+#, python-format
+msgid "Could not remove %(count)d survey because it already had questions."
+msgid_plural "Could not remove %(count)d surveys because they already had questions."
+msgstr[0] "Ei voitu poistaa %(count)d kyselyä, koska siinä oli jo kysymyksiä."
+msgstr[1] "Ei voitu poistaa %(count)d kyselyä, koska niissä oli jo kysymyksiä."
+
 #: wikikysely_project/survey/views.py:791
 #, python-format
 msgid "Could not remove %(count)d question because it already had answers."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -486,6 +486,20 @@ msgid_plural "Removed %(removed)d/%(total)d questions."
 msgstr[0] "Tog bort %(removed)d/%(total)d fråga."
 msgstr[1] "Tog bort %(removed)d/%(total)d frågor."
 
+#: wikikysely_project/survey/views.py:934
+#, python-format
+msgid "Removed %(removed)d/%(total)d survey."
+msgid_plural "Removed %(removed)d/%(total)d surveys."
+msgstr[0] "Tog bort %(removed)d/%(total)d enkät."
+msgstr[1] "Tog bort %(removed)d/%(total)d enkäter."
+
+#: wikikysely_project/survey/views.py:951
+#, python-format
+msgid "Could not remove %(count)d survey because it already had questions."
+msgid_plural "Could not remove %(count)d surveys because they already had questions."
+msgstr[0] "Kunde inte ta bort %(count)d enkät eftersom den redan hade frågor."
+msgstr[1] "Kunde inte ta bort %(count)d enkäter eftersom de redan hade frågor."
+
 #: wikikysely_project/survey/views.py:791
 #, python-format
 msgid "Could not remove %(count)d question because it already had answers."

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -416,6 +416,20 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertFalse(User.objects.filter(pk=self.user.pk).exists())
         self.assertContains(response, "Account removed.")
 
+    def test_user_data_delete_removes_empty_surveys(self):
+        empty_survey = self._create_survey()
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        other = self.users[1]
+        Answer.objects.create(question=q, user=other, answer="yes")
+
+        response = self.client.post(reverse("survey:user_data_delete"), follow=True)
+        self.assertRedirects(response, reverse("survey:userinfo"))
+        self.assertFalse(Survey.objects.filter(pk=empty_survey.pk).exists())
+        self.assertTrue(Survey.objects.filter(pk=survey.pk).exists())
+        User = get_user_model()
+        self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
+
     def test_logout_from_protected_page_redirects_to_answers(self):
         self._create_survey()
         url = reverse("survey:survey_edit")


### PR DESCRIPTION
## Summary
- delete surveys created by a user that have no questions during user data removal
- show messages about removed surveys
- add tests for removing empty surveys
- update Finnish and Swedish translations
- remove compiled .mo files from the change

## Testing
- `DJANGO_SECRET=foo DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688c6200a730832ea4f54cc7f215bdb3