### PR TITLE
Enable SPA navigation for answers page

### DIFF
--- a/static/js/answers_vue.js
+++ b/static/js/answers_vue.js
@@ -1,98 +1,110 @@
 const { createApp, ref, onMounted, nextTick, watch } = Vue;
 
-const app = createApp({
-  setup() {
-    const questions = ref([]);
-    const loading = ref(true);
-    const root = document.getElementById('answers-app');
-    const isAuthenticated = root.dataset.auth === 'true';
-    const answerUrlTemplate = root.dataset.answerUrlTemplate;
-    const totalUsers = ref(parseInt(root.dataset.totalUsers, 10) || 0);
-    const chartTypeKey = 'resultsChartType';
-    const chartType = ref(localStorage.getItem(chartTypeKey) || 'pie');
-    watch(chartType, val => localStorage.setItem(chartTypeKey, val));
+window.mountAnswersApp = function () {
+  const root = document.getElementById('answers-app');
+  if (!root) return;
 
-    function formatDate(str) {
-      return str ? str.slice(0, 10) : '';
-    }
+  const questionsJsonUrl = root.dataset.questionsJsonUrl;
+  const yesLabel = root.dataset.yesLabel;
+  const noLabel = root.dataset.noLabel;
+  const noAnswersLabel = root.dataset.noAnswersLabel;
 
-    function answerUrl(id) {
-      const nextParam = encodeURIComponent(window.location.pathname + window.location.search);
-      return answerUrlTemplate.replace('0', id) + `?next=${nextParam}`;
-    }
+  const app = createApp({
+    setup() {
+      const questions = ref([]);
+      const loading = ref(true);
+      const isAuthenticated = root.dataset.auth === 'true';
+      const answerUrlTemplate = root.dataset.answerUrlTemplate;
+      const totalUsers = ref(parseInt(root.dataset.totalUsers, 10) || 0);
+      const chartTypeKey = 'resultsChartType';
+      const chartType = ref(localStorage.getItem(chartTypeKey) || 'pie');
+      watch(chartType, val => localStorage.setItem(chartTypeKey, val));
 
-    function percent(count, total) {
-      return total ? (count / total) * 100 : 0;
-    }
+      function formatDate(str) {
+        return str ? str.slice(0, 10) : '';
+      }
 
-    function renderPieCharts() {
-      const yesLabel = window.answersConfig.yesLabel;
-      const noLabel = window.answersConfig.noLabel;
-      const noAnswersLabel = window.answersConfig.noAnswersLabel;
-      const successColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-success').trim() || 'green';
-      const dangerColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-danger').trim() || 'red';
-      const placeholderColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary-bg').trim() ||
-        getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary').trim() || 'gray';
-      const pieContainers = document.querySelectorAll('#pieCharts .pie-chart');
-      const totals = Array.from(pieContainers, el => parseInt(el.dataset.total));
-      const maxTotal = Math.max(...totals, 1);
-      const maxSize = 200;
-      pieContainers.forEach(el => {
-        const yes = parseInt(el.dataset.yes);
-        const no = parseInt(el.dataset.no);
-        const total = parseInt(el.dataset.total);
-        const placeholderSize = 100;
-        const size = total === 0 ? placeholderSize : maxSize * Math.sqrt(total / maxTotal);
-        const canvas = el.querySelector('canvas');
-        canvas.width = size;
-        canvas.height = size;
-        const data = total === 0 ? [1] : [yes, no];
-        const colors = total === 0 ? [placeholderColor] : [successColor, dangerColor];
-        new Chart(canvas, {
-          type: 'pie',
-          data: {
-            labels: total === 0 ? [noAnswersLabel] : [yesLabel, noLabel],
-            datasets: [{
-              data: data,
-              backgroundColor: colors
-            }]
-          },
-          options: {
-            responsive: false,
-            maintainAspectRatio: false,
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-      });
-    }
+      function answerUrl(id) {
+        const nextParam = encodeURIComponent(window.location.pathname + window.location.search);
+        return answerUrlTemplate.replace('0', id) + `?next=${nextParam}`;
+      }
 
-    function fetchQuestions() {
-      loading.value = true;
-      return fetch(window.questionsJsonUrl)
-        .then(resp => resp.json())
-        .then(data => {
-          questions.value = data.questions || [];
-        })
-        .finally(() => {
-          loading.value = false;
-          nextTick(() => {
-            renderPieCharts();
-            if (typeof initSortableTables === 'function') {
-              initSortableTables('#answerTable');
+      function percent(count, total) {
+        return total ? (count / total) * 100 : 0;
+      }
+
+      function renderPieCharts() {
+        const successColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-success').trim() || 'green';
+        const dangerColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-danger').trim() || 'red';
+        const placeholderColor =
+          getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary-bg').trim() ||
+          getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary').trim() || 'gray';
+        const pieContainers = document.querySelectorAll('#pieCharts .pie-chart');
+        const totals = Array.from(pieContainers, el => parseInt(el.dataset.total));
+        const maxTotal = Math.max(...totals, 1);
+        const maxSize = 200;
+        pieContainers.forEach(el => {
+          const yes = parseInt(el.dataset.yes);
+          const no = parseInt(el.dataset.no);
+          const total = parseInt(el.dataset.total);
+          const placeholderSize = 100;
+          const size = total === 0 ? placeholderSize : maxSize * Math.sqrt(total / maxTotal);
+          const canvas = el.querySelector('canvas');
+          canvas.width = size;
+          canvas.height = size;
+          const data = total === 0 ? [1] : [yes, no];
+          const colors = total === 0 ? [placeholderColor] : [successColor, dangerColor];
+          new Chart(canvas, {
+            type: 'pie',
+            data: {
+              labels: total === 0 ? [noAnswersLabel] : [yesLabel, noLabel],
+              datasets: [
+                {
+                  data: data,
+                  backgroundColor: colors
+                }
+              ]
+            },
+            options: {
+              responsive: false,
+              maintainAspectRatio: false,
+              plugins: {
+                legend: { display: false }
+              }
             }
           });
         });
+      }
+
+      function fetchQuestions() {
+        loading.value = true;
+        return fetch(questionsJsonUrl)
+          .then(resp => resp.json())
+          .then(data => {
+            questions.value = data.questions || [];
+          })
+          .finally(() => {
+            loading.value = false;
+            nextTick(() => {
+              renderPieCharts();
+              if (typeof initSortableTables === 'function') {
+                initSortableTables('#answerTable');
+              }
+            });
+          });
+      }
+
+      onMounted(() => {
+        fetchQuestions();
+      });
+
+      return { questions, loading, isAuthenticated, formatDate, answerUrl, percent, chartType, totalUsers };
     }
+  });
 
-    onMounted(() => {
-      fetchQuestions();
-    });
+  app.config.compilerOptions.delimiters = ['[[', ']]'];
+  app.mount('#answers-app');
+};
 
-    return { questions, loading, isAuthenticated, formatDate, answerUrl, percent, chartType, totalUsers };
-  }
-});
+window.mountAnswersApp();
 
-app.config.compilerOptions.delimiters = ['[[', ']]'];
-app.mount('#answers-app');

--- a/static/js/spa_nav.js
+++ b/static/js/spa_nav.js
@@ -1,0 +1,66 @@
+document.addEventListener('DOMContentLoaded', () => {
+  let content = document.getElementById('content');
+  const questionsLink = document.getElementById('nav-questions');
+  const answersLink = document.getElementById('nav-answers');
+  const navRoot = document.getElementById('nav-answer-app');
+
+  const questionsPath = questionsLink ? questionsLink.pathname : null;
+  const answersPath = answersLink ? answersLink.pathname : null;
+
+  function setActive(path) {
+    if (questionsLink) questionsLink.classList.toggle('active', path === questionsPath);
+    if (answersLink) answersLink.classList.toggle('active', path === answersPath);
+    if (navRoot && window.navApp) {
+      const active = path === questionsPath;
+      window.navApp.isActive = active;
+      navRoot.dataset.isActive = active ? 'true' : 'false';
+    }
+    const langNext = document.getElementById('language-next');
+    if (langNext) langNext.value = path;
+  }
+
+  function loadPage(url, push = true) {
+    fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+      .then(resp => resp.text())
+      .then(html => {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const newContent = doc.getElementById('content');
+        const newTitle = doc.querySelector('title');
+        if (newContent) {
+          content.replaceWith(newContent);
+          content = newContent;
+          if (newTitle) document.title = newTitle.textContent;
+          window.mountSurveyDetailApp();
+          window.mountAnswersApp();
+          setActive(new URL(url, window.location.origin).pathname);
+          window.scrollTo(0, 0);
+        }
+        if (push) {
+          window.history.pushState({}, '', url);
+        }
+      });
+  }
+
+  document.addEventListener('click', ev => {
+    const link = ev.target.closest('a');
+    if (!link) return;
+    if (link.target === '_blank' || link.hasAttribute('download')) return;
+    if (link.origin !== window.location.origin) return;
+    const path = link.pathname;
+    if (path === questionsPath || path === answersPath) {
+      ev.preventDefault();
+      loadPage(link.href);
+    }
+  });
+
+  window.addEventListener('popstate', () => {
+    loadPage(location.href, false);
+  });
+
+  // initial mount for current page
+  setActive(window.location.pathname);
+  window.mountSurveyDetailApp();
+  window.mountAnswersApp();
+});
+

--- a/static/js/survey_detail_vue.js
+++ b/static/js/survey_detail_vue.js
@@ -4,216 +4,225 @@ if (typeof window.unansweredCount === 'number') {
   window.unansweredCount = ref(window.unansweredCount);
 }
 
-const app = createApp({
-  setup() {
-    const questions = ref([]);
-    const loading = ref(true);
-    const currentQuestion = ref(null);
-    const root = document.getElementById('survey-detail-app');
-    const isAuthenticated = root.dataset.auth === 'true';
-    const answerUrlTemplate = root.dataset.answerUrlTemplate;
-    const answerApiUrlTemplate = root.dataset.answerApiUrlTemplate;
-    const answerDeleteUrlTemplate = root.dataset.answerDeleteUrlTemplate;
-    const answerDeleteApiUrlTemplate = root.dataset.answerDeleteApiUrlTemplate;
-    const questionEditUrlTemplate = root.dataset.questionEditUrlTemplate;
-    const isRunning = root.dataset.running === 'true';
-    const answerSurveyUrl = root.dataset.answerSurveyUrl;
+let surveyApp = null;
 
-    function formatDate(str) {
-      return str ? str.slice(0, 10) : '';
-    }
+window.mountSurveyDetailApp = function () {
+  const root = document.getElementById('survey-detail-app');
+  if (!root) return;
 
-    function answerUrl(id) {
-      const nextParam = encodeURIComponent(window.location.pathname + window.location.search);
-      return answerUrlTemplate.replace('0', id) + `?next=${nextParam}`;
-    }
+  const questionsJsonUrl = root.dataset.questionsJsonUrl;
 
-    function answerPath(id) {
-      return answerUrlTemplate.replace('0', id);
-    }
+  const app = createApp({
+    setup() {
+      const questions = ref([]);
+      const loading = ref(true);
+      const currentQuestion = ref(null);
+      const isAuthenticated = root.dataset.auth === 'true';
+      const answerUrlTemplate = root.dataset.answerUrlTemplate;
+      const answerApiUrlTemplate = root.dataset.answerApiUrlTemplate;
+      const answerDeleteUrlTemplate = root.dataset.answerDeleteUrlTemplate;
+      const answerDeleteApiUrlTemplate = root.dataset.answerDeleteApiUrlTemplate;
+      const questionEditUrlTemplate = root.dataset.questionEditUrlTemplate;
+      const isRunning = root.dataset.running === 'true';
+      const answerSurveyUrl = root.dataset.answerSurveyUrl;
 
-    function questionEditUrl(id) {
-      return questionEditUrlTemplate.replace('0', id);
-    }
+      function formatDate(str) {
+        return str ? str.slice(0, 10) : '';
+      }
 
-    const unansweredQuestions = computed(() =>
-      questions.value.filter(q => !q.my_answer)
-    );
-    const userAnswers = computed(() =>
-      questions.value.filter(q => q.my_answer)
-    );
-    const otherUserAnswers = computed(() =>
-      questions.value.filter(q => q.my_answer && (!currentQuestion.value || q.id !== currentQuestion.value.id))
-    );
+      function answerUrl(id) {
+        const nextParam = encodeURIComponent(window.location.pathname + window.location.search);
+        return answerUrlTemplate.replace('0', id) + `?next=${nextParam}`;
+      }
 
-    function getCookie(name) {
-      const value = `; ${document.cookie}`;
-      const parts = value.split(`; ${name}=`);
-      if (parts.length === 2) return parts.pop().split(';').shift();
-    }
+      function answerPath(id) {
+        return answerUrlTemplate.replace('0', id);
+      }
 
-    function fetchQuestions() {
-      const currentId = currentQuestion.value ? currentQuestion.value.id : null;
-      loading.value = true;
-      return fetch(window.questionsJsonUrl)
-        .then(resp => resp.json())
-        .then(data => {
-          questions.value = data.questions || [];
-          if (currentId) {
-            currentQuestion.value = questions.value.find(q => q.id === currentId) || null;
-          }
-          if (window.unansweredCount && 'value' in window.unansweredCount) {
-            window.unansweredCount.value = questions.value.filter(q => !q.my_answer).length;
-          }
-        })
-        .finally(() => {
-          loading.value = false;
-          nextTick(() => {
-            if (typeof initSortableTables === 'function') {
-              initSortableTables('.survey-detail-table');
+      function questionEditUrl(id) {
+        return questionEditUrlTemplate.replace('0', id);
+      }
+
+      const unansweredQuestions = computed(() => questions.value.filter(q => !q.my_answer));
+      const userAnswers = computed(() => questions.value.filter(q => q.my_answer));
+      const otherUserAnswers = computed(() =>
+        questions.value.filter(q => q.my_answer && (!currentQuestion.value || q.id !== currentQuestion.value.id))
+      );
+
+      function getCookie(name) {
+        const value = `; ${document.cookie}`;
+        const parts = value.split(`; ${name}=`);
+        if (parts.length === 2) return parts.pop().split(';').shift();
+      }
+
+      function fetchQuestions() {
+        const currentId = currentQuestion.value ? currentQuestion.value.id : null;
+        loading.value = true;
+        return fetch(questionsJsonUrl)
+          .then(resp => resp.json())
+          .then(data => {
+            questions.value = data.questions || [];
+            if (currentId) {
+              currentQuestion.value = questions.value.find(q => q.id === currentId) || null;
             }
+            if (window.unansweredCount && 'value' in window.unansweredCount) {
+              window.unansweredCount.value = questions.value.filter(q => !q.my_answer).length;
+            }
+          })
+          .finally(() => {
+            loading.value = false;
+            nextTick(() => {
+              if (typeof initSortableTables === 'function') {
+                initSortableTables('.survey-detail-table');
+              }
+            });
           });
-        });
-    }
-
-    function updateAnswer(a) {
-      const url = answerApiUrlTemplate.replace('0', a.id);
-      const formData = new FormData();
-      formData.append('answer', a.my_answer);
-      formData.append('question_id', a.id);
-      fetch(url, {
-        method: 'POST',
-        headers: {
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-CSRFToken': getCookie('csrftoken') || ''
-        },
-        body: formData
-      }).then(resp => resp.ok ? resp.json() : Promise.reject())
-        .then(() => fetchQuestions())
-        .catch(() => window.location.reload());
-    }
-
-    function deleteAnswer(a) {
-      const url = answerDeleteApiUrlTemplate.replace('0', a.my_answer_id);
-      fetch(url, {
-        method: 'POST',
-        headers: {
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-CSRFToken': getCookie('csrftoken') || ''
-        }
-      }).then(resp => resp.ok ? resp.json() : Promise.reject())
-        .then(() => fetchQuestions())
-        .catch(() => window.location.reload());
-    }
-
-    function deleteUrl(id) {
-      return answerDeleteUrlTemplate.replace('0', id);
-    }
-
-    function openQuestion(q, push = true) {
-      currentQuestion.value = q;
-      if (push) {
-        window.history.pushState({ questionId: q.id }, '', answerPath(q.id));
       }
-    }
 
-    function closeQuestion(push = true) {
-      currentQuestion.value = null;
-      if (push) {
-        window.history.pushState({}, '', answerSurveyUrl);
+      function updateAnswer(a) {
+        const url = answerApiUrlTemplate.replace('0', a.id);
+        const formData = new FormData();
+        formData.append('answer', a.my_answer);
+        formData.append('question_id', a.id);
+        fetch(url, {
+          method: 'POST',
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRFToken': getCookie('csrftoken') || ''
+          },
+          body: formData
+        })
+          .then(resp => (resp.ok ? resp.json() : Promise.reject()))
+          .then(() => fetchQuestions())
+          .catch(() => window.location.reload());
       }
-    }
 
-    function submitAnswer(ans) {
-      if (!currentQuestion.value) return;
-      const prevId = currentQuestion.value.id;
-      const url = answerApiUrlTemplate.replace('0', prevId);
-      const formData = new FormData();
-      formData.append('answer', ans);
-      formData.append('question_id', prevId);
-      closeQuestion(false);
-      fetch(url, {
-        method: 'POST',
-        headers: {
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-CSRFToken': getCookie('csrftoken') || ''
-        },
-        body: formData
-      }).then(resp => resp.ok ? resp.json() : Promise.reject())
-        .then(() => fetchQuestions())
-        .then(() => {
-          const next = unansweredQuestions.value.find(q => q.id !== prevId);
-          if (next) {
-            openQuestion(next);
-          } else {
-            closeQuestion();
+      function deleteAnswer(a) {
+        const url = answerDeleteApiUrlTemplate.replace('0', a.my_answer_id);
+        fetch(url, {
+          method: 'POST',
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRFToken': getCookie('csrftoken') || ''
           }
         })
-        .catch(() => window.location.reload());
-    }
-
-    function handlePopState() {
-      const m = window.location.pathname.match(/question\/(\d+)/);
-      if (m) {
-        const id = parseInt(m[1]);
-        const q = questions.value.find(q => q.id === id);
-        if (q) {
-          openQuestion(q, false);
-        }
-      } else {
-        closeQuestion(false);
+          .then(resp => (resp.ok ? resp.json() : Promise.reject()))
+          .then(() => fetchQuestions())
+          .catch(() => window.location.reload());
       }
-    }
 
-    onMounted(() => {
-      fetchQuestions().then(() => {
-        handlePopState();
+      function deleteUrl(id) {
+        return answerDeleteUrlTemplate.replace('0', id);
+      }
+
+      function openQuestion(q, push = true) {
+        currentQuestion.value = q;
+        if (push) {
+          window.history.pushState({ questionId: q.id }, '', answerPath(q.id));
+        }
+      }
+
+      function closeQuestion(push = true) {
+        currentQuestion.value = null;
+        if (push) {
+          window.history.pushState({}, '', answerSurveyUrl);
+        }
+      }
+
+      function submitAnswer(ans) {
+        if (!currentQuestion.value) return;
+        const prevId = currentQuestion.value.id;
+        const url = answerApiUrlTemplate.replace('0', prevId);
+        const formData = new FormData();
+        formData.append('answer', ans);
+        formData.append('question_id', prevId);
+        closeQuestion(false);
+        fetch(url, {
+          method: 'POST',
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRFToken': getCookie('csrftoken') || ''
+          },
+          body: formData
+        })
+          .then(resp => (resp.ok ? resp.json() : Promise.reject()))
+          .then(() => fetchQuestions())
+          .then(() => {
+            const next = unansweredQuestions.value.find(q => q.id !== prevId);
+            if (next) {
+              openQuestion(next);
+            } else {
+              closeQuestion();
+            }
+          })
+          .catch(() => window.location.reload());
+      }
+
+      function handlePopState() {
+        const m = window.location.pathname.match(/question\/(\d+)/);
+        if (m) {
+          const id = parseInt(m[1]);
+          const q = questions.value.find(q => q.id === id);
+          if (q) {
+            openQuestion(q, false);
+          }
+        } else {
+          closeQuestion(false);
+        }
+      }
+
+      onMounted(() => {
+        fetchQuestions().then(() => {
+          handlePopState();
+        });
+        window.addEventListener('popstate', handlePopState);
       });
-      window.addEventListener('popstate', handlePopState);
-    });
 
-    return {
-      loading,
-      isAuthenticated,
-      isRunning,
-      questions,
-      currentQuestion,
-      answerSurveyUrl,
-      questionEditUrl,
-      unansweredQuestions,
-      userAnswers,
-      otherUserAnswers,
-      formatDate,
-      answerUrl,
-      updateAnswer,
-      deleteAnswer,
-      deleteUrl,
-      openQuestion,
-      closeQuestion,
-      submitAnswer
-    };
-  }
-});
+      return {
+        loading,
+        isAuthenticated,
+        isRunning,
+        questions,
+        currentQuestion,
+        answerSurveyUrl,
+        questionEditUrl,
+        unansweredQuestions,
+        userAnswers,
+        otherUserAnswers,
+        formatDate,
+        answerUrl,
+        updateAnswer,
+        deleteAnswer,
+        deleteUrl,
+        openQuestion,
+        closeQuestion,
+        submitAnswer
+      };
+    }
+  });
 
-app.config.compilerOptions.delimiters = ['[[', ']]'];
-const surveyApp = app.mount('#survey-detail-app');
+  app.config.compilerOptions.delimiters = ['[[', ']]'];
+  surveyApp = app.mount('#survey-detail-app');
 
-window.openFirstQuestion = () => {
-  if (surveyApp && surveyApp.unansweredQuestions.length) {
-    surveyApp.openQuestion(surveyApp.unansweredQuestions[0]);
-  } else if (surveyApp && surveyApp.answerSurveyUrl) {
-    window.location.href = surveyApp.answerSurveyUrl;
-  }
+  window.openFirstQuestion = () => {
+    if (surveyApp && surveyApp.unansweredQuestions.length) {
+      surveyApp.openQuestion(surveyApp.unansweredQuestions[0]);
+    } else if (surveyApp && surveyApp.answerSurveyUrl) {
+      window.location.href = surveyApp.answerSurveyUrl;
+    }
+  };
 };
+
+window.mountSurveyDetailApp();
 
 const navRoot = document.getElementById('nav-answer-app');
 if (navRoot) {
-  const navApp = createApp({
+  const navAppInstance = createApp({
     setup() {
       const count = window.unansweredCount;
       const auth = navRoot.dataset.auth === 'true';
       const answerUrl = navRoot.dataset.answerUrl;
-      const isActive = navRoot.dataset.isActive === 'true';
+      const isActive = ref(navRoot.dataset.isActive === 'true');
       function openFirstQuestion() {
         if (typeof window.openFirstQuestion === 'function') {
           window.openFirstQuestion();
@@ -224,6 +233,7 @@ if (navRoot) {
       return { count, auth, answerUrl, isActive, openFirstQuestion };
     }
   });
-  navApp.config.compilerOptions.delimiters = ['[[', ']]'];
-  navApp.mount('#nav-answer-app');
+  navAppInstance.config.compilerOptions.delimiters = ['[[', ']]'];
+  window.navApp = navAppInstance.mount('#nav-answer-app');
 }
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,7 +22,7 @@
       {% url 'survey:survey_answers' as survey_answers_url %}
       {% url 'survey:userinfo' as userinfo_url %}
       <ul class="navbar-nav me-auto">
-        <li class="nav-item"><a class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
+        <li class="nav-item"><a id="nav-questions" class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
         <li id="nav-answer-app" class="nav-item"
             data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}"
             data-answer-url="{{ survey_detail_url }}"
@@ -31,7 +31,7 @@
           <a v-if="count > 0" class="nav-link" :class="{ active: isActive }" :href="answerUrl" @click.prevent="openFirstQuestion">{{ answer_label }} (<span id="unanswered-count">[[ count ]]</span>)</a>
           <span v-else class="nav-link text-secondary">{{ answer_label }}<template v-if="auth">(<span id="unanswered-count">[[ count ]]</span>)</template></span>
         </li>
-        <li class="nav-item"><a class="nav-link{% if request.path == survey_answers_url %} active{% endif %}" href="{{ survey_answers_url }}">{% translate 'Answers' %}</a></li>
+        <li class="nav-item"><a id="nav-answers" class="nav-link{% if request.path == survey_answers_url %} active{% endif %}" href="{{ survey_answers_url }}">{% translate 'Answers' %}</a></li>
       </ul>
       <ul id="userbar" class="navbar-nav ms-auto">
       <li class="nav-item">
@@ -62,7 +62,7 @@
     </div>
   </div>
 </nav>
-<div class="container mt-4">
+<div id="content" class="container mt-4">
     {% if messages %}
         {% for message in messages %}
             <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
@@ -83,10 +83,15 @@
 </footer>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+<script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+<script src="{% static 'js/sort_tables.js' %}"></script>
+<script src="{% static 'js/survey_detail_vue.js' %}"></script>
+<script src="{% static 'js/answers_vue.js' %}"></script>
 <script>
   window.unansweredCount = {{ unanswered_count|default:0 }};
 </script>
 <script src="{% static 'js/langswitch.js' %}"></script>
+<script src="{% static 'js/spa_nav.js' %}"></script>
 {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -34,6 +34,10 @@
   data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}"
   data-answer-url-template="{% url 'survey:answer_question' 0 %}"
   data-total-users="{{ total_users }}"
+  data-questions-json-url="{% url 'survey:questions_json' %}"
+  data-yes-label="{{ yes_label }}"
+  data-no-label="{{ no_label }}"
+  data-no-answers-label="{{ no_answers_label }}"
 >
   <div class="mb-3">
     <div class="form-check form-check-inline">
@@ -111,17 +115,4 @@
     </table>
   </div>
 </div>
-{% endblock %}
-{% block scripts %}
-<script src="{% static 'js/sort_tables.js' %}"></script>
-<script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
-<script>
-  window.questionsJsonUrl = "{% url 'survey:questions_json' %}";
-  window.answersConfig = {
-    yesLabel: '{{ yes_label|escapejs }}',
-    noLabel: '{{ no_label|escapejs }}',
-    noAnswersLabel: '{{ no_answers_label|escapejs }}'
-  };
-</script>
-<script src="{% static 'js/answers_vue.js' %}"></script>
 {% endblock %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -26,7 +26,8 @@
      data-answer-delete-api-url-template="{% url 'survey:api_answer_delete' 0 %}"
      data-question-edit-url-template="{% url 'survey:question_edit' 0 %}"
      data-running="{% if survey.state == 'running' %}true{% else %}false{% endif %}"
-     data-answer-survey-url="{% url 'survey:survey_detail' %}">
+     data-answer-survey-url="{% url 'survey:survey_detail' %}"
+     data-questions-json-url="{% url 'survey:questions_json' %}">
   <p v-if="loading">{% translate 'Loading...' %}</p>
   <template v-else>
     <div v-if="!currentQuestion">
@@ -199,12 +200,4 @@
    <a href="{% url 'survey:survey_edit' %}" class="btn btn-warning ms-2">{% translate 'Edit survey' %}</a>
 {% endif %}
 
-{% endblock %}
-{% block scripts %}
-<script src="{% static 'js/sort_tables.js' %}"></script>
-<script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
-<script>
-  window.questionsJsonUrl = "{% url 'survey:questions_json' %}";
-</script>
-<script src="{% static 'js/survey_detail_vue.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add client-side router to switch between Questions and Answers without full reload
- Load Vue apps from data attributes and mount on demand
- Consolidate script includes and shared container in base template

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688ec688c698832e8f83ba195dd29326