### PR TITLE
Show hidden questions in user profile

### DIFF
--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -32,7 +32,13 @@
   {% for question in questions %}
     <tr>
       <td data-label="{% translate 'ID' %}">{{ question.pk }}</td>
-      <td data-label="{% translate 'Question' %}">{{ question.text }}</td>
+      <td data-label="{% translate 'Question' %}">
+        {% if question.visible %}
+          {{ question.text }}
+        {% else %}
+          <span class="text-decoration-line-through">{{ question.text }}</span>
+        {% endif %}
+      </td>
       <td class="text-end" data-label="">
         {% if question.pk in editable_questions %}
         <a href="{% url 'survey:question_edit' question.pk %}" class="btn btn-sm btn-warning me-2">{% translate 'Edit' %}</a>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -482,6 +482,24 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(answers[0].total_answers, 3)
         self.assertAlmostEqual(answers[0].agree_ratio, 33.3333, places=1)
 
+    def test_userinfo_includes_hidden_questions_without_edit_button(self):
+        survey = self._create_survey()
+        visible_q = self._create_question(survey, text="Visible Q")
+        hidden_q = self._create_question(survey, text="Hidden Q")
+        hidden_q.visible = False
+        hidden_q.save()
+
+        response = self.client.get(reverse("survey:userinfo"))
+        self.assertContains(response, visible_q.text)
+        self.assertContains(response, hidden_q.text)
+        self.assertContains(
+            response,
+            f'<span class="text-decoration-line-through">{hidden_q.text}</span>',
+            html=True,
+        )
+        edit_url = reverse("survey:question_edit", args=[hidden_q.pk])
+        self.assertNotContains(response, edit_url)
+
     def test_user_data_delete_removes_answers_and_questions(self):
         survey = self._create_survey()
         q1 = self._create_question(survey)

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -893,7 +893,6 @@ def userinfo(request):
     questions_qs = (
         Question.objects.filter(
             creator=request.user,
-            visible=True,
             survey__deleted=False,
         )
         .select_related("survey")
@@ -927,7 +926,7 @@ def userinfo(request):
         )
         if q.survey.state == "closed":
             can_modify = False
-        if can_modify:
+        if can_modify and q.visible:
             editable_questions.append(q.pk)
 
     return render(


### PR DESCRIPTION
## Summary
- include hidden questions in "My questions" list with strikethrough styling
- restrict edit links to visible questions only
- cover behavior with unit test

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6898353f5b44832ea5e3f83141c70bb7