### PR TITLE
Show login info on answer page when anonymous

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -42,6 +42,8 @@
   </div>
 
 </form>
+{% else %}
+<div class="alert alert-info">{{ login_message }}</div>
 {% endif %}
   </div>
 </div>

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -755,14 +755,12 @@ def answer_question(request, pk):
     can_delete_question = False
     next_url = request.GET.get("next") or request.POST.get("next")
 
+    login_message = None
     if not request.user.is_authenticated:
         login_url = f"{reverse('login')}?next={request.path}"
-        messages.info(
-            request,
-            format_html(
-                _('To answer the question you must <a href="{0}">log in</a>.'),
-                login_url,
-            ),
+        login_message = format_html(
+            _('To answer the question you must <a href="{0}">log in</a>.'),
+            login_url,
         )
         form = None
     else:
@@ -861,6 +859,7 @@ def answer_question(request, pk):
             "no_label": no_label,
             "no_answers_label": no_answers_label,
             "next": next_url,
+            "login_message": login_message,
         },
     )
 


### PR DESCRIPTION
## Summary
- Display question page with an info alert when user is not logged in instead of triggering a login dialog
- Pass login message to template for anonymous visitors

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68989d31b544832ea63a8b5e8a292279