### PR TITLE
Update unanswered question table logic

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -127,6 +127,12 @@ document.addEventListener('DOMContentLoaded', () => {
             tr.appendChild(tdActions);
 
             tbody.appendChild(tr);
+            if (unansweredHeader.style.display === 'none') {
+              unansweredHeader.style.display = '';
+            }
+            if (unansweredTable.style.display === 'none') {
+              unansweredTable.style.display = '';
+            }
           }
         } else if (!noReload) {
           window.location.reload();

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -37,10 +37,9 @@
         <a href="?login_required=1" class="btn btn-primary">{% translate 'Answer survey' %}</a>
     {% endif %}
 {% endif %}
-    {% if unanswered_questions %}
-        <h2 id="unanswered-header" class="mt-3">{% translate 'Unanswered questions' %}</h2>
+        <h2 id="unanswered-header" class="mt-3"{% if not unanswered_questions %} style="display:none"{% endif %}>{% translate 'Unanswered questions' %}</h2>
       <div class="table-responsive">
-      <table id="unanswered-table" class="table mb-3 survey-detail-table stacked-table">
+      <table id="unanswered-table" class="table mb-3 survey-detail-table stacked-table"{% if not unanswered_questions %} style="display:none"{% endif %}>
         <thead>
       <tr>
         <th>{% translate 'Published' %}</th>
@@ -72,7 +71,6 @@
         </tbody>
       </table>
       </div>
-    {% endif %}
 
 {% if user_answers %}
 <h2 class="mt-4">{% translate 'My answers' %}</h2>


### PR DESCRIPTION
## Summary
- render the unanswered question table in survey detail even when empty
- unhide the table when the first answer is removed via AJAX

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688d0c324218832eb3934dc9acf9a2b7