### PR TITLE
Clarify user data deletion warning message

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -464,17 +464,17 @@ msgstr "%(n)s kysymyst\xC3\xA4"
 msgid "%(n)s answers"
 msgstr "%(n)s vastausta"
 
-#: templates/survey/userinfo.html:13
+#: templates/survey/userinfo.html:17
 msgid ""
-"Deleting your data removes all answers, all questions you have asked that "
-"do not yet have answers from other users and are not hidden, and your user "
-"account if you no longer have questions or answers. This action cannot be "
-"undone. Delete your data?"
+"Deleting your data will remove all answers and all questions you have asked "
+"that do not yet have answers from other users and are not hidden. If you no "
+"longer have any questions or answers, your account will also be deleted. "
+"This action cannot be undone. Delete your data?"
 msgstr ""
-"Tietojen poisto poistaa kaikki vastaukset, kaikki käyttäjän tekemät "
-"kysymykset joihin ei ole vielä vastauksia muilta käyttäjiltä ja jotka "
-"eivät ole piilotettuja sekä käyttäjätunnuksen jos käyttäjällä ei ole "
-"enää kysymyksiä tai vastauksia. Tätä toimintoa ei voi perua. Poista "
+"Tietojen poisto poistaa kaikki vastaukset ja kaikki tekemäsi kysymykset "
+"joihin ei ole vielä vastauksia muilta käyttäjiltä ja jotka eivät ole "
+"piilotettuja. Jos sinulla ei ole enää kysymyksiä tai vastauksia, myös "
+"käyttäjätunnuksesi poistetaan. Tätä toimintoa ei voi perua. Poista "
 "tietosi?"
 
 #: templates/survey/userinfo.html:15

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -464,17 +464,17 @@ msgstr "%(n)s fr\xC3\xA5gor"
 msgid "%(n)s answers"
 msgstr "%(n)s svar"
 
-#: templates/survey/userinfo.html:13
+#: templates/survey/userinfo.html:17
 msgid ""
-"Deleting your data removes all answers, all questions you have asked that do"
-"not yet have answers from other users and are not hidden, and your user account"
-"if you no longer have questions or answers. This action cannot be undone."
-"Delete your data?"
+"Deleting your data will remove all answers and all questions you have asked that"
+" do not yet have answers from other users and are not hidden. If you no"
+" longer have any questions or answers, your account will also be deleted."
+" This action cannot be undone. Delete your data?"
 msgstr ""
-"Radering av dina uppgifter tar bort alla svar, alla frågor du har ställt som"
-"ännu inte har svar från andra användare och som inte är dolda samt ditt"
-"användarkonto om du inte längre har några frågor eller svar. Denna åtgärd kan"
-"inte ångras. Radera dina uppgifter?"
+"Radering av dina uppgifter tar bort alla svar och alla frågor du har ställt som"
+" ännu inte har svar från andra användare och som inte är dolda. Om du"
+" inte längre har några frågor eller svar tas ditt användarkonto också bort."
+" Denna åtgärd kan inte ångras. Radera dina uppgifter?"
 
 #: templates/survey/userinfo.html:15
 msgid "Download my data (JSON)"

--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -14,7 +14,7 @@
   <dd>{{ total_answers }}</dd>
 </dl>
 <p>
-  <form method="post" action="{% url 'survey:user_data_delete' %}" class="d-inline" onsubmit="return confirm('{% translate 'Deleting your data removes all answers, all questions you have asked that do not yet have answers from other users and are not hidden, and your user account if you no longer have questions or answers. This action cannot be undone. Delete your data?' %}');">
+  <form method="post" action="{% url 'survey:user_data_delete' %}" class="d-inline" onsubmit="return confirm('{% translate 'Deleting your data will remove all answers and all questions you have asked that do not yet have answers from other users and are not hidden. If you no longer have any questions or answers, your account will also be deleted. This action cannot be undone. Delete your data?' %}');">
     {% csrf_token %}
     <a href="{% url 'survey:userinfo_download' %}" class="btn btn-primary">{% translate 'Download my data (JSON)' %}</a>
     <button type="submit" class="btn btn-danger ms-2">{% translate 'Delete my data' %}</button>


### PR DESCRIPTION
## Summary
- clarify the English warning about deleting user data
- update Finnish and Swedish translations for the new wording

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689839baf7b8832eb66dd6fb1ddac71b