### PR TITLE
Show skipped questions on user info page

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -442,6 +442,14 @@ msgstr "Omat kysymykset"
 msgid "No answers"
 msgstr "Ei vastauksia"
 
+#: templates/survey/userinfo.html:112
+msgid "Skipped questions"
+msgstr "Ohitetut kysymykset"
+
+#: templates/survey/userinfo.html:134
+msgid "No skipped questions"
+msgstr "Ei ohitettuja kysymyksiä"
+
 #: wikikysely_project/survey/forms.py:34
 msgid "Text"
 msgstr "Teksti"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -442,6 +442,14 @@ msgstr "Mina frågor"
 msgid "No answers"
 msgstr "Inga svar"
 
+#: templates/survey/userinfo.html:112
+msgid "Skipped questions"
+msgstr "Överhoppade frågor"
+
+#: templates/survey/userinfo.html:134
+msgid "No skipped questions"
+msgstr "Inga överhoppade frågor"
+
 #: wikikysely_project/survey/forms.py:34
 msgid "Text"
 msgstr "Text"

--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -108,6 +108,34 @@
 </tbody>
 </table>
 </div>
+
+<h2 class="mt-4">{% translate 'Skipped questions' %}</h2>
+<div class="table-responsive">
+<table class="table mb-0 stacked-table">
+  <thead>
+    <tr>
+      <th>{% translate 'ID' %}</th>
+      <th>{% translate 'Question' %}</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for skip in skipped_questions %}
+    <tr>
+      <td data-label="{% translate 'ID' %}">{{ skip.question.pk }}</td>
+      <td data-label="{% translate 'Question' %}">
+        {% if skip.question.survey.state == 'running' %}
+          <a href="{% url 'survey:answer_question' skip.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ skip.question.text }}</a>
+        {% else %}
+          {{ skip.question.text }}
+        {% endif %}
+      </td>
+    </tr>
+  {% empty %}
+    <tr><td colspan="2">{% translate 'No skipped questions' %}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+</div>
 {% endblock %}
 
 {% block scripts %}

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -568,6 +568,17 @@ class SurveyFlowTests(TransactionTestCase):
         edit_url = reverse("survey:question_edit", args=[hidden_q.pk])
         self.assertNotContains(response, edit_url)
 
+    def test_userinfo_shows_skipped_questions(self):
+        survey = self._create_survey()
+        q = Question.objects.create(survey=survey, text="Skipped Q", creator=self.users[1])
+        SkippedQuestion.objects.create(user=self.user, question=q)
+
+        response = self.client.get(reverse("survey:userinfo"))
+        self.assertEqual(response.status_code, 200)
+        skipped = list(response.context["skipped_questions"])
+        self.assertEqual(skipped[0].question, q)
+        self.assertContains(response, q.text)
+
     def test_user_data_delete_removes_answers_and_questions(self):
         survey = self._create_survey()
         q1 = self._create_question(survey)

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -977,6 +977,15 @@ def userinfo(request):
 
     total_answers = Answer.objects.filter(user=request.user).count()
 
+    skipped_questions = (
+        SkippedQuestion.objects.filter(
+            user=request.user,
+            question__visible=True,
+            question__survey__deleted=False,
+        )
+        .select_related("question", "question__survey")
+    )
+
     questions_qs = (
         Question.objects.filter(
             creator=request.user,
@@ -1021,6 +1030,7 @@ def userinfo(request):
         "survey/userinfo.html",
         {
             "answers": answers,
+            "skipped_questions": skipped_questions,
             "questions": questions_qs,
             "hard_deletable_questions": hard_deletable_questions,
             "editable_questions": editable_questions,


### PR DESCRIPTION
## Summary
- List skipped questions on the user info page beneath answered questions
- Track skipped questions in view context and render with links to answer
- Cover skipped questions in tests and update translations

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c87fbe28832eb96307e9e1a9edd8