### PR TITLE
Move edit survey link to navbar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,7 @@
       {% url 'survey:answer_survey' as answer_survey_url %}
       {% url 'survey:survey_answers' as survey_answers_url %}
       {% url 'survey:userinfo' as userinfo_url %}
+      {% url 'survey:survey_edit' as survey_edit_url %}
       <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
         {% if unanswered_count %}
@@ -30,6 +31,9 @@
         <li class="nav-item"><span id="answer-nav-link" class="nav-link text-secondary" data-answer-url="{{ answer_survey_url }}">{% translate 'Answer survey' %}{% if request.user.is_authenticated %}(<span id="unanswered-count">0</span>){% endif %}</span></li>
         {% endif %}
         <li class="nav-item"><a class="nav-link{% if request.path == survey_answers_url %} active{% endif %}" href="{{ survey_answers_url }}">{% translate 'Answers' %}</a></li>
+        {% if can_edit %}
+        <li class="nav-item"><a class="nav-link{% if request.path == survey_edit_url %} active{% endif %}" href="{{ survey_edit_url }}">{% translate 'Edit survey' %}</a></li>
+        {% endif %}
       </ul>
       <ul id="userbar" class="navbar-nav ms-auto">
       <li class="nav-item">

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -122,10 +122,6 @@
 </table>
 </div>
 {% endif %}
-{% if can_edit %}
-   <a href="{% url 'survey:survey_edit' %}" class="btn btn-warning ms-2">{% translate 'Edit survey' %}</a>
-{% endif %}
-
 {% endblock %}
 {% block scripts %}
 <script src="{% static 'js/sort_tables.js' %}"></script>

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -15,11 +15,7 @@
 </tbody>
 </table>
 </div>
-{% if request.user.is_authenticated %}
-  {% if surveys %}
-    <a href="{% url 'survey:survey_edit' %}" class="btn btn-primary mt-3">{% translate 'Edit survey' %}</a>
-  {% else %}
-    <a href="{% url 'survey:survey_create' %}" class="btn btn-primary mt-3">{% translate 'Create survey' %}</a>
-  {% endif %}
+{% if request.user.is_authenticated and not surveys %}
+  <a href="{% url 'survey:survey_create' %}" class="btn btn-primary mt-3">{% translate 'Create survey' %}</a>
 {% endif %}
 {% endblock %}

--- a/wikikysely_project/survey/context_processors.py
+++ b/wikikysely_project/survey/context_processors.py
@@ -1,14 +1,19 @@
 from django.conf import settings
 from .models import Survey, Answer
+from .views import can_edit_survey
 
 
 def unanswered_count(request):
     """Return number of unanswered questions for the logged-in user."""
     if not request.user.is_authenticated:
-        return {"local_login_enabled": settings.LOCAL_LOGIN_ENABLED}
+        return {"local_login_enabled": settings.LOCAL_LOGIN_ENABLED, "can_edit": False}
     survey = Survey.get_main_survey()
     if survey is None:
-        return {"unanswered_count": 0, "local_login_enabled": settings.LOCAL_LOGIN_ENABLED}
+        return {
+            "unanswered_count": 0,
+            "local_login_enabled": settings.LOCAL_LOGIN_ENABLED,
+            "can_edit": False,
+        }
     answered_ids = Answer.objects.filter(
         user=request.user,
         question__survey=survey,
@@ -18,4 +23,9 @@ def unanswered_count(request):
         .exclude(id__in=answered_ids)
         .count()
     )
-    return {"unanswered_count": count, "local_login_enabled": settings.LOCAL_LOGIN_ENABLED}
+    can_edit = can_edit_survey(request.user, survey)
+    return {
+        "unanswered_count": count,
+        "local_login_enabled": settings.LOCAL_LOGIN_ENABLED,
+        "can_edit": can_edit,
+    }


### PR DESCRIPTION
## Summary
- Show "Edit survey" in the navbar when the user can edit the survey
- Supply `can_edit` in the global context processor
- Remove old edit-survey buttons from detail and list pages

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68982ce10cc4832eb0e96d61f6b625e4