### PR TITLE
Display question IDs in lists

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -29,11 +29,11 @@ body {
 }
 .survey-detail-table th:nth-child(2),
 .survey-detail-table td:nth-child(2) {
-  width: 50%;
+  width: 10%;
 }
 .survey-detail-table th:nth-child(3),
 .survey-detail-table td:nth-child(3) {
-  width: 10%;
+  width: 40%;
 }
 .survey-detail-table th:nth-child(4),
 .survey-detail-table td:nth-child(4) {
@@ -41,6 +41,10 @@ body {
 }
 .survey-detail-table th:nth-child(5),
 .survey-detail-table td:nth-child(5) {
+  width: 10%;
+}
+.survey-detail-table th:nth-child(6),
+.survey-detail-table td:nth-child(6) {
   width: 20%;
 }
 

--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -130,11 +130,18 @@ document.addEventListener('DOMContentLoaded', () => {
             const tr = document.createElement('tr');
             tr.dataset.questionId = data.question_id;
 
+            const tdId = document.createElement('td');
+            tdId.dataset.label = data.id_label;
+            tdId.textContent = data.question_id;
+            tr.appendChild(tdId);
+
             const tdPublished = document.createElement('td');
+            tdPublished.dataset.label = data.published_label;
             tdPublished.textContent = data.question_published;
             tr.appendChild(tdPublished);
 
             const tdTitle = document.createElement('td');
+            tdTitle.dataset.label = data.title_label;
             const titleLink = document.createElement('a');
             const nextParam = encodeURIComponent(window.location.pathname + window.location.search);
             titleLink.href = `${data.question_url}?next=${nextParam}`;
@@ -144,11 +151,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const tdTotal = document.createElement('td');
             tdTotal.className = 'total-answers';
+            tdTotal.dataset.label = data.answers_label;
             tdTotal.textContent = data.total;
             tr.appendChild(tdTotal);
 
             const tdRatio = document.createElement('td');
             tdRatio.className = 'agree-ratio';
+            tdRatio.dataset.label = data.agree_label;
             tdRatio.textContent = `${data.agree_ratio}%`;
             tr.appendChild(tdRatio);
 

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -87,6 +87,7 @@
   <table class="table mb-3 survey-detail-table stacked-table">
     <thead>
       <tr>
+        <th>{% translate 'ID' %}</th>
         <th>{% translate 'Answer date' %}</th>
         <th>{% translate 'Title' %}</th>
         <th>{% translate 'Answers' %}</th>
@@ -97,6 +98,7 @@
     <tbody>
       {% for a in user_answers %}
       <tr data-question-id="{{ a.question.pk }}">
+        <td data-label="{% translate 'ID' %}">{{ a.question.pk }}</td>
         <td data-label="{% translate 'Answer date' %}">{{ a.created_at|date:"Y-m-d" }}</td>
         <td data-label="{% translate 'Title' %}"><a href="{% url 'survey:answer_question' a.question.pk %}">{{ a.question.text }}</a></td>
         <td class="total-answers" data-label="{% translate 'Answers' %}">{{ a.total_answers }}</td>
@@ -130,7 +132,7 @@
 <script src="{% static 'js/sort_tables.js' %}"></script>
 <script>
 document.addEventListener("DOMContentLoaded", () => {
-    initSortableTables(".survey-detail-table");
+    initSortableTables(".survey-detail-table", 1);
 });
 </script>
 <script>

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -44,6 +44,7 @@
   <tbody>
   {% for row in data %}
   <tr>
+    <td>{{ row.question.pk }}</td>
     <td class="bar-chart-question">
     {% if request.user.is_authenticated %}
       <a href="{% url 'survey:answer_question' row.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ row.question.text }}</a>
@@ -84,6 +85,7 @@
 <table id="answerTable" class="table stacked-table">
 <thead>
 <tr>
+  <th>{% translate 'ID' %}</th>
   <th>{% translate 'Published' %}</th>
   <th>{% translate 'Question' %}</th>
   {% if request.user.is_authenticated %}
@@ -98,6 +100,7 @@
 <tbody>
 {% for row in data %}
 <tr>
+  <td data-label="{% translate 'ID' %}">{{ row.question.pk }}</td>
   <td data-label="{% translate 'Published' %}">{{ row.published|date:"Y-m-d" }}</td>
   <td data-label="{% translate 'Question' %}">
     {% if request.user.is_authenticated %}
@@ -200,7 +203,7 @@ document.querySelectorAll('input[name="chartType"]').forEach(radio => {
 <script src="{% static 'js/sort_tables.js' %}"></script>
 <script>
 document.addEventListener("DOMContentLoaded", () => {
-    initSortableTables("#answerTable");
+    initSortableTables("#answerTable", 1);
 });
 </script>
 {% endblock %}

--- a/templates/survey/answers_wikitext.txt
+++ b/templates/survey/answers_wikitext.txt
@@ -4,15 +4,22 @@
 ''{% translate 'Generated on' %}: {{ generated_at|date:"Y-m-d H:i" }}''
 
 === {% translate 'Bar charts' %} ===
-<table>{% for row in data %}<tr><td style="min-width:15rem"> {% if request.user.is_authenticated %}<a href="{% url 'survey:answer_question' row.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ row.question.text }}</a>{% else %}{{ row.question.text }}{% endif %}</td>
-<td style="width:100%"><div style="background-color:#e9ecef;border:1px solid black;display:flex;border-radius:0.25rem;margin-bottom:0.25em;margin-top:0.25em;">{% if row.yes  %}<div style="width: {% widthratio row.yes total_users 100 %}%;background-color:#198754;color:#000;display:flex;align-items:center;justify-content:center;">{{ row.yes }}</div>{% endif %}{% if row.no  %}<div style="width: {% widthratio row.no total_users 100 %}%;background-color:#dc3545;color:#fff;display:flex;align-items:center;justify-content:center;">{{ row.no }}</div>{% endif %}</div></td></tr>{% endfor %}</table>
+<table>
+{% for row in data %}
+<tr>
+<td>{{ row.question.pk }}</td>
+<td style="min-width:15rem"> {% if request.user.is_authenticated %}<a href="{% url 'survey:answer_question' row.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ row.question.text }}</a>{% else %}{{ row.question.text }}{% endif %}</td>
+<td style="width:100%"><div style="background-color:#e9ecef;border:1px solid black;display:flex;border-radius:0.25rem;margin-bottom:0.25em;margin-top:0.25em;">{% if row.yes  %}<div style="width: {% widthratio row.yes total_users 100 %}%;background-color:#198754;color:#000;display:flex;align-items:center;justify-content:center;">{{ row.yes }}</div>{% endif %}{% if row.no  %}<div style="width: {% widthratio row.no total_users 100 %}%;background-color:#dc3545;color:#fff;display:flex;align-items:center;justify-content:center;">{{ row.no }}</div>{% endif %}</div></td>
+</tr>
+{% endfor %}
+</table>
 
 === {% translate 'Answer table' %} ===
 {| class="wikitable"
-! {% translate 'Published' %} !! {% translate 'Question' %}{% if include_personal %} !! {% translate 'My answer' %}{% endif %} !! {{ yes_label }} !! {{ no_label }} !! {% translate 'Total' %} !! {% translate 'Agree' %}
+! {% translate 'ID' %} !! {% translate 'Published' %} !! {% translate 'Question' %}{% if include_personal %} !! {% translate 'My answer' %}{% endif %} !! {{ yes_label }} !! {{ no_label }} !! {% translate 'Total' %} !! {% translate 'Agree' %}
 {% for row in data %}
 |-
-| {{ row.published|date:"Y-m-d" }} || {{ row.question.text }}{% if include_personal %} || {{ row.my_answer|default:"" }}{% endif %} || {{ row.yes }} || {{ row.no }} || {{ row.total }} || {{ row.agree_ratio|floatformat:1 }}%
+| {{ row.question.pk }} || {{ row.published|date:"Y-m-d" }} || {{ row.question.text }}{% if include_personal %} || {{ row.my_answer|default:"" }}{% endif %} || {{ row.yes }} || {{ row.no }} || {{ row.total }} || {{ row.agree_ratio|floatformat:1 }}%
 {% endfor %}
 |}
 

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -45,6 +45,7 @@
       <table id="unanswered-table" class="table mb-3 survey-detail-table stacked-table"{% if not unanswered_questions %} style="display:none"{% endif %}>
         <thead>
       <tr>
+        <th>{% translate 'ID' %}</th>
         <th>{% translate 'Published' %}</th>
         <th>{% translate 'Title' %}</th>
         <th>{% translate 'Answers' %}</th>
@@ -55,6 +56,7 @@
       <tbody>
       {% for q in unanswered_questions %}
         <tr>
+        <td data-label="{% translate 'ID' %}">{{ q.pk }}</td>
         <td data-label="{% translate 'Published' %}">{{ q.created_at | date:"Y-m-d" }}</td>
 {% if request.user.is_authenticated %}
         <td data-label="{% translate 'Title' %}"><a href="{% url 'survey:answer_question' q.pk %}?next={{ request.get_full_path|urlencode }}">{{ q.text }}</a></td>
@@ -81,6 +83,7 @@
 <table class="table mb-3 survey-detail-table stacked-table">
   <thead>
   <tr>
+    <th>{% translate 'ID' %}</th>
     <th>{% translate 'Published' %}</th>
     <th>{% translate 'Title' %}</th>
     <th>{% translate 'Answers' %}</th>
@@ -91,6 +94,7 @@
   <tbody>
   {% for a in user_answers %}
     <tr>
+      <td data-label="{% translate 'ID' %}">{{ a.question.pk }}</td>
       <td data-label="{% translate 'Published' %}">{{ a.question.created_at|date:"Y-m-d" }}</td>
       <td data-label="{% translate 'Title' %}">
         <a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a>
@@ -127,7 +131,7 @@
 <script src="{% static 'js/sort_tables.js' %}"></script>
 <script>
 document.addEventListener("DOMContentLoaded", () => {
-    initSortableTables(".survey-detail-table");
+    initSortableTables(".survey-detail-table", 1);
 });
 </script>
 <script src="{% static 'js/survey_detail_ajax.js' %}"></script>

--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -23,6 +23,7 @@
 <table class="table mb-0 stacked-table">
   <thead>
     <tr>
+      <th>{% translate 'ID' %}</th>
       <th>{% translate 'Question' %}</th>
       <th></th>
     </tr>
@@ -30,6 +31,7 @@
   <tbody>
   {% for question in questions %}
     <tr>
+      <td data-label="{% translate 'ID' %}">{{ question.pk }}</td>
       <td data-label="{% translate 'Question' %}">{{ question.text }}</td>
       <td class="text-end" data-label="">
         {% if question.pk in editable_questions %}
@@ -52,6 +54,7 @@
 <table class="table mb-0 stacked-table">
 <thead>
   <tr>
+    <th>{% translate 'ID' %}</th>
     <th>{% translate 'Question' %}</th>
     <th>{% translate 'Answer' %}</th>
     <th>{% translate 'Answers' %}</th>
@@ -62,6 +65,7 @@
 <tbody>
 {% for answer in answers %}
   <tr>
+    <td data-label="{% translate 'ID' %}">{{ answer.question.pk }}</td>
     <td data-label="{% translate 'Question' %}">
       {% if answer.question.survey.state == 'running' %}
         <a href="{% url 'survey:answer_question' answer.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ answer.question.text }}</a>
@@ -79,7 +83,7 @@
     </td>
   </tr>
 {% empty %}
-  <tr><td colspan="5">{% translate 'No answers' %}</td></tr>
+  <tr><td colspan="6">{% translate 'No answers' %}</td></tr>
 {% endfor %}
 </tbody>
 </table>

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -1222,6 +1222,7 @@ def answer_delete(request, pk):
                 "can_edit": can_edit,
                 "edit_url": reverse("survey:question_edit", args=[question.pk]) if can_edit else "",
                 "delete_url": reverse("survey:question_delete", args=[question.pk]) if can_edit else "",
+                "id_label": gettext("ID"),
                 "edit_label": gettext("Edit"),
                 "remove_label": gettext("Remove question"),
                 "unanswered_label": gettext("Unanswered questions"),


### PR DESCRIPTION
## Summary
- show each question's numeric ID as the first column in survey and results tables
- adjust styling, sorting and AJAX code for the new ID column
- include question IDs in wikitext exports

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_689472f00f38832ea21296acfba07e97