### PR TITLE
Allow anonymous users to view random questions

### DIFF
--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -2,18 +2,6 @@
 {% load i18n static %}
 {% block title %}{% translate 'Answers' %}{% endblock %}
 {% block content %}
-{% if not request.user.is_authenticated and data %}
-  {% if request.GET.login_required %}
-    <p class="alert alert-info">
-      {% translate 'You must be logged in to answer questions' %}.
-      {% if local_login_enabled %}
-      <a href="{% url 'login' %}?next={% url 'login_redirect' %}">{% translate 'Login' %}</a>
-      {% else %}
-      <a href="{% url 'social:begin' 'mediawiki' %}?next={% url 'login_redirect' %}">{% translate 'Login with Wikimedia' %}</a>
-      {% endif %}
-    </p>
-  {% endif %}
-{% endif %}
 <p>{{ survey.description }}</p>
 {% if request.user.is_authenticated %}
     {% if data and survey.state == 'running' %}
@@ -22,9 +10,9 @@
       {% endif %}
       <a href="{% url 'survey:survey_answers_wikitext' %}" class="btn btn-secondary mb-3">{% translate 'Print wikitext' %}</a>
     {% endif %}
-  {% else %}
+{% else %}
     {% if data %}
-      <a href="?login_required=1" class="btn btn-primary mb-3 me-2">{% translate 'Answer survey' %}</a>
+      <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary mb-3 me-2">{% translate 'Answer survey' %}</a>
       <a href="{% url 'survey:survey_answers_wikitext' %}" class="btn btn-secondary mb-3">{% translate 'Print wikitext' %}</a>
     {% endif %}
   {% endif %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -12,18 +12,6 @@
 {% if not questions %}
   <p class="alert alert-warning">{% translate 'This survey has no questions yet. Please add questions.' %}</p>
 {% endif %}
-{% if not request.user.is_authenticated and questions %}
-  {% if request.GET.login_required %}
-    <p class="alert alert-info">
-      {% translate 'You must be logged in to answer questions' %}.
-      {% if local_login_enabled %}
-      <a href="{% url 'login' %}?next={% url 'login_redirect' %}">{% translate 'Login' %}</a>
-      {% else %}
-      <a href="{% url 'social:begin' 'mediawiki' %}?next={% url 'login_redirect' %}">{% translate 'Login with Wikimedia' %}</a>
-      {% endif %}
-    </p>
-  {% endif %}
-{% endif %}
 <p>{{ survey.description }}</p>
 {% if request.user.is_authenticated %}
   <div class="mb-3">
@@ -37,7 +25,7 @@
   </div>
 {% else %}
     {% if questions %}
-        <a href="?login_required=1" class="btn btn-primary">{% translate 'Answer survey' %}</a>
+        <a href="{% url 'survey:answer_survey' %}" class="btn btn-primary">{% translate 'Answer survey' %}</a>
     {% endif %}
 {% endif %}
         <h2 id="unanswered-header" class="mt-3"{% if not unanswered_questions %} style="display:none"{% endif %}>{% translate 'Unanswered questions' %}</h2>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -113,6 +113,24 @@ class SurveyFlowTests(TransactionTestCase):
         response = self.client.get(reverse("survey:survey_detail"))
         self.assertEqual(response.context["latest_question"], latest)
 
+    def test_answer_survey_accessible_without_login(self):
+        survey = self._create_survey()
+        question = self._create_question(survey)
+        self.client.logout()
+        response = self.client.get(reverse("survey:answer_survey"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["question"], question)
+        self.assertIsNone(response.context["form"])
+
+    def test_anonymous_cannot_submit_answer(self):
+        survey = self._create_survey()
+        question = self._create_question(survey)
+        self.client.logout()
+        data = {"question_id": question.pk, "answer": "yes"}
+        response = self.client.post(reverse("survey:answer_survey"), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Answer.objects.count(), 0)
+
     def test_survey_edit(self):
         survey = self._create_survey()
         data = {


### PR DESCRIPTION
## Summary
- Allow unauthenticated visitors to access the random question page but disable answering until login
- Link to random question page for logged-out users from survey detail and results pages
- Add tests covering anonymous access and answer restrictions

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6898a8c21800832e89b76e53d8a111eb