### PR TITLE
Handle deletion redirect without next url

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -502,6 +502,17 @@ class SurveyFlowTests(TransactionTestCase):
         data = json.loads(response.content)
         self.assertEqual(data["unanswered_count"], 1)
 
+    def test_delete_answer_without_next_redirects_to_detail(self):
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        ans = Answer.objects.create(question=q, user=self.user, answer="yes")
+
+        response = self.client.get(
+            reverse("survey:answer_delete", args=[ans.pk]) + "?next=None"
+        )
+        self.assertRedirects(response, reverse("survey:survey_detail"))
+        self.assertFalse(Answer.objects.filter(pk=ans.pk).exists())
+
     def test_logout_from_protected_page_redirects_to_answers(self):
         self._create_survey()
         url = reverse("survey:survey_edit")

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -1194,10 +1194,10 @@ def answer_delete(request, pk):
         )
     messages.success(request, _("Answer removed"))
 
-    next_url = request.GET.get("next") or request.META.get("HTTP_REFERER")
-    if next_url:
-        return redirect(next_url)
-    return redirect("survey:survey_detail")
+    next_url = request.GET.get("next")
+    if not next_url or next_url == "None":
+        return redirect("survey:survey_detail")
+    return redirect(next_url)
 
 
 def survey_answers(request):


### PR DESCRIPTION
## Summary
- avoid redirecting to the edit page when deleting an answer without a `next` URL
- add regression test for deleting an answer without `next`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6890869acc64832e89fe4c2928c01d41