### PR TITLE
Fix skip-all questions crash

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -132,6 +132,28 @@ class SurveyFlowTests(TransactionTestCase):
             )
             self.assertEqual(response.context["question"], q1)
 
+    def test_skipping_all_questions_via_answer_question(self):
+        survey = self._create_survey()
+        q1, q2 = self._create_questions(survey, count=2)
+
+        data = {"question_id": q1.pk, "answer": ""}
+        response = self.client.post(
+            reverse("survey:answer_question", args=[q1.pk]), data
+        )
+        self.assertTrue(
+            SkippedQuestion.objects.filter(user=self.user, question=q1).exists()
+        )
+        self.assertEqual(response.context["question"], q2)
+
+        data = {"question_id": q2.pk, "answer": ""}
+        response = self.client.post(
+            reverse("survey:answer_question", args=[q2.pk]), data
+        )
+        self.assertEqual(
+            SkippedQuestion.objects.filter(user=self.user).count(), 0
+        )
+        self.assertEqual(response.context["question"], q1)
+
     def test_survey_edit(self):
         survey = self._create_survey()
         data = {

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -876,11 +876,12 @@ def answer_question(request, pk):
                 skipped_questions = SkippedQuestion.objects.filter(
                     user=request.user, question__survey=survey
                 ).values_list("question_id", flat=True)
+                current_question_pk = question.pk
                 question = (
                     survey.questions.filter(visible=True)
                     .exclude(id__in=answered_questions)
                     .exclude(id__in=skipped_questions)
-                    .exclude(id=question.pk)
+                    .exclude(id=current_question_pk)
                     .order_by('?')
                     .first()
                 )
@@ -892,7 +893,7 @@ def answer_question(request, pk):
                     question = (
                         survey.questions.filter(visible=True)
                         .exclude(id__in=answered_questions)
-                        .exclude(id=question.pk)
+                        .exclude(id=current_question_pk)
                         .order_by('?')
                         .first()
                     )


### PR DESCRIPTION
## Summary
- avoid referencing `question` after it becomes `None` in `answer_question`
- add regression test for skipping all questions via `answer_question`

## Testing
- `python manage.py test wikikysely_project.survey.tests.test_views.SurveyFlowTests.test_skipping_all_questions_via_answer_question` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c44b0038832e907f334ce08fe91b