### PR TITLE
Hide grey explanation except for bar charts

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -208,8 +208,8 @@ msgid "Print wikitext"
 msgstr "Tulosta wikitekstinä"
 
 #: templates/survey/answers.html:24
-msgid "<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s answers and <span class=\"bg-success text-black px-1\">%(green)s</span> means %(yes)s answers. <span class=\"bg-secondary text-light px-1\">%(grey)s</span> shows the share of all respondents who have not yet answered the question."
-msgstr "<span class=\"bg-danger text-light px-1\">%(red)s</span> tarkoittaa %(no)s vastauksia ja <span class=\"bg-success text-black px-1\">%(green)s</span> tarkoittaa %(yes)s vastauksia. <span class=\"bg-secondary text-light px-1\">%(grey)s</span> kertoo kuinka suuri osa kaikista vastaajista ei ole vielä vastannut kysymykseen."
+msgid "<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s answers and <span class=\"bg-success text-black px-1\">%(green)s</span> means %(yes)s answers. <span id=\"unansweredInfo\"><span class=\"bg-secondary text-light px-1\">%(grey)s</span> shows the share of all respondents who have not yet answered the question.</span>"
+msgstr "<span class=\"bg-danger text-light px-1\">%(red)s</span> tarkoittaa %(no)s vastauksia ja <span class=\"bg-success text-black px-1\">%(green)s</span> tarkoittaa %(yes)s vastauksia. <span id=\"unansweredInfo\"><span class=\"bg-secondary text-light px-1\">%(grey)s</span> kertoo kuinka suuri osa kaikista vastaajista ei ole vielä vastannut kysymykseen.</span>"
 
 #: templates/survey/answers.html:20
 msgid "Red"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -208,8 +208,8 @@ msgid "Print wikitext"
 msgstr "Skriv ut wikikod"
 
 #: templates/survey/answers.html:24
-msgid "<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s answers and <span class=\"bg-success text-black px-1\">%(green)s</span> means %(yes)s answers. <span class=\"bg-secondary text-light px-1\">%(grey)s</span> shows the share of all respondents who have not yet answered the question."
-msgstr "<span class=\"bg-danger text-light px-1\">%(red)s</span> betyder %(no)s svar och <span class=\"bg-success text-black px-1\">%(green)s</span> betyder %(yes)s svar. <span class=\"bg-secondary text-light px-1\">%(grey)s</span> visar hur stor andel av alla svarande som ännu inte har svarat på frågan."
+msgid "<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s answers and <span class=\"bg-success text-black px-1\">%(green)s</span> means %(yes)s answers. <span id=\"unansweredInfo\"><span class=\"bg-secondary text-light px-1\">%(grey)s</span> shows the share of all respondents who have not yet answered the question.</span>"
+msgstr "<span class=\"bg-danger text-light px-1\">%(red)s</span> betyder %(no)s svar och <span class=\"bg-success text-black px-1\">%(green)s</span> betyder %(yes)s svar. <span id=\"unansweredInfo\"><span class=\"bg-secondary text-light px-1\">%(grey)s</span> visar hur stor andel av alla svarande som ännu inte har svarat på frågan.</span>"
 
 #: templates/survey/answers.html:20
 msgid "Red"

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -22,7 +22,7 @@
 {% translate 'Grey' as grey_label %}
 <p>
   {% blocktrans trimmed with red=red_label green=green_label grey=grey_label yes=yes_label no=no_label %}
-  <span class="bg-danger text-light px-1">{{ red }}</span> means {{ no }} answers and <span class="bg-success text-black px-1">{{ green }}</span> means {{ yes }} answers. <span class="bg-secondary text-light px-1">{{ grey }}</span> shows the share of all respondents who have not yet answered the question.
+  <span class="bg-danger text-light px-1">{{ red }}</span> means {{ no }} answers and <span class="bg-success text-black px-1">{{ green }}</span> means {{ yes }} answers. <span id="unansweredInfo" style="display:none"><span class="bg-secondary text-light px-1">{{ grey }}</span> shows the share of all respondents who have not yet answered the question.</span>
   {% endblocktrans %}
 </p>
 <div class="mb-3">
@@ -185,12 +185,15 @@ pieContainers.forEach(el => {
 function updateChartVisibility(type) {
     const barEl = document.getElementById('barChartTable');
     const pieEl = document.getElementById('pieChartsContainer');
+    const greyInfoEl = document.getElementById('unansweredInfo');
     if (type === 'bar') {
         barEl.style.display = '';
         pieEl.style.display = 'none';
+        greyInfoEl.style.display = '';
     } else {
         barEl.style.display = 'none';
         pieEl.style.display = '';
+        greyInfoEl.style.display = 'none';
     }
 }
 


### PR DESCRIPTION
## Summary
- Hide grey legend on answers page when not viewing bar chart
- Update Finnish and Swedish translations to match new legend markup

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a49e604c38832eabc670c4fefb1dab