### PR TITLE
Display answer counts and consensus on my answers page

### DIFF
--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -54,6 +54,8 @@
   <tr>
     <th>{% translate 'Question' %}</th>
     <th>{% translate 'Answer' %}</th>
+    <th>{% translate 'Answers' %}</th>
+    <th>{% translate 'Agree' %}</th>
     <th></th>
   </tr>
 </thead>
@@ -68,6 +70,8 @@
       {% endif %}
     </td>
     <td data-label="{% translate 'Answer' %}">{{ answer.get_answer_display }}</td>
+    <td data-label="{% translate 'Answers' %}">{{ answer.total_answers }}</td>
+    <td data-label="{% translate 'Agree' %}">{{ answer.agree_ratio|floatformat:1 }}%</td>
     <td class="text-end" data-label="">
       {% if answer.question.survey.state == 'running' %}
       <a href="{% url 'survey:answer_delete' answer.pk %}" class="btn btn-sm btn-danger ms-2 ajax-delete-answer" data-no-reload="true">{% translate 'Remove answer' %}</a>
@@ -75,7 +79,7 @@
     </td>
   </tr>
 {% empty %}
-  <tr><td colspan="3">{% translate 'No answers' %}</td></tr>
+  <tr><td colspan="5">{% translate 'No answers' %}</td></tr>
 {% endfor %}
 </tbody>
 </table>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -403,6 +403,19 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(surveys_by_title["Other Survey"]["description"], "desc")
 
 
+    def test_userinfo_shows_answer_counts_and_consensus(self):
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        Answer.objects.create(question=q, user=self.user, answer="yes")
+        Answer.objects.create(question=q, user=self.users[1], answer="no")
+        Answer.objects.create(question=q, user=self.users[2], answer="yes")
+
+        response = self.client.get(reverse("survey:userinfo"))
+        self.assertEqual(response.status_code, 200)
+        answers = list(response.context["answers"])
+        self.assertEqual(answers[0].total_answers, 3)
+        self.assertAlmostEqual(answers[0].agree_ratio, 33.3333, places=1)
+
     def test_user_data_delete_removes_answers_and_questions(self):
         survey = self._create_survey()
         q1 = self._create_question(survey)


### PR DESCRIPTION
## Summary
- annotate user answers with total answer count and consensus percentage
- show total answers and consensus in the My answers table
- add regression test for userinfo view

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f0c09ec94832eaa46fd75b53e0e20