### PR TITLE
Ensure navbar answer count is displayed

### DIFF
--- a/static/js/nav_qr_vue.js
+++ b/static/js/nav_qr_vue.js
@@ -19,7 +19,10 @@
   const app = createApp({
     setup() {
       const view = ref(initialView);
-      const count = window.unansweredCount;
+      const count = (window.unansweredCount && typeof window.unansweredCount === 'object' && 'value' in window.unansweredCount)
+        ? window.unansweredCount
+        : ref(window.unansweredCount || 0);
+      window.unansweredCount = count;
       const auth = navRoot ? navRoot.dataset.auth === 'true' : false;
       const answerUrl = navRoot ? navRoot.dataset.answerUrl : '';
       const isActive = ref(navRoot ? navRoot.dataset.isActive === 'true' : false);

--- a/templates/base.html
+++ b/templates/base.html
@@ -89,10 +89,10 @@
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
 <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
-<script src="{% static 'js/nav_qr_vue.js' %}"></script>
 <script>
   window.unansweredCount = {{ unanswered_count|default:0 }};
 </script>
+<script src="{% static 'js/nav_qr_vue.js' %}"></script>
 <script src="{% static 'js/langswitch.js' %}"></script>
 {% block scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- Initialize unanswered question count before loading navigation script
- Make navigation script use a reactive unanswered count

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f12d63c00832eac1c9b019b3042d3