### PR TITLE
Activate answer nav link when answers are removed

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -5,6 +5,40 @@ document.addEventListener('DOMContentLoaded', () => {
     if (parts.length === 2) return parts.pop().split(';').shift();
   }
 
+  function updateAnswerNavLink(count) {
+    const navCount = document.getElementById('unanswered-count');
+    if (navCount) {
+      navCount.textContent = count;
+    }
+
+    const navLink = document.getElementById('answer-nav-link');
+    if (!navLink) return;
+
+    if (count > 0 && navLink.tagName === 'SPAN') {
+      const url = navLink.dataset.answerUrl;
+      const newLink = document.createElement('a');
+      newLink.id = 'answer-nav-link';
+      newLink.className = 'nav-link';
+      newLink.href = url;
+      newLink.innerHTML = navLink.innerHTML;
+      navLink.replaceWith(newLink);
+    } else if (count === 0 && navLink.tagName === 'A') {
+      const url = navLink.href;
+      const newSpan = document.createElement('span');
+      newSpan.id = 'answer-nav-link';
+      newSpan.className = 'nav-link text-secondary';
+      newSpan.dataset.answerUrl = url;
+      newSpan.innerHTML = navLink.innerHTML;
+      navLink.replaceWith(newSpan);
+    }
+  }
+
+  const initialNavCount = document.getElementById('unanswered-count');
+  if (initialNavCount) {
+    const initialCount = parseInt(initialNavCount.textContent, 10) || 0;
+    updateAnswerNavLink(initialCount);
+  }
+
   function attachDeleteQuestion(link) {
     link.addEventListener('click', ev => {
       ev.preventDefault();
@@ -76,19 +110,8 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         }
         if (row) row.remove();
-        const navCount = document.getElementById('unanswered-count');
-        if (navCount && typeof data.unanswered_count !== 'undefined') {
-          navCount.textContent = data.unanswered_count;
-        }
-        const navLink = document.getElementById('answer-nav-link');
-        if (navLink && typeof data.unanswered_count !== 'undefined' && data.unanswered_count > 0 && navLink.tagName === 'SPAN') {
-          const url = navLink.dataset.answerUrl;
-          const newLink = document.createElement('a');
-          newLink.id = 'answer-nav-link';
-          newLink.className = 'nav-link';
-          newLink.href = url;
-          newLink.innerHTML = navLink.innerHTML;
-          navLink.replaceWith(newLink);
+        if (typeof data.unanswered_count !== 'undefined') {
+          updateAnswerNavLink(data.unanswered_count);
         }
         const answerBtn = document.getElementById('answer-survey-btn');
         const answersBtn = document.getElementById('answers-btn');

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -479,6 +479,19 @@ class SurveyFlowTests(TransactionTestCase):
         User = get_user_model()
         self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
 
+    def test_delete_answer_returns_unanswered_count(self):
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        ans = Answer.objects.create(question=q, user=self.user, answer="yes")
+
+        response = self.client.post(
+            reverse("survey:answer_delete", args=[ans.pk]),
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEqual(data["unanswered_count"], 1)
+
     def test_logout_from_protected_page_redirects_to_answers(self):
         self._create_survey()
         url = reverse("survey:survey_edit")


### PR DESCRIPTION
## Summary
- ensure top navigation "Answer survey" link becomes clickable after deleting answers by dynamically toggling the element
- add regression test validating `answer_delete` returns updated unanswered count

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f13ea9740832e9268f08826c10694