### PR TITLE
Hide skipped questions section when empty

### DIFF
--- a/templates/survey/userinfo.html
+++ b/templates/survey/userinfo.html
@@ -109,6 +109,7 @@
 </table>
 </div>
 
+{% if skipped_questions %}
 <h2 class="mt-4">{% translate 'Skipped questions' %}</h2>
 <div class="table-responsive">
 <table class="table mb-0 stacked-table">
@@ -130,12 +131,11 @@
         {% endif %}
       </td>
     </tr>
-  {% empty %}
-    <tr><td colspan="2">{% translate 'No skipped questions' %}</td></tr>
   {% endfor %}
   </tbody>
 </table>
 </div>
+{% endif %}
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- Only show the "Skipped questions" section on the user info page when the user has skipped questions

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cbc772c4832ea972994c5d17a752