### PR TITLE
Add yes/no controls to answer view my answers list

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -165,6 +165,7 @@
               <th>{% translate 'Title' %}</th>
               <th>{% translate 'Answers' %}</th>
               <th>{% translate 'Agree' %}</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -173,6 +174,20 @@
               <td data-label="{% translate 'Title' %}"><a :href="answerUrl(a.id)" @click.prevent="openQuestion(a)">[[ a.text ]]</a></td>
               <td class="total-answers" data-label="{% translate 'Answers' %}">[[ a.total_answers ]]</td>
               <td class="agree-ratio" data-label="{% translate 'Agree' %}">[[ a.agree_ratio.toFixed(1) ]]%</td>
+              <td class="text-end">
+                <template v-if="isRunning">
+                  <form class="d-inline" @change="updateAnswer(a)">
+                    <input type="hidden" name="question_id" :value="a.id">
+                    <div class="btn-group yes-no-group" role="group">
+                      <input type="radio" class="btn-check" :name="'answer-' + a.id" :id="'answer-' + a.id + '-yes'" value="yes" v-model="a.my_answer">
+                      <label class="btn btn-sm btn-outline-success" :for="'answer-' + a.id + '-yes'">{% translate 'Yes' %}</label>
+                      <input type="radio" class="btn-check" :name="'answer-' + a.id" :id="'answer-' + a.id + '-no'" value="no" v-model="a.my_answer">
+                      <label class="btn btn-sm btn-outline-danger" :for="'answer-' + a.id + '-no'">{% translate 'No' %}</label>
+                    </div>
+                  </form>
+                  <a :href="deleteUrl(a.my_answer_id)" class="btn btn-sm btn-danger ms-2" @click.prevent="deleteAnswer(a)">{% translate 'Remove answer' %}</a>
+                </template>
+              </td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- Show yes/no radio buttons and remove-answer button in answer view's "My answers" table so users can adjust or delete responses

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e5a1e0c54832ead731d829ce95955