### PR TITLE
Use Vue for in-page answering

### DIFF
--- a/static/js/survey_detail_vue.js
+++ b/static/js/survey_detail_vue.js
@@ -160,7 +160,15 @@ const app = createApp({
 });
 
 app.config.compilerOptions.delimiters = ['[[', ']]'];
-app.mount('#survey-detail-app');
+const surveyApp = app.mount('#survey-detail-app');
+
+window.openFirstQuestion = () => {
+  if (surveyApp && surveyApp.unansweredQuestions.length) {
+    surveyApp.openQuestion(surveyApp.unansweredQuestions[0]);
+  } else if (surveyApp && surveyApp.answerSurveyUrl) {
+    window.location.href = surveyApp.answerSurveyUrl;
+  }
+};
 
 const navRoot = document.getElementById('nav-answer-app');
 if (navRoot) {
@@ -170,7 +178,14 @@ if (navRoot) {
       const auth = navRoot.dataset.auth === 'true';
       const answerUrl = navRoot.dataset.answerUrl;
       const isActive = navRoot.dataset.isActive === 'true';
-      return { count, auth, answerUrl, isActive };
+      function openFirstQuestion() {
+        if (typeof window.openFirstQuestion === 'function') {
+          window.openFirstQuestion();
+        } else {
+          window.location.href = answerUrl;
+        }
+      }
+      return { count, auth, answerUrl, isActive, openFirstQuestion };
     }
   });
   navApp.config.compilerOptions.delimiters = ['[[', ']]'];

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,10 +26,10 @@
         <li class="nav-item"><a class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
         <li id="nav-answer-app" class="nav-item"
             data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}"
-            data-answer-url="{{ answer_survey_url }}"
-            data-is-active="{% if request.path == answer_survey_url %}true{% else %}false{% endif %}">
+            data-answer-url="{{ survey_detail_url }}"
+            data-is-active="{% if request.path == survey_detail_url %}true{% else %}false{% endif %}">
           {% translate 'Answer survey' as answer_label %}
-          <a v-if="count > 0" class="nav-link" :class="{ active: isActive }" :href="answerUrl">{{ answer_label }} (<span id="unanswered-count">[[ count ]]</span>)</a>
+          <a v-if="count > 0" class="nav-link" :class="{ active: isActive }" :href="answerUrl" @click.prevent="openFirstQuestion">{{ answer_label }} (<span id="unanswered-count">[[ count ]]</span>)</a>
           <span v-else class="nav-link text-secondary">{{ answer_label }}<template v-if="auth">(<span id="unanswered-count">[[ count ]]</span>)</template></span>
         </li>
         <li class="nav-item"><a class="nav-link{% if request.path == survey_answers_url %} active{% endif %}" href="{{ survey_answers_url }}">{% translate 'Answers' %}</a></li>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -25,12 +25,12 @@
      data-answer-delete-url-template="{% url 'survey:answer_delete' 0 %}"
      data-question-edit-url-template="{% url 'survey:question_edit' 0 %}"
      data-running="{% if survey.state == 'running' %}true{% else %}false{% endif %}"
-     data-answer-survey-url="{% url 'survey:answer_survey' %}">
+     data-answer-survey-url="{% url 'survey:survey_detail' %}">
   <p v-if="loading">{% translate 'Loading...' %}</p>
   <template v-else>
     <div v-if="!currentQuestion">
       <div class="mb-3" v-if="isAuthenticated">
-        <a v-if="unansweredQuestions.length && isRunning" :href="answerSurveyUrl" class="btn btn-primary">{% translate 'Answer survey' %}</a>
+        <a v-if="unansweredQuestions.length && isRunning" :href="answerSurveyUrl" class="btn btn-primary" @click.prevent="openQuestion(unansweredQuestions[0])">{% translate 'Answer survey' %}</a>
         <a v-else-if="questions.length" href="{% url 'survey:survey_answers' %}" class="btn btn-info">{% translate 'Answers' %}</a>
         <a href="{% url 'survey:question_add' %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
       </div>


### PR DESCRIPTION
## Summary
- Open the first unanswered question with Vue when clicking the navbar answer link
- Trigger Vue answering from the survey page's "Answer survey" button without reloading
- Expose a global helper so other pages can invoke the Vue answer view and fall back gracefully

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688e064d8748832e9ad40bbea2b34c2b