### PR TITLE
Add survey info section to answers page

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -630,6 +630,30 @@ msgstr "Vastauksen voi poistaa vain, kun kysely on käynnissä"
 msgid "Answer removed"
 msgstr "Vastaus poistettu"
 
+#: templates/survey/answers.html:124
+msgid "Survey information"
+msgstr "Tietoa kyselystä"
+
+#: templates/survey/answers.html:126
+msgid "Number of questions"
+msgstr "Kysymysten määrä"
+
+#: templates/survey/answers.html:128
+msgid "Number of respondents"
+msgstr "Vastaajien määrä"
+
+#: templates/survey/answers.html:130
+msgid "Number of question authors"
+msgstr "Kysymyksiä tehneiden käyttäjien määrä"
+
+#: templates/survey/answers.html:132
+msgid "First question date"
+msgstr "Ensimmäisen kysymyksen päivämäärä"
+
+#: templates/survey/answers.html:134
+msgid "Latest question date"
+msgstr "Viimeisimmän kysymyksen päivämäärä"
+
 #~ msgid "Deleted questions"
 #~ msgstr "Poistetut kysymykset"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -627,6 +627,30 @@ msgstr "Svar kan tas bort endast när enkäten är igång"
 msgid "Answer removed"
 msgstr "Svar borttaget"
 
+#: templates/survey/answers.html:124
+msgid "Survey information"
+msgstr "Information om enkäten"
+
+#: templates/survey/answers.html:126
+msgid "Number of questions"
+msgstr "Antal frågor"
+
+#: templates/survey/answers.html:128
+msgid "Number of respondents"
+msgstr "Antal svarande"
+
+#: templates/survey/answers.html:130
+msgid "Number of question authors"
+msgstr "Antal frågeställare"
+
+#: templates/survey/answers.html:132
+msgid "First question date"
+msgstr "Datum för första frågan"
+
+#: templates/survey/answers.html:134
+msgid "Latest question date"
+msgstr "Datum för senaste frågan"
+
 #~ msgid "Deleted questions"
 #~ msgstr "Borttagna frågor"
 

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -121,6 +121,19 @@
 </tbody>
 </table>
 </div>
+<h2>{% translate 'Survey information' %}</h2>
+<dl>
+  <dt>{% translate 'Number of questions' %}</dt>
+  <dd>{{ question_count }}</dd>
+  <dt>{% translate 'Number of respondents' %}</dt>
+  <dd>{{ total_users }}</dd>
+  <dt>{% translate 'Number of question authors' %}</dt>
+  <dd>{{ question_author_count }}</dd>
+  <dt>{% translate 'First question date' %}</dt>
+  <dd>{{ first_question_date|date:"Y-m-d" }}</dd>
+  <dt>{% translate 'Latest question date' %}</dt>
+  <dd>{{ last_question_date|date:"Y-m-d" }}</dd>
+</dl>
 {% endblock %}
 {% block scripts %}
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js"></script>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -363,6 +363,25 @@ class SurveyFlowTests(TransactionTestCase):
             html=True,
         )
 
+    def test_results_view_includes_survey_info(self):
+        survey = self._create_survey()
+        q1 = self._create_question(survey)
+        q2 = Question.objects.create(
+            survey=survey, text="Another?", creator=self.users[1]
+        )
+        Answer.objects.create(question=q1, user=self.user, answer="yes")
+        Answer.objects.create(question=q2, user=self.users[1], answer="no")
+        response = self.client.get(reverse("survey:survey_answers"))
+        self.assertEqual(response.context["question_count"], 2)
+        self.assertEqual(response.context["question_author_count"], 2)
+        self.assertEqual(
+            response.context["first_question_date"].date(), q1.created_at.date()
+        )
+        self.assertEqual(
+            response.context["last_question_date"].date(), q2.created_at.date()
+        )
+        self.assertContains(response, "Survey information")
+
     def test_answers_wikitext_contains_json(self):
         survey = self._create_survey()
         question = self._create_question(survey)

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -1249,6 +1249,14 @@ def survey_answers(request):
     total_users = (
         Answer.objects.filter(question__survey=survey).values("user").distinct().count()
     )
+    question_count = questions.count()
+    question_author_count = questions.values("creator").distinct().count()
+    first_question_date = (
+        questions.order_by("created_at").values_list("created_at", flat=True).first()
+    )
+    last_question_date = (
+        questions.order_by("-created_at").values_list("created_at", flat=True).first()
+    )
 
     user_answers = {}
     if request.user.is_authenticated:
@@ -1283,6 +1291,10 @@ def survey_answers(request):
             "survey": survey,
             "data": data,
             "total_users": total_users,
+            "question_count": question_count,
+            "question_author_count": question_author_count,
+            "first_question_date": first_question_date,
+            "last_question_date": last_question_date,
             "yes_label": yes_label,
             "no_label": no_label,
         "no_answers_label": no_answers_label,


### PR DESCRIPTION
## Summary
- Show "Survey information" with question/response stats on the answers page
- Localize new labels in Finnish and Swedish
- Test that results page exposes survey metadata

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689874132a60832e85cea88e47cdf708