### PR TITLE
Add linkable answer page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
     <div class="collapse navbar-collapse" id="navbar-main">
       {% url 'survey:survey_detail' as survey_detail_url %}
       {% url 'survey:survey_answers' as survey_answers_url %}
+      {% url 'survey:survey_answer' as survey_answer_url %}
       {% url 'survey:userinfo' as userinfo_url %}
       <ul class="navbar-nav me-auto" id="nav-qr-app"
           data-questions-id="questions-view"
@@ -30,8 +31,8 @@
         <li class="nav-item"><a class="nav-link" :class="{ active: view === 'questions' }" href="{{ survey_detail_url }}" @click.prevent="show('questions')">{% translate 'Questions' %}</a></li>
         <li id="nav-answer-app" class="nav-item"
             data-auth="{{ request.user.is_authenticated|yesno:'true,false' }}"
-            data-answer-url="{{ survey_detail_url }}"
-            data-is-active="{% if request.path == survey_detail_url %}true{% else %}false{% endif %}">
+            data-answer-url="{{ survey_answer_url }}"
+            data-is-active="{% if request.path == survey_answer_url or '/question/' in request.path %}true{% else %}false{% endif %}">
           {% translate 'Answer survey' as answer_label %}
           <a v-if="count > 0" class="nav-link" :class="{ active: isActive && view === 'questions' }" :href="answerUrl" @click.prevent="openFirstQuestion">{{ answer_label }} (<span id="unanswered-count">[[ count ]]</span>)</a>
           <span v-else class="nav-link text-secondary">{{ answer_label }}<template v-if="auth">(<span id="unanswered-count">[[ count ]]</span>)</template></span>

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -27,7 +27,7 @@
      data-answer-delete-api-url-template="{% url 'survey:api_answer_delete' 0 %}"
      data-question-edit-url-template="{% url 'survey:question_edit' 0 %}"
      data-running="{% if survey.state == 'running' %}true{% else %}false{% endif %}"
-     data-answer-survey-url="{% url 'survey:survey_detail' %}">
+     data-answer-survey-url="{% url 'survey:survey_answer' %}">
   <p v-if="loading">{% translate 'Loading...' %}</p>
   <template v-else>
     <div v-if="!currentQuestion">
@@ -216,4 +216,13 @@
 </script>
 <script src="{% static 'js/survey_detail_vue.js' %}"></script>
 <script src="{% static 'js/answers_vue.js' %}"></script>
+{% if open_first_question %}
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof window.openFirstQuestion === 'function') {
+      window.openFirstQuestion();
+    }
+  });
+</script>
+{% endif %}
 {% endblock %}

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -460,3 +460,11 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["deleted"])
         self.assertFalse(Answer.objects.filter(pk=ans.pk).exists())
+
+    def test_survey_answer_view(self):
+        survey = self._create_survey()
+        self._create_question(survey)
+        response = self.client.get(reverse("survey:survey_answer"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "survey/survey_detail.html")
+        self.assertTrue(response.context["open_first_question"])

--- a/wikikysely_project/survey/urls.py
+++ b/wikikysely_project/survey/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path("my_answers/", views.userinfo, name="userinfo"),
     path("my_answers/download/", views.userinfo_download, name="userinfo_download"),
     path("my_answers/delete_data/", views.user_data_delete, name="user_data_delete"),
+    path("answer/", views.survey_answer, name="survey_answer"),
     path("answers/", views.survey_answers, name="survey_answers"),
     path(
         "answers/wikitext/",

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -178,7 +178,7 @@ def survey_logout(request):
     return redirect("survey:survey_answers")
 
 
-def survey_detail(request, pk=None):
+def survey_detail(request, pk=None, open_first=False):
     survey = Survey.get_main_survey()
     if survey is None:
         if request.user.is_authenticated:
@@ -233,8 +233,13 @@ def survey_detail(request, pk=None):
             "yes_label": yes_label,
             "no_label": no_label,
             "no_answers_label": no_answers_label,
+            "open_first_question": open_first,
         },
     )
+
+
+def survey_answer(request):
+    return survey_detail(request, open_first=True)
 
 
 def calculate_agree_ratio(yes_count, total_answers):


### PR DESCRIPTION
## Summary
- Add `/answer/` URL and view to open the first question for answering
- Point navigation and question page answer buttons to the new answer URL
- Open the first question automatically when visiting the answer page

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_688f155a975c832e9a1b2e512fc1bcbf