### PR TITLE
Use Vue for survey results charts

### DIFF
--- a/static/js/answers_vue.js
+++ b/static/js/answers_vue.js
@@ -1,12 +1,16 @@
-const { createApp, ref, onMounted, nextTick } = Vue;
+const { createApp, ref, onMounted, nextTick, watch } = Vue;
 
 const app = createApp({
   setup() {
     const questions = ref([]);
     const loading = ref(true);
-    const root = document.getElementById('answers-table-app');
+    const root = document.getElementById('answers-app');
     const isAuthenticated = root.dataset.auth === 'true';
     const answerUrlTemplate = root.dataset.answerUrlTemplate;
+    const totalUsers = ref(parseInt(root.dataset.totalUsers, 10) || 0);
+    const chartTypeKey = 'resultsChartType';
+    const chartType = ref(localStorage.getItem(chartTypeKey) || 'pie');
+    watch(chartType, val => localStorage.setItem(chartTypeKey, val));
 
     function formatDate(str) {
       return str ? str.slice(0, 10) : '';
@@ -15,6 +19,53 @@ const app = createApp({
     function answerUrl(id) {
       const nextParam = encodeURIComponent(window.location.pathname + window.location.search);
       return answerUrlTemplate.replace('0', id) + `?next=${nextParam}`;
+    }
+
+    function percent(count, total) {
+      return total ? (count / total) * 100 : 0;
+    }
+
+    function renderPieCharts() {
+      const yesLabel = window.answersConfig.yesLabel;
+      const noLabel = window.answersConfig.noLabel;
+      const noAnswersLabel = window.answersConfig.noAnswersLabel;
+      const successColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-success').trim() || 'green';
+      const dangerColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-danger').trim() || 'red';
+      const placeholderColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary-bg').trim() ||
+        getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary').trim() || 'gray';
+      const pieContainers = document.querySelectorAll('#pieCharts .pie-chart');
+      const totals = Array.from(pieContainers, el => parseInt(el.dataset.total));
+      const maxTotal = Math.max(...totals, 1);
+      const maxSize = 200;
+      pieContainers.forEach(el => {
+        const yes = parseInt(el.dataset.yes);
+        const no = parseInt(el.dataset.no);
+        const total = parseInt(el.dataset.total);
+        const placeholderSize = 100;
+        const size = total === 0 ? placeholderSize : maxSize * Math.sqrt(total / maxTotal);
+        const canvas = el.querySelector('canvas');
+        canvas.width = size;
+        canvas.height = size;
+        const data = total === 0 ? [1] : [yes, no];
+        const colors = total === 0 ? [placeholderColor] : [successColor, dangerColor];
+        new Chart(canvas, {
+          type: 'pie',
+          data: {
+            labels: total === 0 ? [noAnswersLabel] : [yesLabel, noLabel],
+            datasets: [{
+              data: data,
+              backgroundColor: colors
+            }]
+          },
+          options: {
+            responsive: false,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false }
+            }
+          }
+        });
+      });
     }
 
     function fetchQuestions() {
@@ -27,6 +78,7 @@ const app = createApp({
         .finally(() => {
           loading.value = false;
           nextTick(() => {
+            renderPieCharts();
             if (typeof initSortableTables === 'function') {
               initSortableTables('#answerTable');
             }
@@ -38,9 +90,9 @@ const app = createApp({
       fetchQuestions();
     });
 
-    return { questions, loading, isAuthenticated, formatDate, answerUrl };
+    return { questions, loading, isAuthenticated, formatDate, answerUrl, percent, chartType, totalUsers };
   }
 });
 
 app.config.compilerOptions.delimiters = ['[[', ']]'];
-app.mount('#answers-table-app');
+app.mount('#answers-app');

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -29,62 +29,53 @@
     {% endif %}
   {% endif %}
 <h1>{% translate 'Answers' %}</h1>
-<div class="mb-3">
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="chartType" id="pieChartRadio" value="pie" checked>
-    <label class="form-check-label" for="pieChartRadio">{% translate 'Pie chart' %}</label>
-  </div>
-  <div class="form-check form-check-inline">
-    <input class="form-check-input" type="radio" name="chartType" id="barChartRadio" value="bar">
-    <label class="form-check-label" for="barChartRadio">{% translate 'Bar chart' %}</label>
-  </div>
-</div>
-<div class="table-responsive">
-<table id="barChartTable" class="table" style="display:none">
-  <tbody>
-  {% for row in data %}
-  <tr>
-    <td class="bar-chart-question">
-    {% if request.user.is_authenticated %}
-      <a href="{% url 'survey:answer_question' row.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ row.question.text }}</a>
-    {% else %}
-      {{ row.question.text }}
-    {% endif %}
-    </td>
-    <td class="w-100">
-      <div class="progress" style="height: 1.25rem;">
-        <div class="progress-bar bg-success text-black" role="progressbar" style="width: {% widthratio row.yes total_users 100 %}%">{{ row.yes }}</div>
-        <div class="progress-bar bg-danger text-light" role="progressbar" style="width: {% widthratio row.no total_users 100 %}%">{{ row.no }}</div>
-      </div>
-    </td>
-  </tr>
-  {% endfor %}
-  </tbody>
-</table>
-</div>
-<div id="pieChartsContainer" style="display:none">
-  <div id="pieCharts" class="d-flex flex-wrap gap-4 mt-4 justify-content-center">
-{% for row in data %}
-  <div class="pie-chart text-center" data-yes="{{ row.yes }}" data-no="{{ row.no }}" data-total="{{ row.total }}">
-    <canvas></canvas>
-    <p class="mt-2">
-    {% if request.user.is_authenticated %}
-      <a href="{% url 'survey:answer_question' row.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ row.question.text }}</a>
-    {% else %}
-      {{ row.question.text }}
-    {% endif %}
-    </p>
-  </div>
-{% endfor %}
-</div>
-</div>
-<p class="mt-3">{% translate 'Total respondents' %}: {{ total_users }}</p>
-<h2>{% translate 'Answer table' %}</h2>
 <div
-  id="answers-table-app"
+  id="answers-app"
   data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}"
   data-answer-url-template="{% url 'survey:answer_question' 0 %}"
+  data-total-users="{{ total_users }}"
 >
+  <div class="mb-3">
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="radio" name="chartType" id="pieChartRadio" value="pie" v-model="chartType">
+      <label class="form-check-label" for="pieChartRadio">{% translate 'Pie chart' %}</label>
+    </div>
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="radio" name="chartType" id="barChartRadio" value="bar" v-model="chartType">
+      <label class="form-check-label" for="barChartRadio">{% translate 'Bar chart' %}</label>
+    </div>
+  </div>
+  <div class="table-responsive" v-show="chartType === 'bar'">
+    <table id="barChartTable" class="table">
+      <tbody>
+      <tr v-for="q in questions" :key="'bar-'+q.id">
+        <td class="bar-chart-question">
+          <a v-if="isAuthenticated" :href="answerUrl(q.id)">[[ q.text ]]</a>
+          <span v-else>[[ q.text ]]</span>
+        </td>
+        <td class="w-100">
+          <div class="progress" style="height: 1.25rem;">
+            <div class="progress-bar bg-success text-black" role="progressbar" :style="{width: percent(q.yes_count, q.total_answers) + '%'}">[[ q.yes_count ]]</div>
+            <div class="progress-bar bg-danger text-light" role="progressbar" :style="{width: percent(q.no_count, q.total_answers) + '%'}">[[ q.no_count ]]</div>
+          </div>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+  <div id="pieChartsContainer" v-show="chartType === 'pie'">
+    <div id="pieCharts" class="d-flex flex-wrap gap-4 mt-4 justify-content-center">
+      <div class="pie-chart text-center" v-for="q in questions" :key="'pie-'+q.id" :data-yes="q.yes_count" :data-no="q.no_count" :data-total="q.total_answers">
+        <canvas></canvas>
+        <p class="mt-2">
+          <a v-if="isAuthenticated" :href="answerUrl(q.id)">[[ q.text ]]</a>
+          <span v-else>[[ q.text ]]</span>
+        </p>
+      </div>
+    </div>
+  </div>
+  <p class="mt-3">{% translate 'Total respondents' %}: [[ totalUsers ]]</p>
+  <h2>{% translate 'Answer table' %}</h2>
   <p v-if="loading">{% translate 'Loading...' %}</p>
   <div class="table-responsive" v-else>
     <table id="answerTable" class="table stacked-table">
@@ -122,79 +113,15 @@
 </div>
 {% endblock %}
 {% block scripts %}
-<script>
-const yesLabel = '{{ yes_label|escapejs }}';
-const noLabel = '{{ no_label|escapejs }}';
-const noAnswersLabel = '{{ no_answers_label|escapejs }}';
-const successColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-success').trim() || 'green';
-const dangerColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-danger').trim() || 'red';
-const placeholderColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary-bg').trim() ||
-    getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary').trim() || 'gray';
-
-// Pie charts
-const pieContainers = document.querySelectorAll('#pieCharts .pie-chart');
-const totals = Array.from(pieContainers, el => parseInt(el.dataset.total));
-const maxTotal = Math.max(...totals, 1);
-const maxSize = 200;
-pieContainers.forEach(el => {
-    const yes = parseInt(el.dataset.yes);
-    const no = parseInt(el.dataset.no);
-    const total = parseInt(el.dataset.total);
-    const placeholderSize = 100;
-    const size = total === 0 ? placeholderSize : maxSize * Math.sqrt(total / maxTotal);
-    const canvas = el.querySelector('canvas');
-    canvas.width = size;
-    canvas.height = size;
-    const data = total === 0 ? [1] : [yes, no];
-    const colors = total === 0 ? [placeholderColor] : [successColor, dangerColor];
-    new Chart(canvas, {
-        type: 'pie',
-        data: {
-            labels: total === 0 ? [noAnswersLabel] : [yesLabel, noLabel],
-            datasets: [{
-                data: data,
-                backgroundColor: colors
-            }]
-        },
-        options: {
-            responsive: false,
-            maintainAspectRatio: false,
-            plugins: {
-                legend: { display: false }
-            }
-        }
-    });
-});
-
-function updateChartVisibility(type) {
-    const barEl = document.getElementById('barChartTable');
-    const pieEl = document.getElementById('pieChartsContainer');
-    if (type === 'bar') {
-        barEl.style.display = '';
-        pieEl.style.display = 'none';
-    } else {
-        barEl.style.display = 'none';
-        pieEl.style.display = '';
-    }
-}
-
-const chartTypeKey = 'resultsChartType';
-let savedType = localStorage.getItem(chartTypeKey) || 'pie';
-document.getElementById(savedType + 'ChartRadio').checked = true;
-updateChartVisibility(savedType);
-
-document.querySelectorAll('input[name="chartType"]').forEach(radio => {
-    radio.addEventListener('change', e => {
-        const type = e.target.value;
-        localStorage.setItem(chartTypeKey, type);
-        updateChartVisibility(type);
-    });
-});
-</script>
 <script src="{% static 'js/sort_tables.js' %}"></script>
 <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
 <script>
   window.questionsJsonUrl = "{% url 'survey:questions_json' %}";
+  window.answersConfig = {
+    yesLabel: '{{ yes_label|escapejs }}',
+    noLabel: '{{ no_label|escapejs }}',
+    noAnswersLabel: '{{ no_answers_label|escapejs }}'
+  };
 </script>
 <script src="{% static 'js/answers_vue.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace server-rendered charts on results page with Vue components powered by questions.json
- Render pie and bar charts via Chart.js after data load
- Store user chart preference and expose translated labels for charts

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_688e6d58522c832e9057bac236c1c8d2