### PR TITLE
Fix login redirect for unanswered questions

### DIFF
--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -7,9 +7,9 @@
     <p class="alert alert-info">
       {% translate 'You must be logged in to answer questions' %}.
       {% if local_login_enabled %}
-      <a href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a>
+      <a href="{% url 'login' %}?next={% url 'login_redirect' %}">{% translate 'Login' %}</a>
       {% else %}
-      <a href="{% url 'social:begin' 'mediawiki' %}?next={{ request.path }}">{% translate 'Login with Wikimedia' %}</a>
+      <a href="{% url 'social:begin' 'mediawiki' %}?next={% url 'login_redirect' %}">{% translate 'Login with Wikimedia' %}</a>
       {% endif %}
     </p>
   {% endif %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -13,9 +13,9 @@
     <p class="alert alert-info">
       {% translate 'You must be logged in to answer questions' %}.
       {% if local_login_enabled %}
-      <a href="{% url 'login' %}?next={{ request.path }}">{% translate 'Login' %}</a>
+      <a href="{% url 'login' %}?next={% url 'login_redirect' %}">{% translate 'Login' %}</a>
       {% else %}
-      <a href="{% url 'social:begin' 'mediawiki' %}?next={{ request.path }}">{% translate 'Login with Wikimedia' %}</a>
+      <a href="{% url 'social:begin' 'mediawiki' %}?next={% url 'login_redirect' %}">{% translate 'Login with Wikimedia' %}</a>
       {% endif %}
     </p>
   {% endif %}


### PR DESCRIPTION
## Summary
- redirect to login_redirect when prompting login from results or detail pages

## Testing
- `DJANGO_SECRET=testingsecret DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688c8c13a688832e8e96ba943cb6a418