### PR TITLE
Show answer counts on pie charts

### DIFF
--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -120,7 +120,9 @@
 </div>
 {% endblock %}
 {% block scripts %}
+<script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js"></script>
 <script>
+Chart.register(ChartDataLabels);
 const yesLabel = '{{ yes_label|escapejs }}';
 const noLabel = '{{ no_label|escapejs }}';
 const noAnswersLabel = '{{ no_answers_label|escapejs }}';
@@ -158,7 +160,13 @@ pieContainers.forEach(el => {
             responsive: false,
             maintainAspectRatio: false,
             plugins: {
-                legend: { display: false }
+                legend: { display: false },
+                datalabels: {
+                    display: total !== 0,
+                    formatter: value => value,
+                    color: '#fff',
+                    font: { weight: 'bold' }
+                }
             }
         }
     });


### PR DESCRIPTION
## Summary
- Add Chart.js DataLabels plugin and register it on the Answers page
- Display answer counts directly on pie chart slices

## Testing
- `python manage.py test`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68922c91d0c0832e95057f56e1c0a584