### PR TITLE
Show latest question link for anonymous users

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -28,7 +28,13 @@
         {% if unanswered_count %}
         <li class="nav-item"><a id="answer-nav-link" class="nav-link{% if request.path == answer_survey_url %} active{% endif %}" href="{{ answer_survey_url }}">{% translate 'Answer survey' %} (<span id="unanswered-count">{{ unanswered_count }}</span>)</a></li>
         {% else %}
-        <li class="nav-item"><span id="answer-nav-link" class="nav-link text-secondary" data-answer-url="{{ answer_survey_url }}">{% translate 'Answer survey' %}{% if request.user.is_authenticated %}(<span id="unanswered-count">0</span>){% endif %}</span></li>
+        {% if request.user.is_authenticated %}
+        <li class="nav-item"><span id="answer-nav-link" class="nav-link text-secondary" data-answer-url="{{ answer_survey_url }}">{% translate 'Answer survey' %}(<span id="unanswered-count">0</span>)</span></li>
+        {% elif latest_question %}
+        <li class="nav-item"><a id="answer-nav-link" class="nav-link" href="{% url 'survey:answer_question' latest_question.id %}">{% translate 'Answer survey' %}</a></li>
+        {% else %}
+        <li class="nav-item"><span id="answer-nav-link" class="nav-link text-secondary">{% translate 'Answer survey' %}</span></li>
+        {% endif %}
         {% endif %}
         <li class="nav-item"><a class="nav-link{% if request.path == survey_answers_url %} active{% endif %}" href="{{ survey_answers_url }}">{% translate 'Answers' %}</a></li>
         {% if can_edit %}

--- a/wikikysely_project/survey/context_processors.py
+++ b/wikikysely_project/survey/context_processors.py
@@ -4,20 +4,36 @@ from .views import can_edit_survey
 
 
 def unanswered_count(request):
-    """Return number of unanswered questions for the logged-in user."""
-    if not request.user.is_authenticated:
-        return {"local_login_enabled": settings.LOCAL_LOGIN_ENABLED, "can_edit": False}
+    """Return unanswered question count and latest question data."""
+
     survey = Survey.get_main_survey()
+    latest_question = (
+        survey.questions.filter(visible=True)
+        .order_by("-created_at", "-id")
+        .first()
+        if survey
+        else None
+    )
+
+    if not request.user.is_authenticated:
+        return {
+            "local_login_enabled": settings.LOCAL_LOGIN_ENABLED,
+            "can_edit": False,
+            "latest_question": latest_question,
+        }
+
     if survey is None:
         return {
             "unanswered_count": 0,
             "local_login_enabled": settings.LOCAL_LOGIN_ENABLED,
             "can_edit": False,
+            "latest_question": latest_question,
         }
+
     answered_ids = Answer.objects.filter(
         user=request.user,
         question__survey=survey,
-    ).values_list('question_id', flat=True)
+    ).values_list("question_id", flat=True)
     count = (
         survey.questions.filter(visible=True)
         .exclude(id__in=answered_ids)
@@ -28,4 +44,5 @@ def unanswered_count(request):
         "unanswered_count": count,
         "local_login_enabled": settings.LOCAL_LOGIN_ENABLED,
         "can_edit": can_edit,
+        "latest_question": latest_question,
     }

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -105,6 +105,14 @@ class SurveyFlowTests(TransactionTestCase):
         response = self.client.get(reverse("login_redirect"))
         self.assertRedirects(response, reverse("survey:survey_detail"))
 
+    def test_nav_link_for_anonymous_points_to_latest_question(self):
+        survey = self._create_survey()
+        self._create_question(survey, text="First?")
+        latest = self._create_question(survey, text="Second?")
+        self.client.logout()
+        response = self.client.get(reverse("survey:survey_detail"))
+        self.assertEqual(response.context["latest_question"], latest)
+
     def test_survey_edit(self):
         survey = self._create_survey()
         data = {


### PR DESCRIPTION
## Summary
- Link "Answer survey" in navbar to newest question for anonymous visitors
- Provide latest visible question in context processor
- Test anonymous users see latest question in context

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68989470bb94832ea84e4170322322ed