### PR TITLE
Remove redirect after answer submission

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -240,11 +240,7 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(Answer.objects.count(), 1)
         answer = Answer.objects.get(question=questions[0], user=self.user)
         self.assertEqual(answer.answer, "yes")
-        self.assertRedirects(
-            response,
-            reverse("survey:answer_survey"),
-            fetch_redirect_response=False,
-        )
+        self.assertEqual(response.status_code, 200)
 
         # answer by second and third users
         for idx, user in enumerate(self.users[1:], start=1):


### PR DESCRIPTION
## Summary
- render the next question directly after submitting an answer instead of redirecting
- update tests to expect status `200` on answer submission

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688cc70ba57c832e85f379675c398c72