### PR TITLE
Add JSON logging for survey edit operations

### DIFF
--- a/templates/survey/survey_form.html
+++ b/templates/survey/survey_form.html
@@ -54,5 +54,15 @@
       {% endfor %}
     </ul>
   {% endif %}
+  <h2 class="mt-4">{% translate 'Survey log' %}</h2>
+  <ul class="list-group">
+    {% for log in logs %}
+      <li class="list-group-item">
+        {{ log.created_at|date:"Y-m-d H:i" }} - {{ log.data.username }} - {{ log.data.action }}{% if log.data.secretary_username %} - {{ log.data.secretary_username }}{% endif %}{% if log.data.question_text %} - {{ log.data.question_text }}{% endif %}
+      </li>
+    {% empty %}
+      <li class="list-group-item">{% translate 'No log entries' %}</li>
+    {% endfor %}
+  </ul>
 {% endif %}
 {% endblock %}

--- a/wikikysely_project/survey/models.py
+++ b/wikikysely_project/survey/models.py
@@ -62,3 +62,23 @@ class Answer(models.Model):
 
     class Meta:
         unique_together = ('question', 'user')
+
+
+class SurveyLog(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    data = models.JSONField()
+
+
+def log_survey_action(user, survey, action, **extra):
+    """Store survey edit actions in a JSON based log."""
+    entry = {
+        "action": action,
+        "user_id": getattr(user, "id", None),
+        "username": getattr(user, "username", ""),
+        "survey_id": getattr(survey, "id", None),
+        "survey_title": getattr(survey, "title", ""),
+        "survey_description": getattr(survey, "description", ""),
+        "survey_state": getattr(survey, "state", ""),
+    }
+    entry.update(extra)
+    SurveyLog.objects.create(data=entry)


### PR DESCRIPTION
## Summary
- store survey modifications in new `SurveyLog` entries containing user info and survey details
- log question visibility changes and secretary additions/removals
- show recent log entries on the survey edit page
- test logging for survey edits, secretaries, question visibility, and log display

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6890955fe318832ebfbefd87e6aa7c09