### PR TITLE
Remove pointer cursor from selected yes/no buttons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -129,6 +129,11 @@ body {
 
 }
 
+/* Remove pointer cursor from selected yes/no buttons */
+.yes-no-group .btn-check:checked + label {
+  cursor: default;
+}
+
 /* Display userinfo definition list on single lines with colon */
 .user-data dt,
 .user-data dd {


### PR DESCRIPTION
## Summary
- Stop showing a pointer cursor over selected yes/no buttons so chosen responses no longer appear clickable

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689855f16a2c832ebb39305ddbe391ce