### PR TITLE
Load survey questions via JSON API on client

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
 
-  document.querySelectorAll('form.ajax-answer-form').forEach(form => {
+  function attachAnswerForm(form) {
     form.addEventListener('change', event => {
       if (event.target.name !== 'answer') return;
       const formData = new FormData(form);
@@ -51,7 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }).catch(() => window.location.reload());
     });
-  });
+  }
 
   function attachDeleteAnswer(link) {
     link.addEventListener('click', ev => {
@@ -141,6 +141,187 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  document.querySelectorAll('a.ajax-delete-answer').forEach(attachDeleteAnswer);
-  document.querySelectorAll('a.ajax-delete-question').forEach(attachDeleteQuestion);
+  function buildTables(data) {
+    const questions = data.questions || [];
+    const unansweredHeader = document.getElementById('unanswered-header');
+    const unansweredTable = document.getElementById('unanswered-table');
+    const unansweredBody = unansweredTable ? unansweredTable.tBodies[0] : null;
+    const answersHeader = document.getElementById('my-answers-header');
+    const answersTable = document.getElementById('my-answers-table');
+    const answersBody = answersTable ? answersTable.tBodies[0] : null;
+    let unansweredCount = 0;
+
+    questions.forEach(q => {
+      if (!unansweredBody || !answersBody) return;
+      if (q.user_answer) {
+        const tr = document.createElement('tr');
+        tr.dataset.questionId = q.id;
+
+        const tdPublished = document.createElement('td');
+        tdPublished.setAttribute('data-label', LABEL_PUBLISHED);
+        tdPublished.textContent = q.published;
+        tr.appendChild(tdPublished);
+
+        const tdTitle = document.createElement('td');
+        tdTitle.setAttribute('data-label', LABEL_TITLE);
+        const titleLink = document.createElement('a');
+        const nextParam = encodeURIComponent(window.location.pathname + window.location.search);
+        titleLink.href = `${q.answer_url}?next=${nextParam}`;
+        titleLink.textContent = q.text;
+        tdTitle.appendChild(titleLink);
+        tr.appendChild(tdTitle);
+
+        const tdTotal = document.createElement('td');
+        tdTotal.className = 'total-answers';
+        tdTotal.setAttribute('data-label', LABEL_ANSWERS);
+        tdTotal.textContent = q.total_answers;
+        tr.appendChild(tdTotal);
+
+        const tdRatio = document.createElement('td');
+        tdRatio.className = 'agree-ratio';
+        tdRatio.setAttribute('data-label', LABEL_AGREE);
+        tdRatio.textContent = `${q.agree_ratio.toFixed ? q.agree_ratio.toFixed(1) : q.agree_ratio}%`;
+        tr.appendChild(tdRatio);
+
+        const tdActions = document.createElement('td');
+        tdActions.className = 'text-end';
+        if (SURVEY_STATE === 'running') {
+          const form = document.createElement('form');
+          form.method = 'post';
+          form.action = q.answer_edit_url;
+          form.className = 'd-inline ajax-answer-form';
+
+          const qInput = document.createElement('input');
+          qInput.type = 'hidden';
+          qInput.name = 'question_id';
+          qInput.value = q.id;
+          form.appendChild(qInput);
+
+          const group = document.createElement('div');
+          group.className = 'btn-group yes-no-group';
+          group.setAttribute('role', 'group');
+          group.setAttribute('aria-label', LABEL_ANSWER);
+
+          const yesInput = document.createElement('input');
+          yesInput.type = 'radio';
+          yesInput.className = 'btn-check';
+          yesInput.name = 'answer';
+          yesInput.id = `answer-${q.answer_id}-yes`;
+          yesInput.value = 'yes';
+          if (q.user_answer === 'yes') yesInput.checked = true;
+          const yesLabel = document.createElement('label');
+          yesLabel.className = 'btn btn-sm btn-outline-success';
+          yesLabel.setAttribute('for', `answer-${q.answer_id}-yes`);
+          yesLabel.textContent = LABEL_YES;
+
+          const noInput = document.createElement('input');
+          noInput.type = 'radio';
+          noInput.className = 'btn-check';
+          noInput.name = 'answer';
+          noInput.id = `answer-${q.answer_id}-no`;
+          noInput.value = 'no';
+          if (q.user_answer === 'no') noInput.checked = true;
+          const noLabel = document.createElement('label');
+          noLabel.className = 'btn btn-sm btn-outline-danger';
+          noLabel.setAttribute('for', `answer-${q.answer_id}-no`);
+          noLabel.textContent = LABEL_NO;
+
+          group.appendChild(yesInput);
+          group.appendChild(yesLabel);
+          group.appendChild(noInput);
+          group.appendChild(noLabel);
+          form.appendChild(group);
+          attachAnswerForm(form);
+          tdActions.appendChild(form);
+
+          const delLink = document.createElement('a');
+          delLink.href = q.answer_delete_url;
+          delLink.className = 'btn btn-sm btn-danger ms-2 ajax-delete-answer';
+          delLink.textContent = LABEL_REMOVE_ANSWER;
+          delLink.dataset.questionId = q.id;
+          tdActions.appendChild(delLink);
+          attachDeleteAnswer(delLink);
+        }
+        tr.appendChild(tdActions);
+        answersBody.appendChild(tr);
+      } else {
+        unansweredCount += 1;
+        const tr = document.createElement('tr');
+        tr.dataset.questionId = q.id;
+
+        const tdPublished = document.createElement('td');
+        tdPublished.setAttribute('data-label', LABEL_PUBLISHED);
+        tdPublished.textContent = q.published;
+        tr.appendChild(tdPublished);
+
+        const tdTitle = document.createElement('td');
+        tdTitle.setAttribute('data-label', LABEL_TITLE);
+        if (IS_AUTHENTICATED) {
+          const link = document.createElement('a');
+          const nextParam = encodeURIComponent(window.location.pathname + window.location.search);
+          link.href = `${q.answer_url}?next=${nextParam}`;
+          link.textContent = q.text;
+          tdTitle.appendChild(link);
+        } else {
+          tdTitle.textContent = q.text;
+        }
+        tr.appendChild(tdTitle);
+
+        const tdTotal = document.createElement('td');
+        tdTotal.className = 'total-answers';
+        tdTotal.setAttribute('data-label', LABEL_ANSWERS);
+        tdTotal.textContent = q.total_answers;
+        tr.appendChild(tdTotal);
+
+        const tdRatio = document.createElement('td');
+        tdRatio.className = 'agree-ratio';
+        tdRatio.setAttribute('data-label', LABEL_AGREE);
+        tdRatio.textContent = `${q.agree_ratio.toFixed ? q.agree_ratio.toFixed(1) : q.agree_ratio}%`;
+        tr.appendChild(tdRatio);
+
+        const tdActions = document.createElement('td');
+        tdActions.className = 'text-end';
+        if (q.can_edit) {
+          const editLink = document.createElement('a');
+          editLink.href = q.edit_url;
+          editLink.className = 'btn btn-sm btn-warning me-2';
+          editLink.textContent = LABEL_EDIT;
+          tdActions.appendChild(editLink);
+
+          const delLink = document.createElement('a');
+          delLink.href = q.delete_url;
+          delLink.className = 'btn btn-sm btn-danger ajax-delete-question';
+          delLink.textContent = LABEL_REMOVE_QUESTION;
+          tdActions.appendChild(delLink);
+          attachDeleteQuestion(delLink);
+        }
+        tr.appendChild(tdActions);
+        unansweredBody.appendChild(tr);
+      }
+    });
+
+    if (unansweredCount > 0) {
+      if (unansweredHeader) unansweredHeader.style.display = '';
+      if (unansweredTable) unansweredTable.style.display = '';
+      const ansBtn = document.getElementById('answer-survey-btn');
+      if (ansBtn) ansBtn.style.display = '';
+    } else if (questions.length > 0) {
+      const answersBtn = document.getElementById('survey-answers-btn');
+      if (answersBtn) answersBtn.style.display = '';
+    }
+
+    if (answersBody && answersBody.children.length > 0) {
+      if (answersHeader) answersHeader.style.display = '';
+      if (answersTable) answersTable.style.display = '';
+    }
+
+    if (typeof initSortableTables === 'function') {
+      initSortableTables('.survey-detail-table');
+    }
+  }
+
+  fetch(QUESTIONS_API_URL, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+    .then(resp => resp.ok ? resp.json() : Promise.reject())
+    .then(buildTables)
+    .catch(() => {});
 });

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -5,10 +5,7 @@
 {% if survey.state == 'paused' %}
   <div class="alert alert-info">{% translate 'This survey is currently paused.' %}</div>
 {% endif %}
-{% if not questions %}
-  <p class="alert alert-warning">{% translate 'This survey has no questions yet. Please add questions.' %}</p>
-{% endif %}
-{% if not request.user.is_authenticated and questions %}
+{% if not request.user.is_authenticated %}
   {% if request.GET.login_required %}
     <p class="alert alert-info">
       {% translate 'You must be logged in to answer questions' %}.
@@ -23,24 +20,18 @@
 <p>{{ survey.description }}</p>
 {% if request.user.is_authenticated %}
   <div class="mb-3">
-    {% if unanswered_questions and survey.state == 'running' %}
-      <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary">{% translate 'Answer survey' %}</a>
-    {% else %}
-      {% if questions %}
-        <a href="{% url 'survey:survey_answers' %}" class="btn btn-info">{% translate 'Answers' %}</a>
-      {% endif %}
-    {% endif %}
+    <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary" id="answer-survey-btn" style="display:none">{% translate 'Answer survey' %}</a>
+    <a href="{% url 'survey:survey_answers' %}" class="btn btn-info" id="survey-answers-btn" style="display:none">{% translate 'Answers' %}</a>
     <a href="{% url 'survey:question_add' %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
   </div>
 {% else %}
-    {% if questions %}
-        <a href="?login_required=1" class="btn btn-primary">{% translate 'Answer survey' %}</a>
-    {% endif %}
+    <a href="?login_required=1" class="btn btn-primary" id="answer-survey-btn" style="display:none">{% translate 'Answer survey' %}</a>
 {% endif %}
-        <h2 id="unanswered-header" class="mt-3"{% if not unanswered_questions %} style="display:none"{% endif %}>{% translate 'Unanswered questions' %}</h2>
-      <div class="table-responsive">
-      <table id="unanswered-table" class="table mb-3 survey-detail-table stacked-table"{% if not unanswered_questions %} style="display:none"{% endif %}>
-        <thead>
+
+<h2 id="unanswered-header" class="mt-3" style="display:none">{% translate 'Unanswered questions' %}</h2>
+<div class="table-responsive">
+  <table id="unanswered-table" class="table mb-3 survey-detail-table stacked-table" style="display:none">
+    <thead>
       <tr>
         <th>{% translate 'Published' %}</th>
         <th>{% translate 'Title' %}</th>
@@ -48,84 +39,47 @@
         <th>{% translate 'Agree' %}</th>
         <th></th>
       </tr>
-      </thead>
-      <tbody>
-      {% for q in unanswered_questions %}
-        <tr>
-        <td data-label="{% translate 'Published' %}">{{ q.created_at | date:"Y-m-d" }}</td>
-{% if request.user.is_authenticated %}
-        <td data-label="{% translate 'Title' %}"><a href="{% url 'survey:answer_question' q.pk %}?next={{ request.get_full_path|urlencode }}">{{ q.text }}</a></td>
-{% else %}
-        <td data-label="{% translate 'Title' %}">{{ q.text }}</td>
-{% endif %}
-        <td class="total-answers" data-label="{% translate 'Answers' %}">{{ q.total_answers }}</td>
-        <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ q.agree_ratio|floatformat:1 }}%</td>
-        <td class="text-end" data-label="">
-          {% if request.user.is_authenticated and request.user == q.creator and q.total_answers == 0 and survey.state != 'closed' %}
-          <a href="{% url 'survey:question_edit' q.pk %}" class="btn btn-sm btn-warning me-2">{% translate 'Edit' %}</a>
-          <a href="{% url 'survey:question_delete' q.pk %}" class="btn btn-sm btn-danger ajax-delete-question">{% translate 'Remove question' %}</a>
-          {% endif %}
-        </td>
-        </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-      </div>
-
-{% if user_answers %}
-<h2 class="mt-4">{% translate 'My answers' %}</h2>
-<div class="table-responsive">
-<table class="table mb-3 survey-detail-table stacked-table">
-  <thead>
-  <tr>
-    <th>{% translate 'Published' %}</th>
-    <th>{% translate 'Title' %}</th>
-    <th>{% translate 'Answers' %}</th>
-    <th>{% translate 'Agree' %}</th>
-    <th></th>
-  </tr>
-  </thead>
-  <tbody>
-  {% for a in user_answers %}
-    <tr>
-      <td data-label="{% translate 'Published' %}">{{ a.question.created_at|date:"Y-m-d" }}</td>
-      <td data-label="{% translate 'Title' %}">
-        <a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a>
-      </td>
-      <td class="total-answers" data-label="{% translate 'Answers' %}">{{ a.total_answers }}</td>
-      <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ a.agree_ratio|floatformat:1 }}%</td>
-      <td class="text-end" data-label="">
-        {% if a.question.survey.state == 'running' %}
-        <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline ajax-answer-form">
-          {% csrf_token %}
-          <input type="hidden" name="question_id" value="{{ a.question.pk }}">
-          <div class="btn-group yes-no-group" role="group" aria-label="{% translate 'Answer' %}">
-            <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-yes" value="yes"{% if a.answer == 'yes' %} checked{% endif %}>
-            <label class="btn btn-sm btn-outline-success" for="answer-{{ a.pk }}-yes">{% translate 'Yes' %}</label>
-            <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-no" value="no"{% if a.answer == 'no' %} checked{% endif %}>
-            <label class="btn btn-sm btn-outline-danger" for="answer-{{ a.pk }}-no">{% translate 'No' %}</label>
-          </div>
-        </form>
-        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ms-2 ajax-delete-answer">{% translate 'Remove answer' %}</a>
-        {% endif %}
-      </td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
+    </thead>
+    <tbody></tbody>
+  </table>
 </div>
