### PR TITLE
Add summary charts to answers page

### DIFF
--- a/static/js/survey_answers_vue.js
+++ b/static/js/survey_answers_vue.js
@@ -11,12 +11,55 @@ function mountAnswersApp() {
   const wikitextUrl = root.dataset.wikitextUrl;
   const auth = root.dataset.auth === 'true';
   const answerUrlTemplate = root.dataset.answerUrlTemplate;
+  const yesLabel = root.dataset.yesLabel;
+  const noLabel = root.dataset.noLabel;
 
   const app = createApp({
     setup() {
       const rows = ref([]);
       const totalUsers = ref(0);
       const loading = ref(true);
+      const pieChart = ref(null);
+      const barChart = ref(null);
+
+      function renderCharts() {
+        if (typeof Chart === 'undefined') return;
+        const yesTotal = rows.value.reduce((sum, r) => sum + r.yes, 0);
+        const noTotal = rows.value.reduce((sum, r) => sum + r.no, 0);
+        const pieCtx = document.getElementById('answerPieChart');
+        if (pieCtx) {
+          if (pieChart.value) pieChart.value.destroy();
+          pieChart.value = new Chart(pieCtx, {
+            type: 'pie',
+            data: {
+              labels: [yesLabel, noLabel],
+              datasets: [{
+                data: [yesTotal, noTotal],
+                backgroundColor: ['#198754', '#dc3545']
+              }]
+            }
+          });
+        }
+        const barCtx = document.getElementById('answerBarChart');
+        if (barCtx) {
+          if (barChart.value) barChart.value.destroy();
+          barChart.value = new Chart(barCtx, {
+            type: 'bar',
+            data: {
+              labels: [yesLabel, noLabel],
+              datasets: [{
+                data: [yesTotal, noTotal],
+                backgroundColor: ['#198754', '#dc3545']
+              }]
+            },
+            options: {
+              plugins: {
+                legend: { display: false }
+              }
+            }
+          });
+        }
+      }
 
       function fetchData() {
         loading.value = true;
@@ -42,6 +85,7 @@ function mountAnswersApp() {
               if (typeof initSortableTables === 'function') {
                 initSortableTables('#answerTable');
               }
+              renderCharts();
             });
           });
       }

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -7,12 +7,18 @@
      data-page-url="{% url 'survey:survey_answers' %}"
      data-wikitext-url="{% url 'survey:survey_answers_wikitext' %}"
      data-answer-url-template="{% url 'survey:answer_question' 0 %}"
-     data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}">
+     data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}"
+     data-yes-label="{% translate 'Yes' %}"
+     data-no-label="{% translate 'No' %}">
   <div v-if="loading">{% translate 'Loading...' %}</div>
   <template v-else>
     <h1>{% translate 'Answers' %}</h1>
     <p class="mt-3">{% translate 'Total respondents' %}: [[ totalUsers ]]</p>
-    <h2>{% translate 'Answer table' %}</h2>
+    <h2 class="mt-4">{% translate 'Pie chart' %}</h2>
+    <canvas id="answerPieChart"></canvas>
+    <h2 class="mt-4">{% translate 'Bar chart' %}</h2>
+    <canvas id="answerBarChart"></canvas>
+    <h2 class="mt-4">{% translate 'Answer table' %}</h2>
     <div class="table-responsive">
       <table id="answerTable" class="table stacked-table">
         <thead>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -200,7 +200,9 @@
      data-page-url="{% url 'survey:survey_answers' %}"
      data-wikitext-url="{% url 'survey:survey_answers_wikitext' %}"
      data-answer-url-template="{% url 'survey:answer_question' 0 %}"
-     data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}">
+     data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}"
+     data-yes-label="{% translate 'Yes' %}"
+     data-no-label="{% translate 'No' %}">
 </div>
 {% if can_edit %}
    <a href="{% url 'survey:survey_edit' %}" class="btn btn-warning ms-2">{% translate 'Edit survey' %}</a>


### PR DESCRIPTION
## Summary
- Display overall results with pie and bar charts on the answers page
- Hook Chart.js into Vue answers app and expose localized labels

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688e65826384832e96963c5156104bc3