### PR TITLE
Add JSON API for survey questions

### DIFF
--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -5,6 +5,7 @@ app_name = "survey"
 
 urlpatterns = [
     path("", views.survey_detail, name="survey_detail"),
+    path("questions.json", views.questions_json, name="questions_json"),
     path("survey/create/", views.survey_create, name="survey_create"),
     path("register/", views.register, name="register"),
     path("survey/edit/", views.survey_edit, name="survey_edit"),


### PR DESCRIPTION
## Summary
- provide `/questions.json` endpoint returning survey questions with statistics
- include user-specific answer data when authenticated
- cover new API with tests for anonymous and logged-in users

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688dc6110bb4832eab31e936c1e6755f