### PR TITLE
Limit pie chart text width

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -20,6 +20,11 @@ body {
   margin-left: auto;
   margin-right: auto;
 }
+#pieCharts .pie-chart p {
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+}
 
 /* Set column widths on question tables */
 #answerTable th:nth-child(1),


### PR DESCRIPTION
## Summary
- constrain pie chart question text width to 400px

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6897af0b1e5c832ebac50f7642c6b12d