### PR TITLE
Add API endpoints for answer operations

### DIFF
--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -24,6 +24,16 @@ urlpatterns = [
     path("question/<int:pk>/", views.answer_question, name="answer_question"),
     path("answer/<int:pk>/edit/", views.answer_edit, name="answer_edit"),
     path("answer/<int:pk>/delete/", views.answer_delete, name="answer_delete"),
+    path(
+        "api/question/<int:pk>/answer/",
+        views.api_answer_question,
+        name="api_answer_question",
+    ),
+    path(
+        "api/answer/<int:pk>/delete/",
+        views.api_answer_delete,
+        name="api_answer_delete",
+    ),
     path("my_answers/", views.userinfo, name="userinfo"),
     path("my_answers/download/", views.userinfo_download, name="userinfo_download"),
     path("my_answers/delete_data/", views.user_data_delete, name="user_data_delete"),


### PR DESCRIPTION
## Summary
- add JSON API endpoints to answer and delete a question
- return next unanswered question details from the answer endpoint
- wire updated API tests

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e1ada5188832ebcd53a066d763127