### PR TITLE
feat: add arrows to collapsible headers

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -159,3 +159,12 @@ body {
 .user-data dt::after {
   content: ": ";
 }
+
+/* Add arrow indicators for collapsible sections */
+.collapse-toggle::after {
+  content: " \25BC"; /* Down arrow */
+  margin-left: 0.25rem;
+}
+.collapse-toggle:not(.collapsed)::after {
+  content: " \25B2"; /* Up arrow when expanded */
+}

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -47,7 +47,7 @@
 </div>
 {% if question_stats %}
   <h2 class="mt-4">
-    <a class="text-decoration-none" data-bs-toggle="collapse" href="#answerDetails" role="button" aria-expanded="false" aria-controls="answerDetails">{% translate 'Answer details' %}</a>
+    <a class="text-decoration-none collapse-toggle collapsed" data-bs-toggle="collapse" href="#answerDetails" role="button" aria-expanded="false" aria-controls="answerDetails">{% translate 'Answer details' %}</a>
   </h2>
   <div id="answerDetails" class="collapse">
   <!--div class="row mb-4">
@@ -89,7 +89,7 @@
 {% if request.user.is_authenticated %}
 {% if user_answers %}
   <h2 class="mt-4">
-    <a class="text-decoration-none" data-bs-toggle="collapse" href="#myAnswers" role="button" aria-expanded="false" aria-controls="myAnswers">{% translate 'My answers' %}</a>
+    <a class="text-decoration-none collapse-toggle collapsed" data-bs-toggle="collapse" href="#myAnswers" role="button" aria-expanded="false" aria-controls="myAnswers">{% translate 'My answers' %}</a>
   </h2>
   <div id="myAnswers" class="collapse">
   <div class="table-responsive">


### PR DESCRIPTION
## Summary
- show up/down arrows next to collapsible headers on the answer page
- style collapse-toggle links with CSS-based arrow indicators

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6898b9cd9110832e9cb985fb757e2c12