### PR TITLE
Clarify data deletion warning

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -465,8 +465,17 @@ msgid "%(n)s answers"
 msgstr "%(n)s vastausta"
 
 #: templates/survey/userinfo.html:13
-msgid "This action cannot be undone. Delete your data?"
-msgstr "T\xC3\xA4t\xC3\xA4 toimintoa ei voi perua. Poista tietosi?"
+msgid ""
+"Deleting your data removes all answers, all questions you have asked that "
+"do not yet have answers from other users and are not hidden, and your user "
+"account if you no longer have questions or answers. This action cannot be "
+"undone. Delete your data?"
+msgstr ""
+"Tietojen poisto poistaa kaikki vastaukset, kaikki käyttäjän tekemät "
+"kysymykset joihin ei ole vielä vastauksia muilta käyttäjiltä ja jotka "
+"eivät ole piilotettuja sekä käyttäjätunnuksen jos käyttäjällä ei ole "
+"enää kysymyksiä tai vastauksia. Tätä toimintoa ei voi perua. Poista "
+"tietosi?"
 
 #: templates/survey/userinfo.html:15
 msgid "Download my data (JSON)"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -465,8 +465,16 @@ msgid "%(n)s answers"
 msgstr "%(n)s svar"
 
 #: templates/survey/userinfo.html:13
-msgid "This action cannot be undone. Delete your data?"
-msgstr "Detta g\xC3\xA5r inte att \xC3\xA5ngra. Ta bort dina uppgifter?"
+msgid ""
+"Deleting your data removes all answers, all questions you have asked that do"
+"not yet have answers from other users and are not hidden, and your user account"
+"if you no longer have questions or answers. This action cannot be undone."
+"Delete your data?"
+msgstr ""
+"Radering av dina uppgifter tar bort alla svar, alla frågor du har ställt som"
+"ännu inte har svar från andra användare och som inte är dolda samt ditt"
+"användarkonto om du inte längre har några frågor eller svar. Denna åtgärd kan"
+"inte ångras. Radera dina uppgifter?"
 
 #: templates/survey/userinfo.html:15
 msgid "Download my data (JSON)"

--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -10,7 +10,7 @@
   <li>{% blocktrans with n=total_answers %}{{ n }} answers{% endblocktrans %}</li>
 </ul>
 <p>
-  <form method="post" action="{% url 'survey:user_data_delete' %}" class="d-inline" onsubmit="return confirm('{% translate 'This action cannot be undone. Delete your data?' %}');">
+  <form method="post" action="{% url 'survey:user_data_delete' %}" class="d-inline" onsubmit="return confirm('{% translate 'Deleting your data removes all answers, all questions you have asked that do not yet have answers from other users and are not hidden, and your user account if you no longer have questions or answers. This action cannot be undone. Delete your data?' %}');">
     {% csrf_token %}
     <a href="{% url 'survey:userinfo_download' %}" class="btn btn-primary">{% translate 'Download my data (JSON)' %}</a>
     <button type="submit" class="btn btn-danger ms-2">{% translate 'Delete my data' %}</button>


### PR DESCRIPTION
## Summary
- expand English data deletion warning to explain removal of answers, unanswered non-hidden questions, and possibly the account
- localize the warning in Finnish and Swedish

## Testing
- `python manage.py compilemessages`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6898310f586c832ebd56ac29cd5304a8