### PR TITLE
Fix duplicate nextTick variable collisions

### DIFF
--- a/static/js/answers_vue.js
+++ b/static/js/answers_vue.js
@@ -1,4 +1,4 @@
-const { createApp, ref, onMounted, nextTick, watch } = Vue;
+const { createApp, ref, onMounted, watch } = Vue;
 
 const app = createApp({
   setup() {
@@ -77,7 +77,7 @@ const app = createApp({
         })
         .finally(() => {
           loading.value = false;
-          nextTick(() => {
+          Vue.nextTick(() => {
             renderPieCharts();
             if (typeof initSortableTables === 'function') {
               initSortableTables('#answerTable');

--- a/static/js/survey_detail_vue.js
+++ b/static/js/survey_detail_vue.js
@@ -1,4 +1,4 @@
-const { createApp, ref, computed, onMounted, nextTick } = Vue;
+const { createApp, ref, computed, onMounted } = Vue;
 
 if (typeof window.unansweredCount === 'number') {
   window.unansweredCount = ref(window.unansweredCount);
@@ -68,7 +68,7 @@ const app = createApp({
         })
         .finally(() => {
           loading.value = false;
-          nextTick(() => {
+          Vue.nextTick(() => {
             if (typeof initSortableTables === 'function') {
               initSortableTables('.survey-detail-table');
             }


### PR DESCRIPTION
## Summary
- remove global `nextTick` declarations and call `Vue.nextTick` instead to avoid syntax errors when multiple Vue scripts are loaded on the same page

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f03d5c004832ebe8745245b8cde40