### PR TITLE
Hide hidden questions for creators

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -421,6 +421,19 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(answers[0].total_answers, 3)
         self.assertAlmostEqual(answers[0].agree_ratio, 33.3333, places=1)
 
+    def test_hidden_question_not_shown_to_creator(self):
+        survey = self._create_survey()
+        visible_q = self._create_question(survey, text="Visible Q")
+        hidden_q = self._create_question(survey, text="Hidden Q")
+        hidden_q.visible = False
+        hidden_q.save()
+        Answer.objects.create(question=hidden_q, user=self.user, answer="yes")
+
+        response = self.client.get(reverse("survey:survey_detail"))
+        self.assertContains(response, visible_q.text)
+        self.assertNotContains(response, hidden_q.text)
+        self.assertEqual(list(response.context["user_answers"]), [])
+
     def test_userinfo_download_returns_json(self):
         survey = self._create_survey()
         q = self._create_question(survey)

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -48,7 +48,9 @@ def can_edit_survey(user, survey):
 def get_user_answers(user, survey):
     """Return user's answers for the survey with aggregated stats."""
     return (
-        Answer.objects.filter(user=user, question__survey=survey)
+        Answer.objects.filter(
+            user=user, question__survey=survey, question__visible=True
+        )
         .select_related("question")
         .annotate(
             yes_count=Count(
@@ -210,6 +212,7 @@ def survey_detail(request):
             Answer.objects.filter(
                 user=request.user,
                 question__survey=survey,
+                question__visible=True,
             )
             .select_related("question")
             .annotate(


### PR DESCRIPTION
## Summary
- prevent hidden questions from appearing to their creators on the survey detail page
- add regression test covering hidden question visibility

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689113e166d0832e82919868eb61b24a