### PR TITLE
Enable answering after removing answers

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -80,6 +80,27 @@ document.addEventListener('DOMContentLoaded', () => {
         if (navCount && typeof data.unanswered_count !== 'undefined') {
           navCount.textContent = data.unanswered_count;
         }
+        const navLink = document.getElementById('answer-nav-link');
+        if (navLink && typeof data.unanswered_count !== 'undefined' && data.unanswered_count > 0 && navLink.tagName === 'SPAN') {
+          const url = navLink.dataset.answerUrl;
+          const newLink = document.createElement('a');
+          newLink.id = 'answer-nav-link';
+          newLink.className = 'nav-link';
+          newLink.href = url;
+          newLink.innerHTML = navLink.innerHTML;
+          navLink.replaceWith(newLink);
+        }
+        const answerBtn = document.getElementById('answer-survey-btn');
+        const answersBtn = document.getElementById('answers-btn');
+        if (typeof data.unanswered_count !== 'undefined' && answerBtn && answersBtn) {
+          if (data.unanswered_count > 0) {
+            answerBtn.style.display = '';
+            answersBtn.style.display = 'none';
+          } else {
+            answersBtn.style.display = '';
+            answerBtn.style.display = 'none';
+          }
+        }
         if (updateUnanswered) {
           const tbody = unansweredTable.tBodies[0];
           if (tbody) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,9 +25,9 @@
       <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
         {% if unanswered_count %}
-        <li class="nav-item"><a class="nav-link{% if request.path == answer_survey_url %} active{% endif %}" href="{{ answer_survey_url }}">{% translate 'Answer survey' %} (<span id="unanswered-count">{{ unanswered_count }}</span>)</a></li>
+        <li class="nav-item"><a id="answer-nav-link" class="nav-link{% if request.path == answer_survey_url %} active{% endif %}" href="{{ answer_survey_url }}">{% translate 'Answer survey' %} (<span id="unanswered-count">{{ unanswered_count }}</span>)</a></li>
         {% else %}
-        <li class="nav-item"><span class="nav-link text-secondary">{% translate 'Answer survey' %}{% if request.user.is_authenticated %}(<span id="unanswered-count">0</span>){% endif %}</span></li>
+        <li class="nav-item"><span id="answer-nav-link" class="nav-link text-secondary" data-answer-url="{{ answer_survey_url }}">{% translate 'Answer survey' %}{% if request.user.is_authenticated %}(<span id="unanswered-count">0</span>){% endif %}</span></li>
         {% endif %}
         <li class="nav-item"><a class="nav-link{% if request.path == survey_answers_url %} active{% endif %}" href="{{ survey_answers_url }}">{% translate 'Answers' %}</a></li>
       </ul>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -23,12 +23,11 @@
 <p>{{ survey.description }}</p>
 {% if request.user.is_authenticated %}
   <div class="mb-3">
-    {% if unanswered_questions and survey.state == 'running' %}
-      <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary">{% translate 'Answer survey' %}</a>
-    {% else %}
-      {% if questions %}
-        <a href="{% url 'survey:survey_answers' %}" class="btn btn-info">{% translate 'Answers' %}</a>
-      {% endif %}
+    {% if survey.state == 'running' %}
+      <a href="{% url 'survey:answer_survey' %}" id="answer-survey-btn" class="btn btn-primary"{% if not unanswered_questions %} style="display:none"{% endif %}>{% translate 'Answer survey' %}</a>
+    {% endif %}
+    {% if questions %}
+      <a href="{% url 'survey:survey_answers' %}" id="answers-btn" class="btn btn-info"{% if survey.state == 'running' and unanswered_questions %} style="display:none"{% endif %}>{% translate 'Answers' %}</a>
     {% endif %}
     <a href="{% url 'survey:question_add' %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
   </div>


### PR DESCRIPTION
## Summary
- Reactivate "Answer survey" navigation link when deleting an answer adds new unanswered questions
- Toggle top "Answer survey" button in questions page after answer deletion

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f10d15bc0832e8881d68409de77b9