### PR TITLE
Highlight yes/no buttons on hover

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -134,6 +134,19 @@ body {
   cursor: default;
 }
 
+/* Highlight unselected yes/no buttons on hover */
+.yes-no-group .btn-check:not(:checked) + label.btn-outline-success:hover,
+.yes-no-group .btn.btn-outline-success:hover {
+  background-color: var(--bs-success);
+  color: #fff;
+}
+
+.yes-no-group .btn-check:not(:checked) + label.btn-outline-danger:hover,
+.yes-no-group .btn.btn-outline-danger:hover {
+  background-color: var(--bs-danger);
+  color: #fff;
+}
+
 /* Display userinfo definition list on single lines with colon */
 .user-data dt,
 .user-data dd {


### PR DESCRIPTION
## Summary
- visually emphasize selectable Yes/No buttons on hover

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689872a31b4c832eb2e9652c0bf2c68e