### PR TITLE
Ensure answer editing returns to origin

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -98,7 +98,7 @@
       {% for a in user_answers %}
       <tr data-question-id="{{ a.question.pk }}">
         <td data-label="{% translate 'Answer date' %}">{{ a.created_at|date:"Y-m-d" }}</td>
-        <td data-label="{% translate 'Title' %}"><a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a></td>
+        <td data-label="{% translate 'Title' %}"><a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a></td>
         <td class="total-answers" data-label="{% translate 'Answers' %}">{{ a.total_answers }}</td>
         <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ a.agree_ratio|floatformat:1 }}%</td>
         <td class="text-end" data-label="">

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -740,20 +740,21 @@ def answer_question(request, pk):
                         }
                     )
 
-                if answer is not None and next_url:
-                    from urllib.parse import urlparse
-                    print(next_url)
-
-                    if urlparse(next_url).path != request.path:
-                        print("REDIRECT")
+                if answer is not None:
+                    if next_url:
                         return redirect(next_url)
+                    return redirect(request.path)
 
                 answered_questions = Answer.objects.filter(
                     user=request.user, question__survey=survey
                 ).values_list("question_id", flat=True)
-                question = survey.questions.filter(visible=True).exclude(
-                    id__in=answered_questions
-                ).exclude(id=question.pk).order_by('?').first()
+                question = (
+                    survey.questions.filter(visible=True)
+                    .exclude(id__in=answered_questions)
+                    .exclude(id=question.pk)
+                    .order_by("?")
+                    .first()
+                )
 
                 if not question:
                     messages.info(request, _("No more questions"))


### PR DESCRIPTION
## Summary
- When editing an answer, redirect back to the originating view
- Move to a new question only when answering a previously unanswered one
- Preserve navigation context when opening edits from the answer page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688e09372fe4832eaa93bf8da454c4b8