-{% endif %}
+
+<h2 id="my-answers-header" class="mt-4" style="display:none">{% translate 'My answers' %}</h2>
+<div class="table-responsive">
+  <table id="my-answers-table" class="table mb-3 survey-detail-table stacked-table" style="display:none">
+    <thead>
+      <tr>
+        <th>{% translate 'Published' %}</th>
+        <th>{% translate 'Title' %}</th>
+        <th>{% translate 'Answers' %}</th>
+        <th>{% translate 'Agree' %}</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</div>
 {% if can_edit %}
    <a href="{% url 'survey:survey_edit' %}" class="btn btn-warning ms-2">{% translate 'Edit survey' %}</a>
 {% endif %}
 
 {% endblock %}
 {% block scripts %}
-<script src="{% static 'js/sort_tables.js' %}"></script>
 <script>
-document.addEventListener("DOMContentLoaded", () => {
-    initSortableTables(".survey-detail-table");
-});
+var QUESTIONS_API_URL = "{% url 'survey:questions_api' %}";
+var IS_AUTHENTICATED = {% if request.user.is_authenticated %}true{% else %}false{% endif %};
+var SURVEY_STATE = "{{ survey.state }}";
+var LABEL_PUBLISHED = "{% translate 'Published' %}";
+var LABEL_TITLE = "{% translate 'Title' %}";
+var LABEL_ANSWERS = "{% translate 'Answers' %}";
+var LABEL_AGREE = "{% translate 'Agree' %}";
+var LABEL_YES = "{% translate 'Yes' %}";
+var LABEL_NO = "{% translate 'No' %}";
+var LABEL_EDIT = "{% translate 'Edit' %}";
+var LABEL_REMOVE_QUESTION = "{% translate 'Remove question' %}";
+var LABEL_REMOVE_ANSWER = "{% translate 'Remove answer' %}";
+var LABEL_ANSWER = "{% translate 'Answer' %}";
 </script>
+<script src="{% static 'js/sort_tables.js' %}"></script>
 <script src="{% static 'js/survey_detail_ajax.js' %}"></script>
 {% endblock %}

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -5,6 +5,7 @@ app_name = "survey"
 
 urlpatterns = [
     path("", views.survey_detail, name="survey_detail"),
+    path("api/questions/", views.questions_api, name="questions_api"),
     path("survey/create/", views.survey_create, name="survey_create"),
     path("register/", views.register, name="register"),
     path("survey/edit/", views.survey_edit, name="survey_edit"),


### PR DESCRIPTION
## Summary
- Render survey detail question lists in the browser using a new JSON API
- Add endpoint to expose question data and user answers as JSON
- Simplify survey detail view and template to fetch question data client-side

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688dc9ed929c832eb54c099d0cfeec5b