### PR TITLE
Replace back link with button and add translations

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -87,6 +87,10 @@ msgstr "Poista kysymys"
 msgid "Skip"
 msgstr "Ohita"
 
+#: templates/survey/survey_detail.html:131
+msgid "Back"
+msgstr "Takaisin"
+
 #: templates/survey/answer_list.html:7
 msgid "My questions"
 msgstr "Omat kysymykset"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -87,6 +87,10 @@ msgstr "Ta bort fråga"
 msgid "Skip"
 msgstr "Hoppa över"
 
+#: templates/survey/survey_detail.html:131
+msgid "Back"
+msgstr "Tillbaka"
+
 #: templates/survey/answer_list.html:7
 msgid "My questions"
 msgstr "Mina frågor"

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -128,7 +128,7 @@
               <template v-else>
                 <button class="btn btn-secondary" @click="submitAnswer('')">{% translate 'Skip' %}</button>
               </template>
-              <button class="btn btn-link" @click="closeQuestion">{% translate 'Back' %}</button>
+              <button class="btn btn-secondary" @click="closeQuestion">{% translate 'Back' %}</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Use a secondary button for the Back action in the survey answer view
- Provide Finnish and Swedish translations for the Back label
- Exclude compiled translation files from the change

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e462033cc832ea26e17cb024f4550