### PR TITLE
Use Wikimedia OAuth login for answers

### DIFF
--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -653,7 +653,7 @@ def answer_survey(request):
         messages.error(request, _("Survey not active"))
         return redirect("survey:survey_detail")
     if not request.user.is_authenticated:
-        login_url = f"{reverse('login')}?next={request.path}"
+        login_url = f"{reverse('social:begin', args=['mediawiki'])}?next={request.path}"
         messages.info(
             request,
             format_html(
@@ -777,7 +777,7 @@ def answer_question(request, pk):
     next_url = request.GET.get("next") or request.POST.get("next")
 
     if not request.user.is_authenticated:
-        login_url = f"{reverse('login')}?next={request.path}"
+        login_url = f"{reverse('social:begin', args=['mediawiki'])}?next={request.path}"
         messages.info(
             request,
             format_html(


### PR DESCRIPTION
## Summary
- Direct answer login prompts to Wikimedia OAuth

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6898f286fc00832eb3e712277135c403