### PR TITLE
Fix redirect after question deletion

### DIFF
--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -460,7 +460,15 @@ def question_delete(request, pk):
 
     next_url = request.GET.get("next") or request.META.get("HTTP_REFERER")
     if next_url:
-        return redirect(next_url)
+        from urllib.parse import urlparse
+
+        try:
+            match = resolve(urlparse(next_url).path)
+        except Resolver404:
+            match = None
+
+        if not (match and match.url_name == "question_edit" and match.kwargs.get("pk") == pk):
+            return redirect(next_url)
     return redirect("survey:survey_detail")
 
 


### PR DESCRIPTION
## Summary
- avoid redirecting back to the deleted question's edit page
- revert previous formatting changes

## Testing
- `DJANGO_SECRET=testsecret DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688c91b1b718832eb4b832ed280efc8c