### PR TITLE
Clarify chart colors on survey answers page

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -207,13 +207,21 @@ msgstr "Sinun tulee olla kirjautunut sisään vastataksesi kysymyksiin"
 msgid "Print wikitext"
 msgstr "Tulosta wikitekstinä"
 
-#: templates/survey/answers.html:21
-msgid "<span class=\"bg-success text-black px-1\">%(yes)s</span> and <span class=\"bg-danger text-light px-1\">%(no)s</span> indicate the answers."
-msgstr "<span class=\"bg-success text-black px-1\">%(yes)s</span> ja <span class=\"bg-danger text-light px-1\">%(no)s</span> ovat vastaukset."
-
 #: templates/survey/answers.html:24
-msgid "<span class=\"bg-secondary text-light px-1\">%(unanswered)s</span> shows the share of all respondents who have not answered."
-msgstr "<span class=\"bg-secondary text-light px-1\">%(unanswered)s</span> näyttää, kuinka suuri osa kaikista vastaajista on vastaamatta."
+msgid "<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s answers and <span class=\"bg-success text-black px-1\">%(green)s</span> means %(yes)s answers. <span class=\"bg-secondary text-light px-1\">%(grey)s</span> shows the share of all respondents who have not yet answered the question."
+msgstr "<span class=\"bg-danger text-light px-1\">%(red)s</span> tarkoittaa %(no)s vastauksia ja <span class=\"bg-success text-black px-1\">%(green)s</span> tarkoittaa %(yes)s vastauksia. <span class=\"bg-secondary text-light px-1\">%(grey)s</span> kertoo kuinka suuri osa kaikista vastaajista ei ole vielä vastannut kysymykseen."
+
+#: templates/survey/answers.html:20
+msgid "Red"
+msgstr "Punainen"
+
+#: templates/survey/answers.html:21
+msgid "Green"
+msgstr "Vihreä"
+
+#: templates/survey/answers.html:22
+msgid "Grey"
+msgstr "Harmaa"
 
 #: templates/survey/answers.html:35
 msgid "Pie chart"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -207,13 +207,21 @@ msgstr "Du måste vara inloggad för att kunna svara på frågorna"
 msgid "Print wikitext"
 msgstr "Skriv ut wikikod"
 
-#: templates/survey/answers.html:21
-msgid "<span class=\"bg-success text-black px-1\">%(yes)s</span> and <span class=\"bg-danger text-light px-1\">%(no)s</span> indicate the answers."
-msgstr "<span class=\"bg-success text-black px-1\">%(yes)s</span> och <span class=\"bg-danger text-light px-1\">%(no)s</span> visar svaren."
-
 #: templates/survey/answers.html:24
-msgid "<span class=\"bg-secondary text-light px-1\">%(unanswered)s</span> shows the share of all respondents who have not answered."
-msgstr "<span class=\"bg-secondary text-light px-1\">%(unanswered)s</span> visar hur stor del av alla svarande som inte har svarat."
+msgid "<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s answers and <span class=\"bg-success text-black px-1\">%(green)s</span> means %(yes)s answers. <span class=\"bg-secondary text-light px-1\">%(grey)s</span> shows the share of all respondents who have not yet answered the question."
+msgstr "<span class=\"bg-danger text-light px-1\">%(red)s</span> betyder %(no)s svar och <span class=\"bg-success text-black px-1\">%(green)s</span> betyder %(yes)s svar. <span class=\"bg-secondary text-light px-1\">%(grey)s</span> visar hur stor andel av alla svarande som ännu inte har svarat på frågan."
+
+#: templates/survey/answers.html:20
+msgid "Red"
+msgstr "Röd"
+
+#: templates/survey/answers.html:21
+msgid "Green"
+msgstr "Grön"
+
+#: templates/survey/answers.html:22
+msgid "Grey"
+msgstr "Grå"
 
 #: templates/survey/answers.html:35
 msgid "Pie chart"

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -17,13 +17,12 @@
   {% endif %}
   {% endif %}
 <h1>{% translate 'Answers' %}</h1>
+{% translate 'Red' as red_label %}
+{% translate 'Green' as green_label %}
+{% translate 'Grey' as grey_label %}
 <p>
-  {% blocktrans trimmed with yes=yes_label no=no_label %}
-  <span class="bg-success text-black px-1">{{ yes }}</span> and
-  <span class="bg-danger text-light px-1">{{ no }}</span> indicate the answers.
-  {% endblocktrans %}
-  {% blocktrans trimmed with unanswered=no_answers_label %}
-  <span class="bg-secondary text-light px-1">{{ unanswered }}</span> shows the share of all respondents who have not answered.
+  {% blocktrans trimmed with red=red_label green=green_label grey=grey_label yes=yes_label no=no_label %}
+  <span class="bg-danger text-light px-1">{{ red }}</span> means {{ no }} answers and <span class="bg-success text-black px-1">{{ green }}</span> means {{ yes }} answers. <span class="bg-secondary text-light px-1">{{ grey }}</span> shows the share of all respondents who have not yet answered the question.
   {% endblocktrans %}
 </p>
 <div class="mb-3">


### PR DESCRIPTION
## Summary
- Explain red, green, and grey chart colors on the answers page
- Add Finnish and Swedish translations for new color legend

## Testing
- `python manage.py compilemessages`
- `pip install -r requirements.txt`
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a49b7971ac832e927e1dfc2bb742c9