### PR TITLE
Make answer count reactive in navbar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -24,11 +24,14 @@
       {% url 'survey:userinfo' as userinfo_url %}
       <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
-        {% if unanswered_count %}
-        <li class="nav-item"><a class="nav-link{% if request.path == answer_survey_url %} active{% endif %}" href="{{ answer_survey_url }}">{% translate 'Answer survey' %} (<span id="unanswered-count">{{ unanswered_count }}</span>)</a></li>
-        {% else %}
-        <li class="nav-item"><span class="nav-link text-secondary">{% translate 'Answer survey' %}{% if request.user.is_authenticated %}(<span id="unanswered-count">0</span>){% endif %}</span></li>
-        {% endif %}
+        <li id="nav-answer-app" class="nav-item"
+            data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}"
+            data-answer-url="{{ answer_survey_url }}"
+            data-is-active="{% if request.path == answer_survey_url %}true{% else %}false{% endif %}">
+          {% translate 'Answer survey' as answer_label %}
+          <a v-if="count > 0" class="nav-link" :class="{ active: isActive }" :href="answerUrl">{{ answer_label }} (<span id="unanswered-count">[[ count ]]</span>)</a>
+          <span v-else class="nav-link text-secondary">{{ answer_label }}<template v-if="auth">(<span id="unanswered-count">[[ count ]]</span>)</template></span>
+        </li>
         <li class="nav-item"><a class="nav-link{% if request.path == survey_answers_url %} active{% endif %}" href="{{ survey_answers_url }}">{% translate 'Answers' %}</a></li>
       </ul>
       <ul id="userbar" class="navbar-nav ms-auto">
@@ -81,6 +84,9 @@
 </footer>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+<script>
+  window.unansweredCount = {{ unanswered_count|default:0 }};
+</script>
 <script src="{% static 'js/langswitch.js' %}"></script>
 {% block scripts %}{% endblock %}
 </body>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -18,30 +18,23 @@
   {% endif %}
 {% endif %}
 <p>{{ survey.description }}</p>
-{% if request.user.is_authenticated %}
-  <div class="mb-3">
-    {% if unanswered_questions and survey.state == 'running' %}
-      <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary">{% translate 'Answer survey' %}</a>
-    {% else %}
-      {% if questions %}
-        <a href="{% url 'survey:survey_answers' %}" class="btn btn-info">{% translate 'Answers' %}</a>
-      {% endif %}
-    {% endif %}
-    <a href="{% url 'survey:question_add' %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
-  </div>
-{% else %}
-    {% if questions %}
-        <a href="?login_required=1" class="btn btn-primary">{% translate 'Answer survey' %}</a>
-    {% endif %}
-{% endif %}
 <div id="survey-detail-app"
      data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}"
      data-answer-url-template="{% url 'survey:answer_question' 0 %}"
      data-answer-edit-url-template="{% url 'survey:answer_edit' 0 %}"
      data-answer-delete-url-template="{% url 'survey:answer_delete' 0 %}"
-     data-running="{% if survey.state == 'running' %}true{% else %}false{% endif %}">
+     data-running="{% if survey.state == 'running' %}true{% else %}false{% endif %}"
+     data-answer-survey-url="{% url 'survey:answer_survey' %}">
   <p v-if="loading">{% translate 'Loading...' %}</p>
   <template v-else>
+    <div class="mb-3" v-if="isAuthenticated">
+      <a v-if="unansweredQuestions.length && isRunning" :href="answerSurveyUrl" class="btn btn-primary">{% translate 'Answer survey' %}</a>
+      <a v-else-if="questions.length" href="{% url 'survey:survey_answers' %}" class="btn btn-info">{% translate 'Answers' %}</a>
+      <a href="{% url 'survey:question_add' %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
+    </div>
+    <div class="mb-3" v-else>
+      <a v-if="questions.length" href="?login_required=1" class="btn btn-primary">{% translate 'Answer survey' %}</a>
+    </div>
     <h2 class="mt-3" v-if="unansweredQuestions.length">{% translate 'Unanswered questions' %}</h2>
     <div class="table-responsive" v-if="unansweredQuestions.length">
       <table class="table mb-3 survey-detail-table stacked-table">


### PR DESCRIPTION
## Summary
- render "Answer survey" navbar link using Vue and track unanswered question count
- toggle survey detail "Answer survey" button reactively when questions change
- update Vue app to share unanswered count with navbar

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688df6ec5f80832ebfd3e815d52ee035