### PR TITLE
Redirect users with unanswered questions directly to survey

### DIFF
--- a/wikikysely_project/settings.py
+++ b/wikikysely_project/settings.py
@@ -93,9 +93,11 @@ STATICFILES_DIRS = [BASE_DIR / 'static']
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-# After logging in, redirect users to the Finnish index page instead of the
-# nonexistent ``/accounts/profile/`` path provided by Django's defaults.
-LOGIN_REDIRECT_URL = '/fi/'
+# After logging in, redirect users based on unanswered questions. ``reverse_lazy``
+# allows resolving the URL without importing the root URL configuration during
+# settings initialization.
+from django.urls import reverse_lazy
+LOGIN_REDIRECT_URL = reverse_lazy('login_redirect')
 
 from django.contrib.messages import constants as message_constants
 

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -90,6 +90,19 @@ class SurveyFlowTests(TransactionTestCase):
         )
         self.assertRedirects(response, reverse("survey:survey_detail"))
 
+    def test_login_redirect_view_to_unanswered(self):
+        survey = self._create_survey()
+        self._create_question(survey)
+        response = self.client.get(reverse("login_redirect"))
+        self.assertRedirects(response, reverse("survey:answer_survey"))
+
+    def test_login_redirect_view_to_detail_when_no_unanswered(self):
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        Answer.objects.create(question=q, user=self.user, answer="yes")
+        response = self.client.get(reverse("login_redirect"))
+        self.assertRedirects(response, reverse("survey:survey_detail"))
+
     def test_survey_edit(self):
         survey = self._create_survey()
         data = {

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -167,6 +167,11 @@ class SurveyLoginView(LoginView):
         return get_login_redirect_url(self.request)
 
 
+@login_required
+def login_redirect(request):
+    """Redirect the user after login based on unanswered questions."""
+    return redirect(get_login_redirect_url(request))
+
 def survey_logout(request):
     """Log the user out and redirect appropriately."""
     next_url = request.GET.get("next")

--- a/wikikysely_project/urls.py
+++ b/wikikysely_project/urls.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import path, include
-from wikikysely_project.survey.views import SurveyLoginView, survey_logout
+from wikikysely_project.survey.views import SurveyLoginView, survey_logout, login_redirect
 from django.views.i18n import set_language
 
 urlpatterns = [
@@ -13,6 +13,7 @@ urlpatterns += i18n_patterns(
     path('admin/', admin.site.urls),
     path('oauth/', include('social_django.urls', namespace='social')),
     path('accounts/login/', SurveyLoginView.as_view(), name='login'),
+    path('accounts/login-redirect/', login_redirect, name='login_redirect'),
     path('accounts/logout/', survey_logout, name='survey_logout'),
     path('accounts/', include('django.contrib.auth.urls')),
     path('', include('wikikysely_project.survey.urls')),


### PR DESCRIPTION
## Summary
- add `login_redirect` view to send logged-in users to unanswered questions if any remain
- expose the new view at `/accounts/login-redirect/`
- use this view as the default `LOGIN_REDIRECT_URL`
- test redirect behaviour for the new view

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688c8467d270832e83309653cb80cb74