### PR TITLE
Add answer date to user answers table

### DIFF
--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -75,6 +75,7 @@
     <th>{% translate 'ID' %}</th>
     <th>{% translate 'Question' %}</th>
     <th>{% translate 'Answer' %}</th>
+    <th>{% translate 'Answer date' %}</th>
     <th>{% translate 'Answers' %}</th>
     <th>{% translate 'Agree' %}</th>
     <th></th>
@@ -92,6 +93,7 @@
       {% endif %}
     </td>
     <td data-label="{% translate 'Answer' %}">{{ answer.get_answer_display }}</td>
+    <td data-label="{% translate 'Answer date' %}">{{ answer.created_at|date:"Y-m-d" }}</td>
     <td data-label="{% translate 'Answers' %}">{{ answer.total_answers }}</td>
     <td data-label="{% translate 'Agree' %}">{{ answer.agree_ratio|floatformat:1 }}%</td>
     <td class="text-end" data-label="">
@@ -101,7 +103,7 @@
     </td>
   </tr>
 {% empty %}
-  <tr><td colspan="6">{% translate 'No answers' %}</td></tr>
+  <tr><td colspan="7">{% translate 'No answers' %}</td></tr>
 {% endfor %}
 </tbody>
 </table>


### PR DESCRIPTION
## Summary
- show answer date in the user's answers table

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68997bb9f030832e9258ab792263b872