### PR TITLE
Fix Vue app collisions in survey pages

### DIFF
--- a/static/js/answers_vue.js
+++ b/static/js/answers_vue.js
@@ -1,3 +1,4 @@
+(() => {
 const { createApp, ref, onMounted, watch } = Vue;
 
 const answersApp = createApp({
@@ -96,3 +97,4 @@ const answersApp = createApp({
 
 answersApp.config.compilerOptions.delimiters = ['[[', ']]'];
 answersApp.mount('#answers-app');
+})();

--- a/static/js/survey_detail_vue.js
+++ b/static/js/survey_detail_vue.js
@@ -1,3 +1,4 @@
+(() => {
 const { createApp, ref, computed, onMounted } = Vue;
 
 if (typeof window.unansweredCount === 'number') {
@@ -195,8 +196,8 @@ const surveyDetailApp = createApp({
   }
   });
 
-  surveyDetailApp.config.compilerOptions.delimiters = ['[[', ']]'];
-  const surveyApp = surveyDetailApp.mount('#survey-detail-app');
+surveyDetailApp.config.compilerOptions.delimiters = ['[[', ']]'];
+const surveyApp = surveyDetailApp.mount('#survey-detail-app');
 
 window.openFirstQuestion = () => {
   if (surveyApp && surveyApp.unansweredQuestions.length) {
@@ -227,3 +228,4 @@ if (navRoot) {
   navApp.config.compilerOptions.delimiters = ['[[', ']]'];
   navApp.mount('#nav-answer-app');
 }
+})();


### PR DESCRIPTION
## Summary
- isolate Vue app setup for answers and survey detail pages with IIFEs
- prevent global `createApp` collisions when both scripts load together

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688f08908dc0832e9b118b7de9f68756