### PR TITLE
Fix duplicate Vue app variable on survey pages

### DIFF
--- a/static/js/answers_vue.js
+++ b/static/js/answers_vue.js
@@ -1,6 +1,6 @@
 const { createApp, ref, onMounted, watch } = Vue;
 
-const app = createApp({
+const answersApp = createApp({
   setup() {
     const questions = ref([]);
     const loading = ref(true);
@@ -94,5 +94,5 @@ const app = createApp({
   }
 });
 
-app.config.compilerOptions.delimiters = ['[[', ']]'];
-app.mount('#answers-app');
+answersApp.config.compilerOptions.delimiters = ['[[', ']]'];
+answersApp.mount('#answers-app');

--- a/static/js/survey_detail_vue.js
+++ b/static/js/survey_detail_vue.js
@@ -4,7 +4,7 @@ if (typeof window.unansweredCount === 'number') {
   window.unansweredCount = ref(window.unansweredCount);
 }
 
-const app = createApp({
+const surveyDetailApp = createApp({
   setup() {
     const questions = ref([]);
     const loading = ref(true);
@@ -193,10 +193,10 @@ const app = createApp({
       submitAnswer
     };
   }
-});
+  });
 
-app.config.compilerOptions.delimiters = ['[[', ']]'];
-const surveyApp = app.mount('#survey-detail-app');
+  surveyDetailApp.config.compilerOptions.delimiters = ['[[', ']]'];
+  const surveyApp = surveyDetailApp.mount('#survey-detail-app');
 
 window.openFirstQuestion = () => {
   if (surveyApp && surveyApp.unansweredQuestions.length) {


### PR DESCRIPTION
## Summary
- avoid global variable collisions by renaming Vue app instances

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688f066c60dc832e97f96df7d1e1fc97