### PR TITLE
Fix color legend translation

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-10 09:43+0000\n"
+"POT-Creation-Date: 2025-08-19 19:45+0000\n"
 "Language: fi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -14,61 +14,60 @@ msgstr ""
 msgid "Questions"
 msgstr "Kysymykset"
 
-#: templates/base.html:29 templates/base.html:31
-#: templates/survey/answers.html:21 templates/survey/answers.html:27
-#: templates/survey/survey_detail.html:31
-#: templates/survey/survey_detail.html:40
+#: templates/base.html:30 templates/base.html:33 templates/base.html:35
+#: templates/base.html:39 templates/base.html:41
+#: templates/survey/answers.html:9 templates/survey/answers.html:15
+#: templates/survey/survey_detail.html:19
+#: templates/survey/survey_detail.html:28
 msgid "Answer survey"
 msgstr "Vastaa"
 
-#: templates/base.html:33 templates/survey/answer_form.html:102
+#: templates/base.html:43 templates/survey/answer_form.html:102
 #: templates/survey/answer_form.html:113 templates/survey/answers.html:3
-#: templates/survey/answers.html:31 templates/survey/survey_detail.html:34
-#: templates/survey/survey_detail.html:51
-#: templates/survey/survey_detail.html:66
-#: templates/survey/survey_detail.html:89
-#: templates/survey/survey_detail.html:102 templates/survey/userinfo.html:20
-#: templates/survey/userinfo.html:78 templates/survey/userinfo.html:95
-#: wikikysely_project/survey/views.py:1231
+#: templates/survey/answers.html:19 templates/survey/survey_detail.html:22
+#: templates/survey/survey_detail.html:38
+#: templates/survey/survey_detail.html:48
+#: templates/survey/survey_detail.html:70
+#: templates/survey/survey_detail.html:82 templates/survey/userinfo.html:20
+#: templates/survey/userinfo.html:79 templates/survey/userinfo.html:97
+#: wikikysely_project/survey/views.py:1335
 msgid "Answers"
 msgstr "Vastaukset"
 
 # UI strings
-#: templates/base.html:35 templates/survey/survey_form.html:3
+#: templates/base.html:45 templates/survey/survey_form.html:3
 #: templates/survey/survey_form.html:5
 msgid "Edit survey"
 msgstr "Muokkaa kyselyä"
 
-#: templates/base.html:54
+#: templates/base.html:64
 msgid "Logout"
 msgstr "Kirjaudu ulos"
 
-#: templates/base.html:57 templates/registration/login.html:3
+#: templates/base.html:67 templates/registration/login.html:3
 #: templates/registration/login.html:5 templates/registration/login.html:10
-#: templates/survey/answers.html:10 templates/survey/survey_detail.html:20
 msgid "Login"
 msgstr "Kirjaudu sisään"
 
-#: templates/base.html:58 templates/registration/register.html:3
+#: templates/base.html:68 templates/registration/register.html:3
 #: templates/registration/register.html:5
 #: templates/registration/register.html:10
 msgid "Register"
 msgstr "Rekisteröidy"
 
-#: templates/base.html:60 templates/registration/login.html:13
-#: templates/survey/answers.html:12 templates/survey/survey_detail.html:22
+#: templates/base.html:70 templates/registration/login.html:13
 msgid "Login with Wikimedia"
 msgstr "Kirjaudu Wikimedian tunnuksilla"
 
-#: templates/base.html:81
+#: templates/base.html:91
 msgid "Project page"
 msgstr "Projektisivu"
 
-#: templates/base.html:82
+#: templates/base.html:92
 msgid "Source code"
 msgstr "Lähdekoodi"
 
-#: templates/base.html:83
+#: templates/base.html:93
 msgid "Privacy policy"
 msgstr "Tietosuojakäytäntö"
 
@@ -77,47 +76,47 @@ msgid "Answer question"
 msgstr "Vastaa kysymykseen"
 
 #: templates/survey/answer_form.html:23 templates/survey/answer_form.html:120
-#: templates/survey/survey_detail.html:109 templates/survey/userinfo.html:77
-#: templates/survey/userinfo.html:94
+#: templates/survey/survey_detail.html:89 templates/survey/userinfo.html:78
+#: templates/survey/userinfo.html:96
 msgid "Answer"
 msgstr "Vastaus"
 
 #: templates/survey/answer_form.html:27 templates/survey/answer_form.html:69
 #: templates/survey/answer_form.html:79 templates/survey/answer_form.html:122
-#: templates/survey/answers.html:94 templates/survey/answers.html:115
-#: templates/survey/survey_detail.html:111
+#: templates/survey/answers.html:82 templates/survey/answers.html:99
+#: templates/survey/survey_detail.html:91
 #: wikikysely_project/survey/models.py:55
-#: wikikysely_project/survey/views.py:396
-#: wikikysely_project/survey/views.py:612
-#: wikikysely_project/survey/views.py:717
-#: wikikysely_project/survey/views.py:841
-#: wikikysely_project/survey/views.py:1276
-#: wikikysely_project/survey/views.py:1340
+#: wikikysely_project/survey/views.py:404
+#: wikikysely_project/survey/views.py:620
+#: wikikysely_project/survey/views.py:774
+#: wikikysely_project/survey/views.py:928
+#: wikikysely_project/survey/views.py:1388
+#: wikikysely_project/survey/views.py:1456
 msgid "Yes"
 msgstr "Kyllä"
 
 #: templates/survey/answer_form.html:29 templates/survey/answer_form.html:70
 #: templates/survey/answer_form.html:80 templates/survey/answer_form.html:124
-#: templates/survey/answers.html:95 templates/survey/answers.html:116
-#: templates/survey/survey_detail.html:113
+#: templates/survey/answers.html:83 templates/survey/answers.html:100
+#: templates/survey/survey_detail.html:93
 #: wikikysely_project/survey/models.py:56
-#: wikikysely_project/survey/views.py:397
-#: wikikysely_project/survey/views.py:613
-#: wikikysely_project/survey/views.py:718
-#: wikikysely_project/survey/views.py:842
-#: wikikysely_project/survey/views.py:1277
-#: wikikysely_project/survey/views.py:1341
+#: wikikysely_project/survey/views.py:405
+#: wikikysely_project/survey/views.py:621
+#: wikikysely_project/survey/views.py:775
+#: wikikysely_project/survey/views.py:929
+#: wikikysely_project/survey/views.py:1389
+#: wikikysely_project/survey/views.py:1457
 msgid "No"
 msgstr "Ei"
 
 #: templates/survey/answer_form.html:33 templates/survey/answer_form.html:127
-#: templates/survey/survey_detail.html:116 templates/survey/userinfo.html:99
+#: templates/survey/survey_detail.html:96 templates/survey/userinfo.html:101
 msgid "Remove answer"
 msgstr "Poista vastaus"
 
 #: templates/survey/answer_form.html:36 templates/survey/question_form.html:12
-#: templates/survey/survey_detail.html:71 templates/survey/userinfo.html:59
-#: wikikysely_project/survey/views.py:1226
+#: templates/survey/survey_detail.html:53 templates/survey/userinfo.html:59
+#: wikikysely_project/survey/views.py:1330
 msgid "Remove question"
 msgstr "Poista kysymys"
 
@@ -138,78 +137,67 @@ msgid "Answers over time"
 msgstr "Vastausten määrä ajan kuluessa"
 
 #: templates/survey/answer_form.html:67 templates/survey/answer_form.html:77
-#: templates/survey/answer_form.html:99 templates/survey/answer_form.html:110
-#: templates/survey/answers.html:88 templates/survey/answers.html:103
+#: templates/survey/answer_form.html:100 templates/survey/answer_form.html:111
+#: templates/survey/answers.html:76 templates/survey/answers.html:91
 #: templates/survey/answers_wikitext.txt:19
-#: templates/survey/survey_detail.html:48
-#: templates/survey/survey_detail.html:59
-#: templates/survey/survey_detail.html:86
-#: templates/survey/survey_detail.html:97 templates/survey/userinfo.html:38
+#: templates/survey/survey_detail.html:36
+#: templates/survey/survey_detail.html:46
+#: templates/survey/survey_detail.html:68
+#: templates/survey/survey_detail.html:78 templates/survey/userinfo.html:38
 #: templates/survey/userinfo.html:46 templates/survey/userinfo.html:75
-#: templates/survey/userinfo.html:86 wikikysely_project/survey/views.py:1224
+#: templates/survey/userinfo.html:87 templates/survey/userinfo.html:118
+#: templates/survey/userinfo.html:125 wikikysely_project/survey/views.py:1328
 msgid "ID"
 msgstr ""
 
 #: templates/survey/answer_form.html:68 templates/survey/answer_form.html:78
-#: templates/survey/answers.html:89 templates/survey/answers.html:104
+#: templates/survey/answers.html:77 templates/survey/answers.html:92
 #: templates/survey/answers_wikitext.txt:19
-#: templates/survey/survey_detail.html:49
-#: templates/survey/survey_detail.html:60
-#: templates/survey/survey_detail.html:87
-#: templates/survey/survey_detail.html:98
-#: wikikysely_project/survey/views.py:1229
+#: wikikysely_project/survey/views.py:1333
 msgid "Published"
 msgstr "Julkaistu"
 
 #: templates/survey/answer_form.html:71 templates/survey/answer_form.html:81
-#: templates/survey/answers.html:96 templates/survey/answers.html:117
+#: templates/survey/answers.html:84 templates/survey/answers.html:101
 #: templates/survey/answers_wikitext.txt:19
 msgid "Total"
 msgstr "Yhteensä"
 
 #: templates/survey/answer_form.html:72 templates/survey/answer_form.html:82
 #: templates/survey/answer_form.html:103 templates/survey/answer_form.html:114
-#: templates/survey/answers.html:97 templates/survey/answers.html:118
+#: templates/survey/answers.html:85 templates/survey/answers.html:102
 #: templates/survey/answers_wikitext.txt:19
-#: templates/survey/survey_detail.html:52
-#: templates/survey/survey_detail.html:67
-#: templates/survey/survey_detail.html:90
-#: templates/survey/survey_detail.html:103 templates/survey/userinfo.html:79
-#: templates/survey/userinfo.html:96 wikikysely_project/survey/views.py:1232
+#: templates/survey/survey_detail.html:39
+#: templates/survey/survey_detail.html:49
+#: templates/survey/survey_detail.html:71
+#: templates/survey/survey_detail.html:83 templates/survey/userinfo.html:80
+#: templates/survey/userinfo.html:98 wikikysely_project/survey/views.py:1336
 msgid "Agree"
 msgstr "Yksimielisyys"
 
-#: templates/survey/answer_form.html:92 templates/survey/survey_detail.html:81
+#: templates/survey/answer_form.html:92 templates/survey/survey_detail.html:63
 #: templates/survey/userinfo.html:70
 msgid "My answers"
 msgstr "Vastaukseni"
 
-#: templates/survey/answer_form.html:100 templates/survey/answer_form.html:111
+#: templates/survey/answer_form.html:99 templates/survey/answer_form.html:110
+#: templates/survey/userinfo.html:77 templates/survey/userinfo.html:95
 msgid "Answer date"
 msgstr "Vastauspäivä"
 
 #: templates/survey/answer_form.html:101 templates/survey/answer_form.html:112
-#: templates/survey/survey_detail.html:50
-#: templates/survey/survey_detail.html:62
-#: templates/survey/survey_detail.html:64
-#: templates/survey/survey_detail.html:88
-#: templates/survey/survey_detail.html:99 templates/survey/survey_list.html:8
+#: templates/survey/survey_detail.html:37
+#: templates/survey/survey_detail.html:47
+#: templates/survey/survey_detail.html:69
+#: templates/survey/survey_detail.html:79 templates/survey/survey_list.html:8
 #: templates/survey/survey_list.html:11 wikikysely_project/survey/models.py:12
-#: wikikysely_project/survey/views.py:1230
+#: wikikysely_project/survey/views.py:1334
 msgid "Title"
 msgstr "Otsikko"
 
-#: templates/survey/answers.html:8 templates/survey/survey_detail.html:18
-msgid "You must be logged in to answer questions"
-msgstr "Sinun tulee olla kirjautunut sisään vastataksesi kysymyksiin"
-
-#: templates/survey/answers.html:23 templates/survey/answers.html:28
+#: templates/survey/answers.html:11 templates/survey/answers.html:16
 msgid "Print wikitext"
 msgstr "Tulosta wikitekstinä"
-
-#: templates/survey/answers.html:24
-msgid "<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s answers and <span class=\"bg-success text-black px-1\">%(green)s</span> means %(yes)s answers. <span id=\"unansweredInfo\"><span class=\"bg-secondary px-1\">%(grey)s</span> shows the share of all respondents who have not yet answered the question.</span>"
-msgstr "<span class=\"bg-danger text-light px-1\">%(red)s</span> tarkoittaa %(no)s vastauksia ja <span class=\"bg-success text-black px-1\">%(green)s</span> tarkoittaa %(yes)s vastauksia. <span id=\"unansweredInfo\"><span class=\"bg-secondary px-1\">%(grey)s</span> kertoo kuinka suuri osa kaikista vastaajista ei ole vielä vastannut kysymykseen.</span>"
 
 #: templates/survey/answers.html:20
 msgid "Red"
@@ -223,33 +211,71 @@ msgstr "Vihreä"
 msgid "Grey"
 msgstr "Harmaa"
 
-#: templates/survey/answers.html:35
+#: templates/survey/answers.html:24
+#, fuzzy, python-format
+#| msgid ""
+#| "<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s "
+#| "answers and <span class=\"bg-success text-black px-1\">%(green)s</span> "
+#| "means %(yes)s answers. <span id=\"unansweredInfo\"><span class=\"bg-"
+#| "secondary px-1\">%(grey)s</span> shows the share of all respondents who "
+#| "have not yet answered the question.</span>"
+msgid ""
+"<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s "
+"answers and <span class=\"bg-success text-black px-1\">%(green)s</span> "
+"means %(yes)s answers. <span id=\"unansweredInfo\" style=\"display:"
+"none\"><span class=\"bg-secondary px-1\">%(grey)s</span> shows the share of "
+"all respondents who have not yet answered the question.</span>"
+msgstr ""
+"<span class=\"bg-danger text-light px-1\">%(red)s</span> tarkoittaa %(no)s "
+"vastauksia ja <span class=\"bg-success text-black px-1\">%(green)s</span> "
+"tarkoittaa %(yes)s vastauksia. <span id=\"unansweredInfo\" style=\"display:none\"><span class=\"bg-"
+"secondary px-1\">%(grey)s</span> kertoo kuinka suuri osa kaikista "
+"vastaajista ei ole vielä vastannut kysymykseen.</span>"
+
+#: templates/survey/answers.html:31
 msgid "Pie chart"
 msgstr "Piirakkakaavio"
 
-#: templates/survey/answers.html:39
+#: templates/survey/answers.html:35
 msgid "Bar chart"
 msgstr "Palkkikaavio"
 
-#: templates/survey/answers.html:82 templates/survey/answers_wikitext.txt:26
+#: templates/survey/answers.html:70 templates/survey/answers_wikitext.txt:26
 msgid "Total respondents"
 msgstr "Vastaajien määrä"
 
-#: templates/survey/answers.html:83 templates/survey/answers_wikitext.txt:17
+#: templates/survey/answers.html:71 templates/survey/answers_wikitext.txt:17
 msgid "Answer table"
 msgstr "Vastaustaulukko"
 
-#: templates/survey/answers.html:90 templates/survey/answers.html:105
+#: templates/survey/answers.html:78 templates/survey/answers.html:93
 #: templates/survey/answers_wikitext.txt:19 templates/survey/userinfo.html:39
 #: templates/survey/userinfo.html:47 templates/survey/userinfo.html:76
-#: templates/survey/userinfo.html:87
+#: templates/survey/userinfo.html:88 templates/survey/userinfo.html:119
+#: templates/survey/userinfo.html:126
 msgid "Question"
 msgstr "Kysymys"
 
-#: templates/survey/answers.html:92 templates/survey/answers.html:113
+#: templates/survey/answers.html:80 templates/survey/answers.html:97
 #: templates/survey/answers_wikitext.txt:19
 msgid "My answer"
 msgstr "Oma vastaus"
+
+#: templates/survey/answers.html:108
+msgid "Survey information"
+msgstr "Tietoa kyselystä"
+
+#: templates/survey/answers.html:111
+msgid "Number of questions"
+msgstr "Kysymysten määrä"
+
+#: templates/survey/answers.html:115
+msgid "Number of respondents"
+msgstr "Vastaajien määrä"
+
+#: templates/survey/answers.html:119
+msgid "Number of question authors"
+msgstr "Kysyjien määrä"
 
 #: templates/survey/answers_wikitext.html:3
 #: templates/survey/answers_wikitext.html:5
@@ -281,7 +307,7 @@ msgid "Edit question"
 msgstr "Muokkaa kysymystä"
 
 #: templates/survey/question_form.html:3 templates/survey/question_form.html:5
-#: templates/survey/survey_detail.html:36
+#: templates/survey/survey_detail.html:24
 msgid "Add question"
 msgstr "Lisää kysymys"
 
@@ -331,13 +357,13 @@ msgstr ""
 msgid "This survey has no questions yet. Please add questions."
 msgstr "Kyselyssä ei ole yhtään kysymystä vielä."
 
-#: templates/survey/survey_detail.html:43
-#: wikikysely_project/survey/views.py:1227
+#: templates/survey/survey_detail.html:31
+#: wikikysely_project/survey/views.py:1331
 msgid "Unanswered questions"
 msgstr "Vastaamattomat kysymykset"
 
-#: templates/survey/survey_detail.html:70 templates/survey/userinfo.html:56
-#: wikikysely_project/survey/views.py:1225
+#: templates/survey/survey_detail.html:52 templates/survey/userinfo.html:56
+#: wikikysely_project/survey/views.py:1329
 msgid "Edit"
 msgstr "Muokkaa"
 
@@ -396,7 +422,7 @@ msgstr "Kyselyt"
 msgid "State"
 msgstr "Tila"
 
-#: templates/survey/survey_list.html:13 wikikysely_project/survey/views.py:198
+#: templates/survey/survey_list.html:13 wikikysely_project/survey/views.py:206
 msgid "No surveys"
 msgstr "Ei kyselyitä"
 
@@ -436,19 +462,15 @@ msgstr "Poista tietoni"
 msgid "My questions"
 msgstr "Omat kysymykset"
 
-#: templates/survey/userinfo.html:104 wikikysely_project/survey/views.py:719
-#: wikikysely_project/survey/views.py:843
-#: wikikysely_project/survey/views.py:1278
+#: templates/survey/userinfo.html:106 wikikysely_project/survey/views.py:776
+#: wikikysely_project/survey/views.py:930
+#: wikikysely_project/survey/views.py:1390
 msgid "No answers"
 msgstr "Ei vastauksia"
 
-#: templates/survey/userinfo.html:112
+#: templates/survey/userinfo.html:113
 msgid "Skipped questions"
 msgstr "Ohitetut kysymykset"
-
-#: templates/survey/userinfo.html:134
-msgid "No skipped questions"
-msgstr "Ei ohitettuja kysymyksiä"
 
 #: wikikysely_project/survey/forms.py:34
 msgid "Text"
@@ -474,40 +496,40 @@ msgstr "Suljettu"
 msgid "Description"
 msgstr "Kuvaus"
 
-#: wikikysely_project/survey/views.py:149
+#: wikikysely_project/survey/views.py:157
 msgid "Registration successful"
 msgstr "Rekisteröinti onnistui"
 
-#: wikikysely_project/survey/views.py:181
+#: wikikysely_project/survey/views.py:189
 msgid "Logged out"
 msgstr "Kirjauduit ulos"
 
-#: wikikysely_project/survey/views.py:324
+#: wikikysely_project/survey/views.py:332
 msgid "Survey created"
 msgstr "Kysely luotu"
 
-#: wikikysely_project/survey/views.py:337
-#: wikikysely_project/survey/views.py:385
-#: wikikysely_project/survey/views.py:433
-#: wikikysely_project/survey/views.py:467
-#: wikikysely_project/survey/views.py:492
-#: wikikysely_project/survey/views.py:496
-#: wikikysely_project/survey/views.py:528
-#: wikikysely_project/survey/views.py:557
-#: wikikysely_project/survey/views.py:592
+#: wikikysely_project/survey/views.py:345
+#: wikikysely_project/survey/views.py:393
+#: wikikysely_project/survey/views.py:441
+#: wikikysely_project/survey/views.py:475
+#: wikikysely_project/survey/views.py:500
+#: wikikysely_project/survey/views.py:504
+#: wikikysely_project/survey/views.py:536
+#: wikikysely_project/survey/views.py:565
+#: wikikysely_project/survey/views.py:600
 msgid "No permission"
 msgstr "Ei oikeuksia"
 
-#: wikikysely_project/survey/views.py:344
+#: wikikysely_project/survey/views.py:352
 msgid "Survey updated"
 msgstr "Kysely päivitetty"
 
-#: wikikysely_project/survey/views.py:378
+#: wikikysely_project/survey/views.py:386
 msgid "Cannot add questions to a closed survey"
 msgstr "Suljettuun kyselyyn ei voi lisätä kysymyksiä"
 
-#: wikikysely_project/survey/views.py:401
-#: wikikysely_project/survey/views.py:617
+#: wikikysely_project/survey/views.py:409
+#: wikikysely_project/survey/views.py:625
 #, python-format
 msgid ""
 "The question \"%(text)s\" already exists and has %(count)d answers "
@@ -516,102 +538,108 @@ msgstr ""
 "Kysymys \"%(text)s\" on jo olemassa ja sille on %(count)d vastausta "
 "(%(yes_label)s %(yes)d, %(no_label)s %(no)d). Muotoile kysymys toisin."
 
-#: wikikysely_project/survey/views.py:417
+#: wikikysely_project/survey/views.py:425
 msgid "Question added"
 msgstr "Kysymys lisätty"
 
-#: wikikysely_project/survey/views.py:437
-#: wikikysely_project/survey/views.py:500
+#: wikikysely_project/survey/views.py:445
+#: wikikysely_project/survey/views.py:508
 msgid "Cannot remove questions from a closed survey"
 msgstr "Suljetusta kyselystä ei voi poistaa kysymyksiä"
 
-#: wikikysely_project/survey/views.py:451
+#: wikikysely_project/survey/views.py:459
 msgid "Question hidden"
 msgstr "Kysymys piilotettu"
 
-#: wikikysely_project/survey/views.py:470
+#: wikikysely_project/survey/views.py:478
 msgid "Cannot restore questions in a closed survey"
 msgstr "Suljettuun kyselyyn ei voi palauttaa kysymyksiä"
 
-#: wikikysely_project/survey/views.py:481
+#: wikikysely_project/survey/views.py:489
 msgid "Question visible"
 msgstr "Kysymys näytetty"
 
-#: wikikysely_project/survey/views.py:506
+#: wikikysely_project/survey/views.py:514
 msgid "Question removed"
 msgstr "Kysymys poistettu"
 
-#: wikikysely_project/survey/views.py:545
+#: wikikysely_project/survey/views.py:553
 msgid "Secretary added"
 msgstr "Sihteeri lisätty"
 
-#: wikikysely_project/survey/views.py:547
-#: wikikysely_project/survey/views.py:572
+#: wikikysely_project/survey/views.py:555
+#: wikikysely_project/survey/views.py:580
 msgid "User not found"
 msgstr "Käyttäjää ei löytynyt"
 
-#: wikikysely_project/survey/views.py:570
+#: wikikysely_project/survey/views.py:578
 msgid "Secretary removed"
 msgstr "Sihteeri poistettu"
 
-#: wikikysely_project/survey/views.py:596
+#: wikikysely_project/survey/views.py:604
 msgid "Cannot edit questions in a closed survey"
 msgstr "Suljetussa kyselyssä ei voi muokata kysymyksiä"
 
-#: wikikysely_project/survey/views.py:630
+#: wikikysely_project/survey/views.py:638
 msgid "Question updated"
 msgstr "Kysymys päivitetty"
 
-#: wikikysely_project/survey/views.py:650
-#: wikikysely_project/survey/views.py:653
-#: wikikysely_project/survey/views.py:748
-#: wikikysely_project/survey/views.py:751
+#: wikikysely_project/survey/views.py:657
+#: wikikysely_project/survey/views.py:660
+#: wikikysely_project/survey/views.py:805
+#: wikikysely_project/survey/views.py:808
 msgid "Survey not active"
 msgstr "Kysely ei ole aktiivinen"
 
-#: wikikysely_project/survey/views.py:671
-#: wikikysely_project/survey/views.py:780
-msgid "Answer saved"
-msgstr "Vastaus tallennettu"
+#: wikikysely_project/survey/views.py:668
+#: wikikysely_project/survey/views.py:821
+#, python-brace-format
+msgid ""
+"To answer the question you must log in. <a href=\"{0}\">Log in with your "
+"Wikimedia account</a>."
+msgstr ""
+"Vastataksesi kysymykseen sinun on kirjauduttava sisälle. <a "
+"href=\"{0}\">Kirjaudu Wikimedian tunnuksilla</a>."
 
-#: wikikysely_project/survey/views.py:673
-#: wikikysely_project/survey/views.py:782
-msgid "Question skipped"
-msgstr "Kysymys ohitettu"
-
-#: wikikysely_project/survey/views.py:686
-#: wikikysely_project/survey/views.py:702
-#: wikikysely_project/survey/views.py:815
+#: wikikysely_project/survey/views.py:680
+#: wikikysely_project/survey/views.py:733
+#: wikikysely_project/survey/views.py:759
+#: wikikysely_project/survey/views.py:902
 msgid "No more questions"
 msgstr "Ei enempää kysymyksiä"
 
-#: wikikysely_project/survey/views.py:763
-#, python-brace-format
-msgid "To answer the question you must log in. <a href=\"{0}\">Log in with your Wikimedia account</a>."
-msgstr "Vastataksesi kysymykseen sinun on kirjauduttava sisälle. <a href=\"{0}\">Kirjaudu Wikimedian tunnuksilla</a>."
+#: wikikysely_project/survey/views.py:702
+#: wikikysely_project/survey/views.py:843
+msgid "Answer saved"
+msgstr "Vastaus tallennettu"
 
-#: wikikysely_project/survey/views.py:1069
+#: wikikysely_project/survey/views.py:707
+#: wikikysely_project/survey/views.py:848
+msgid "Question skipped"
+msgstr "Kysymys ohitettu"
+
+#: wikikysely_project/survey/views.py:1173
 #, python-format
 msgid "Removed %(removed)d/%(total)d answer."
 msgid_plural "Removed %(removed)d/%(total)d answers."
 msgstr[0] "Poistettu %(removed)d/%(total)d vastaus."
 msgstr[1] "Poistettu %(removed)d/%(total)d vastausta."
 
-#: wikikysely_project/survey/views.py:1075
+#: wikikysely_project/survey/views.py:1179
 #, python-format
 msgid "Removed %(removed)d/%(total)d question."
 msgid_plural "Removed %(removed)d/%(total)d questions."
 msgstr[0] "Poistettu %(removed)d/%(total)d kysymys."
 msgstr[1] "Poistettu %(removed)d/%(total)d kysymystä."
 
-#: wikikysely_project/survey/views.py:1081
+#: wikikysely_project/survey/views.py:1185
 #, python-format
 msgid "Removed %(removed)d/%(total)d survey."
 msgid_plural "Removed %(removed)d/%(total)d surveys."
 msgstr[0] "Poistettu %(removed)d/%(total)d kysely."
 msgstr[1] "Poistettu %(removed)d/%(total)d kyselyä."
 
-#: wikikysely_project/survey/views.py:1091
+#: wikikysely_project/survey/views.py:1195
 #, python-format
 msgid "Could not remove %(count)d question because it already had answers."
 msgid_plural ""
@@ -621,7 +649,7 @@ msgstr[0] ""
 msgstr[1] ""
 "Ei voitu poistaa %(count)d kysymystä, koska niihin oli jo vastauksia."
 
-#: wikikysely_project/survey/views.py:1101
+#: wikikysely_project/survey/views.py:1205
 #, python-format
 msgid "Could not remove %(count)d survey because it already had questions."
 msgid_plural ""
@@ -629,45 +657,35 @@ msgid_plural ""
 msgstr[0] "Ei voitu poistaa %(count)d kyselyä, koska siinä oli jo kysymyksiä."
 msgstr[1] "Ei voitu poistaa %(count)d kyselyä, koska niissä oli jo kysymyksiä."
 
-#: wikikysely_project/survey/views.py:1111
+#: wikikysely_project/survey/views.py:1215
 msgid "Account removed."
 msgstr "Tili poistettu."
 
-#: wikikysely_project/survey/views.py:1121
+#: wikikysely_project/survey/views.py:1225
 msgid "Account not removed because all your questions could not be deleted."
 msgstr "Tiliä ei poistettu, koska kaikkia kysymyksiäsi ei voitu poistaa."
 
-#: wikikysely_project/survey/views.py:1145
+#: wikikysely_project/survey/views.py:1249
 msgid "Answer can only be edited while the survey is running"
 msgstr "Vastauksen voi muokata vain, kun kysely on käynnissä"
 
-#: wikikysely_project/survey/views.py:1166
+#: wikikysely_project/survey/views.py:1270
 msgid "Answer updated"
 msgstr "Vastaus päivitetty"
 
-#: wikikysely_project/survey/views.py:1188
+#: wikikysely_project/survey/views.py:1292
 msgid "Answer can only be removed while the survey is running"
 msgstr "Vastauksen voi poistaa vain, kun kysely on käynnissä"
 
-#: wikikysely_project/survey/views.py:1235
+#: wikikysely_project/survey/views.py:1339
 msgid "Answer removed"
 msgstr "Vastaus poistettu"
 
-#: templates/survey/answers.html:124
-msgid "Survey information"
-msgstr "Tietoa kyselystä"
+#~ msgid "You must be logged in to answer questions"
+#~ msgstr "Sinun tulee olla kirjautunut sisään vastataksesi kysymyksiin"
 
-#: templates/survey/answers.html:126
-msgid "Number of questions"
-msgstr "Kysymysten määrä"
-
-#: templates/survey/answers.html:128
-msgid "Number of respondents"
-msgstr "Vastaajien määrä"
-
-#: templates/survey/answers.html:130
-msgid "Number of question authors"
-msgstr "Kysyjien määrä"
+#~ msgid "No skipped questions"
+#~ msgstr "Ei ohitettuja kysymyksiä"
 
 #~ msgid "Deleted questions"
 #~ msgstr "Poistetut kysymykset"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-10 09:43+0000\n"
+"POT-Creation-Date: 2025-08-19 19:45+0000\n"
 "Language: sv\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -14,61 +14,60 @@ msgstr ""
 msgid "Questions"
 msgstr "Frågor"
 
-#: templates/base.html:29 templates/base.html:31
-#: templates/survey/answers.html:21 templates/survey/answers.html:27
-#: templates/survey/survey_detail.html:31
-#: templates/survey/survey_detail.html:40
+#: templates/base.html:30 templates/base.html:33 templates/base.html:35
+#: templates/base.html:39 templates/base.html:41
+#: templates/survey/answers.html:9 templates/survey/answers.html:15
+#: templates/survey/survey_detail.html:19
+#: templates/survey/survey_detail.html:28
 msgid "Answer survey"
 msgstr "Svara"
 
-#: templates/base.html:33 templates/survey/answer_form.html:102
+#: templates/base.html:43 templates/survey/answer_form.html:102
 #: templates/survey/answer_form.html:113 templates/survey/answers.html:3
-#: templates/survey/answers.html:31 templates/survey/survey_detail.html:34
-#: templates/survey/survey_detail.html:51
-#: templates/survey/survey_detail.html:66
-#: templates/survey/survey_detail.html:89
-#: templates/survey/survey_detail.html:102 templates/survey/userinfo.html:20
-#: templates/survey/userinfo.html:78 templates/survey/userinfo.html:95
-#: wikikysely_project/survey/views.py:1231
+#: templates/survey/answers.html:19 templates/survey/survey_detail.html:22
+#: templates/survey/survey_detail.html:38
+#: templates/survey/survey_detail.html:48
+#: templates/survey/survey_detail.html:70
+#: templates/survey/survey_detail.html:82 templates/survey/userinfo.html:20
+#: templates/survey/userinfo.html:79 templates/survey/userinfo.html:97
+#: wikikysely_project/survey/views.py:1335
 msgid "Answers"
 msgstr "Svar"
 
 # UI strings
-#: templates/base.html:35 templates/survey/survey_form.html:3
+#: templates/base.html:45 templates/survey/survey_form.html:3
 #: templates/survey/survey_form.html:5
 msgid "Edit survey"
 msgstr "Redigera enkät"
 
-#: templates/base.html:54
+#: templates/base.html:64
 msgid "Logout"
 msgstr "Logga ut"
 
-#: templates/base.html:57 templates/registration/login.html:3
+#: templates/base.html:67 templates/registration/login.html:3
 #: templates/registration/login.html:5 templates/registration/login.html:10
-#: templates/survey/answers.html:10 templates/survey/survey_detail.html:20
 msgid "Login"
 msgstr "Logga in"
 
-#: templates/base.html:58 templates/registration/register.html:3
+#: templates/base.html:68 templates/registration/register.html:3
 #: templates/registration/register.html:5
 #: templates/registration/register.html:10
 msgid "Register"
 msgstr "Registrera"
 
-#: templates/base.html:60 templates/registration/login.html:13
-#: templates/survey/answers.html:12 templates/survey/survey_detail.html:22
+#: templates/base.html:70 templates/registration/login.html:13
 msgid "Login with Wikimedia"
 msgstr "Logga in med Wikimedia"
 
-#: templates/base.html:81
+#: templates/base.html:91
 msgid "Project page"
 msgstr "Projectsida"
 
-#: templates/base.html:82
+#: templates/base.html:92
 msgid "Source code"
 msgstr "Källkod"
 
-#: templates/base.html:83
+#: templates/base.html:93
 msgid "Privacy policy"
 msgstr "Integritetspolicy"
 
@@ -77,47 +76,47 @@ msgid "Answer question"
 msgstr "Svara på frågan"
 
 #: templates/survey/answer_form.html:23 templates/survey/answer_form.html:120
-#: templates/survey/survey_detail.html:109 templates/survey/userinfo.html:77
-#: templates/survey/userinfo.html:94
+#: templates/survey/survey_detail.html:89 templates/survey/userinfo.html:78
+#: templates/survey/userinfo.html:96
 msgid "Answer"
 msgstr "Svar"
 
 #: templates/survey/answer_form.html:27 templates/survey/answer_form.html:69
 #: templates/survey/answer_form.html:79 templates/survey/answer_form.html:122
-#: templates/survey/answers.html:94 templates/survey/answers.html:115
-#: templates/survey/survey_detail.html:111
+#: templates/survey/answers.html:82 templates/survey/answers.html:99
+#: templates/survey/survey_detail.html:91
 #: wikikysely_project/survey/models.py:55
-#: wikikysely_project/survey/views.py:396
-#: wikikysely_project/survey/views.py:612
-#: wikikysely_project/survey/views.py:717
-#: wikikysely_project/survey/views.py:841
-#: wikikysely_project/survey/views.py:1276
-#: wikikysely_project/survey/views.py:1340
+#: wikikysely_project/survey/views.py:404
+#: wikikysely_project/survey/views.py:620
+#: wikikysely_project/survey/views.py:774
+#: wikikysely_project/survey/views.py:928
+#: wikikysely_project/survey/views.py:1388
+#: wikikysely_project/survey/views.py:1456
 msgid "Yes"
 msgstr "Ja"
 
 #: templates/survey/answer_form.html:29 templates/survey/answer_form.html:70
 #: templates/survey/answer_form.html:80 templates/survey/answer_form.html:124
-#: templates/survey/answers.html:95 templates/survey/answers.html:116
-#: templates/survey/survey_detail.html:113
+#: templates/survey/answers.html:83 templates/survey/answers.html:100
+#: templates/survey/survey_detail.html:93
 #: wikikysely_project/survey/models.py:56
-#: wikikysely_project/survey/views.py:397
-#: wikikysely_project/survey/views.py:613
-#: wikikysely_project/survey/views.py:718
-#: wikikysely_project/survey/views.py:842
-#: wikikysely_project/survey/views.py:1277
-#: wikikysely_project/survey/views.py:1341
+#: wikikysely_project/survey/views.py:405
+#: wikikysely_project/survey/views.py:621
+#: wikikysely_project/survey/views.py:775
+#: wikikysely_project/survey/views.py:929
+#: wikikysely_project/survey/views.py:1389
+#: wikikysely_project/survey/views.py:1457
 msgid "No"
 msgstr "Nej"
 
 #: templates/survey/answer_form.html:33 templates/survey/answer_form.html:127
-#: templates/survey/survey_detail.html:116 templates/survey/userinfo.html:99
+#: templates/survey/survey_detail.html:96 templates/survey/userinfo.html:101
 msgid "Remove answer"
 msgstr "Ta bort svar"
 
 #: templates/survey/answer_form.html:36 templates/survey/question_form.html:12
-#: templates/survey/survey_detail.html:71 templates/survey/userinfo.html:59
-#: wikikysely_project/survey/views.py:1226
+#: templates/survey/survey_detail.html:53 templates/survey/userinfo.html:59
+#: wikikysely_project/survey/views.py:1330
 msgid "Remove question"
 msgstr "Ta bort fråga"
 
@@ -138,78 +137,67 @@ msgid "Answers over time"
 msgstr "Antal svar över tid"
 
 #: templates/survey/answer_form.html:67 templates/survey/answer_form.html:77
-#: templates/survey/answer_form.html:99 templates/survey/answer_form.html:110
-#: templates/survey/answers.html:88 templates/survey/answers.html:103
+#: templates/survey/answer_form.html:100 templates/survey/answer_form.html:111
+#: templates/survey/answers.html:76 templates/survey/answers.html:91
 #: templates/survey/answers_wikitext.txt:19
-#: templates/survey/survey_detail.html:48
-#: templates/survey/survey_detail.html:59
-#: templates/survey/survey_detail.html:86
-#: templates/survey/survey_detail.html:97 templates/survey/userinfo.html:38
+#: templates/survey/survey_detail.html:36
+#: templates/survey/survey_detail.html:46
+#: templates/survey/survey_detail.html:68
+#: templates/survey/survey_detail.html:78 templates/survey/userinfo.html:38
 #: templates/survey/userinfo.html:46 templates/survey/userinfo.html:75
-#: templates/survey/userinfo.html:86 wikikysely_project/survey/views.py:1224
+#: templates/survey/userinfo.html:87 templates/survey/userinfo.html:118
+#: templates/survey/userinfo.html:125 wikikysely_project/survey/views.py:1328
 msgid "ID"
 msgstr ""
 
 #: templates/survey/answer_form.html:68 templates/survey/answer_form.html:78
-#: templates/survey/answers.html:89 templates/survey/answers.html:104
+#: templates/survey/answers.html:77 templates/survey/answers.html:92
 #: templates/survey/answers_wikitext.txt:19
-#: templates/survey/survey_detail.html:49
-#: templates/survey/survey_detail.html:60
-#: templates/survey/survey_detail.html:87
-#: templates/survey/survey_detail.html:98
-#: wikikysely_project/survey/views.py:1229
+#: wikikysely_project/survey/views.py:1333
 msgid "Published"
 msgstr "Publicerad"
 
 #: templates/survey/answer_form.html:71 templates/survey/answer_form.html:81
-#: templates/survey/answers.html:96 templates/survey/answers.html:117
+#: templates/survey/answers.html:84 templates/survey/answers.html:101
 #: templates/survey/answers_wikitext.txt:19
 msgid "Total"
 msgstr "Totalt"
 
 #: templates/survey/answer_form.html:72 templates/survey/answer_form.html:82
 #: templates/survey/answer_form.html:103 templates/survey/answer_form.html:114
-#: templates/survey/answers.html:97 templates/survey/answers.html:118
+#: templates/survey/answers.html:85 templates/survey/answers.html:102
 #: templates/survey/answers_wikitext.txt:19
-#: templates/survey/survey_detail.html:52
-#: templates/survey/survey_detail.html:67
-#: templates/survey/survey_detail.html:90
-#: templates/survey/survey_detail.html:103 templates/survey/userinfo.html:79
-#: templates/survey/userinfo.html:96 wikikysely_project/survey/views.py:1232
+#: templates/survey/survey_detail.html:39
+#: templates/survey/survey_detail.html:49
+#: templates/survey/survey_detail.html:71
+#: templates/survey/survey_detail.html:83 templates/survey/userinfo.html:80
+#: templates/survey/userinfo.html:98 wikikysely_project/survey/views.py:1336
 msgid "Agree"
 msgstr "Instämmande"
 
-#: templates/survey/answer_form.html:92 templates/survey/survey_detail.html:81
+#: templates/survey/answer_form.html:92 templates/survey/survey_detail.html:63
 #: templates/survey/userinfo.html:70
 msgid "My answers"
 msgstr "Mina svar"
 
-#: templates/survey/answer_form.html:100 templates/survey/answer_form.html:111
+#: templates/survey/answer_form.html:99 templates/survey/answer_form.html:110
+#: templates/survey/userinfo.html:77 templates/survey/userinfo.html:95
 msgid "Answer date"
 msgstr "Svarstid"
 
 #: templates/survey/answer_form.html:101 templates/survey/answer_form.html:112
-#: templates/survey/survey_detail.html:50
-#: templates/survey/survey_detail.html:62
-#: templates/survey/survey_detail.html:64
-#: templates/survey/survey_detail.html:88
-#: templates/survey/survey_detail.html:99 templates/survey/survey_list.html:8
+#: templates/survey/survey_detail.html:37
+#: templates/survey/survey_detail.html:47
+#: templates/survey/survey_detail.html:69
+#: templates/survey/survey_detail.html:79 templates/survey/survey_list.html:8
 #: templates/survey/survey_list.html:11 wikikysely_project/survey/models.py:12
-#: wikikysely_project/survey/views.py:1230
+#: wikikysely_project/survey/views.py:1334
 msgid "Title"
 msgstr "Titel"
 
-#: templates/survey/answers.html:8 templates/survey/survey_detail.html:18
-msgid "You must be logged in to answer questions"
-msgstr "Du måste vara inloggad för att kunna svara på frågorna"
-
-#: templates/survey/answers.html:23 templates/survey/answers.html:28
+#: templates/survey/answers.html:11 templates/survey/answers.html:16
 msgid "Print wikitext"
 msgstr "Skriv ut wikikod"
-
-#: templates/survey/answers.html:24
-msgid "<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s answers and <span class=\"bg-success text-black px-1\">%(green)s</span> means %(yes)s answers. <span id=\"unansweredInfo\"><span class=\"bg-secondary px-1\">%(grey)s</span> shows the share of all respondents who have not yet answered the question.</span>"
-msgstr "<span class=\"bg-danger text-light px-1\">%(red)s</span> betyder %(no)s svar och <span class=\"bg-success text-black px-1\">%(green)s</span> betyder %(yes)s svar. <span id=\"unansweredInfo\"><span class=\"bg-secondary px-1\">%(grey)s</span> visar hur stor andel av alla svarande som ännu inte har svarat på frågan.</span>"
 
 #: templates/survey/answers.html:20
 msgid "Red"
@@ -223,33 +211,71 @@ msgstr "Grön"
 msgid "Grey"
 msgstr "Grå"
 
-#: templates/survey/answers.html:35
+#: templates/survey/answers.html:24
+#, fuzzy, python-format
+#| msgid ""
+#| "<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s "
+#| "answers and <span class=\"bg-success text-black px-1\">%(green)s</span> "
+#| "means %(yes)s answers. <span id=\"unansweredInfo\"><span class=\"bg-"
+#| "secondary px-1\">%(grey)s</span> shows the share of all respondents who "
+#| "have not yet answered the question.</span>"
+msgid ""
+"<span class=\"bg-danger text-light px-1\">%(red)s</span> means %(no)s "
+"answers and <span class=\"bg-success text-black px-1\">%(green)s</span> "
+"means %(yes)s answers. <span id=\"unansweredInfo\" style=\"display:"
+"none\"><span class=\"bg-secondary px-1\">%(grey)s</span> shows the share of "
+"all respondents who have not yet answered the question.</span>"
+msgstr ""
+"<span class=\"bg-danger text-light px-1\">%(red)s</span> betyder %(no)s svar "
+"och <span class=\"bg-success text-black px-1\">%(green)s</span> betyder "
+"%(yes)s svar. <span id=\"unansweredInfo\" style=\"display:none\"><span class=\"bg-secondary "
+"px-1\">%(grey)s</span> visar hur stor andel av alla svarande som ännu inte "
+"har svarat på frågan.</span>"
+
+#: templates/survey/answers.html:31
 msgid "Pie chart"
 msgstr "Cirkeldiagram"
 
-#: templates/survey/answers.html:39
+#: templates/survey/answers.html:35
 msgid "Bar chart"
 msgstr "Stapeldiagram"
 
-#: templates/survey/answers.html:82 templates/survey/answers_wikitext.txt:26
+#: templates/survey/answers.html:70 templates/survey/answers_wikitext.txt:26
 msgid "Total respondents"
 msgstr "Antal svarande"
 
-#: templates/survey/answers.html:83 templates/survey/answers_wikitext.txt:17
+#: templates/survey/answers.html:71 templates/survey/answers_wikitext.txt:17
 msgid "Answer table"
 msgstr "Svarstabell"
 
-#: templates/survey/answers.html:90 templates/survey/answers.html:105
+#: templates/survey/answers.html:78 templates/survey/answers.html:93
 #: templates/survey/answers_wikitext.txt:19 templates/survey/userinfo.html:39
 #: templates/survey/userinfo.html:47 templates/survey/userinfo.html:76
-#: templates/survey/userinfo.html:87
+#: templates/survey/userinfo.html:88 templates/survey/userinfo.html:119
+#: templates/survey/userinfo.html:126
 msgid "Question"
 msgstr "Fråga"
 
-#: templates/survey/answers.html:92 templates/survey/answers.html:113
+#: templates/survey/answers.html:80 templates/survey/answers.html:97
 #: templates/survey/answers_wikitext.txt:19
 msgid "My answer"
 msgstr "Mitt svar"
+
+#: templates/survey/answers.html:108
+msgid "Survey information"
+msgstr "Information om enkäten"
+
+#: templates/survey/answers.html:111
+msgid "Number of questions"
+msgstr "Antal frågor"
+
+#: templates/survey/answers.html:115
+msgid "Number of respondents"
+msgstr "Antal svarande"
+
+#: templates/survey/answers.html:119
+msgid "Number of question authors"
+msgstr "Antal frågeställare"
 
 #: templates/survey/answers_wikitext.html:3
 #: templates/survey/answers_wikitext.html:5
@@ -281,7 +307,7 @@ msgid "Edit question"
 msgstr "Redigera fråga"
 
 #: templates/survey/question_form.html:3 templates/survey/question_form.html:5
-#: templates/survey/survey_detail.html:36
+#: templates/survey/survey_detail.html:24
 msgid "Add question"
 msgstr "Lägg till fråga"
 
@@ -331,13 +357,13 @@ msgstr ""
 msgid "This survey has no questions yet. Please add questions."
 msgstr "Enkäten har inga frågor ännu. Lägg till frågor."
 
-#: templates/survey/survey_detail.html:43
-#: wikikysely_project/survey/views.py:1227
+#: templates/survey/survey_detail.html:31
+#: wikikysely_project/survey/views.py:1331
 msgid "Unanswered questions"
 msgstr "Obesvarade frågor"
 
-#: templates/survey/survey_detail.html:70 templates/survey/userinfo.html:56
-#: wikikysely_project/survey/views.py:1225
+#: templates/survey/survey_detail.html:52 templates/survey/userinfo.html:56
+#: wikikysely_project/survey/views.py:1329
 msgid "Edit"
 msgstr "Redigera"
 
@@ -396,7 +422,7 @@ msgstr "Enkäter"
 msgid "State"
 msgstr "Status"
 
-#: templates/survey/survey_list.html:13 wikikysely_project/survey/views.py:198
+#: templates/survey/survey_list.html:13 wikikysely_project/survey/views.py:206
 msgid "No surveys"
 msgstr "Inga enkäter"
 
@@ -436,19 +462,15 @@ msgstr "Ta bort mina uppgifter"
 msgid "My questions"
 msgstr "Mina frågor"
 
-#: templates/survey/userinfo.html:104 wikikysely_project/survey/views.py:719
-#: wikikysely_project/survey/views.py:843
-#: wikikysely_project/survey/views.py:1278
+#: templates/survey/userinfo.html:106 wikikysely_project/survey/views.py:776
+#: wikikysely_project/survey/views.py:930
+#: wikikysely_project/survey/views.py:1390
 msgid "No answers"
 msgstr "Inga svar"
 
-#: templates/survey/userinfo.html:112
+#: templates/survey/userinfo.html:113
 msgid "Skipped questions"
 msgstr "Överhoppade frågor"
-
-#: templates/survey/userinfo.html:134
-msgid "No skipped questions"
-msgstr "Inga överhoppade frågor"
 
 #: wikikysely_project/survey/forms.py:34
 msgid "Text"
@@ -474,40 +496,40 @@ msgstr "Stängd"
 msgid "Description"
 msgstr "Beskrivning"
 
-#: wikikysely_project/survey/views.py:149
+#: wikikysely_project/survey/views.py:157
 msgid "Registration successful"
 msgstr "Registreringen lyckades"
 
-#: wikikysely_project/survey/views.py:181
+#: wikikysely_project/survey/views.py:189
 msgid "Logged out"
 msgstr "Du loggades ut"
 
-#: wikikysely_project/survey/views.py:324
+#: wikikysely_project/survey/views.py:332
 msgid "Survey created"
 msgstr "Enkät skapad"
 
-#: wikikysely_project/survey/views.py:337
-#: wikikysely_project/survey/views.py:385
-#: wikikysely_project/survey/views.py:433
-#: wikikysely_project/survey/views.py:467
-#: wikikysely_project/survey/views.py:492
-#: wikikysely_project/survey/views.py:496
-#: wikikysely_project/survey/views.py:528
-#: wikikysely_project/survey/views.py:557
-#: wikikysely_project/survey/views.py:592
+#: wikikysely_project/survey/views.py:345
+#: wikikysely_project/survey/views.py:393
+#: wikikysely_project/survey/views.py:441
+#: wikikysely_project/survey/views.py:475
+#: wikikysely_project/survey/views.py:500
+#: wikikysely_project/survey/views.py:504
+#: wikikysely_project/survey/views.py:536
+#: wikikysely_project/survey/views.py:565
+#: wikikysely_project/survey/views.py:600
 msgid "No permission"
 msgstr "Ingen behörighet"
 
-#: wikikysely_project/survey/views.py:344
+#: wikikysely_project/survey/views.py:352
 msgid "Survey updated"
 msgstr "Enkät uppdaterad"
 
-#: wikikysely_project/survey/views.py:378
+#: wikikysely_project/survey/views.py:386
 msgid "Cannot add questions to a closed survey"
 msgstr "Det går inte att lägga till frågor i en stängd enkät"
 
-#: wikikysely_project/survey/views.py:401
-#: wikikysely_project/survey/views.py:617
+#: wikikysely_project/survey/views.py:409
+#: wikikysely_project/survey/views.py:625
 #, python-format
 msgid ""
 "The question \"%(text)s\" already exists and has %(count)d answers "
@@ -516,102 +538,108 @@ msgstr ""
 "Frågan \"%(text)s\" finns redan och har %(count)d svar (%(yes_label)s "
 "%(yes)d, %(no_label)s %(no)d). Formulera frågan annorlunda."
 
-#: wikikysely_project/survey/views.py:417
+#: wikikysely_project/survey/views.py:425
 msgid "Question added"
 msgstr "Fråga tillagd"
 
-#: wikikysely_project/survey/views.py:437
-#: wikikysely_project/survey/views.py:500
+#: wikikysely_project/survey/views.py:445
+#: wikikysely_project/survey/views.py:508
 msgid "Cannot remove questions from a closed survey"
 msgstr "Det går inte att ta bort frågor från en stängd enkät"
 
-#: wikikysely_project/survey/views.py:451
+#: wikikysely_project/survey/views.py:459
 msgid "Question hidden"
 msgstr "Fråga dold"
 
-#: wikikysely_project/survey/views.py:470
+#: wikikysely_project/survey/views.py:478
 msgid "Cannot restore questions in a closed survey"
 msgstr "Det går inte att återställa frågor i en stängd enkät"
 
-#: wikikysely_project/survey/views.py:481
+#: wikikysely_project/survey/views.py:489
 msgid "Question visible"
 msgstr "Fråga synlig"
 
-#: wikikysely_project/survey/views.py:506
+#: wikikysely_project/survey/views.py:514
 msgid "Question removed"
 msgstr "Fråga borttagen"
 
-#: wikikysely_project/survey/views.py:545
+#: wikikysely_project/survey/views.py:553
 msgid "Secretary added"
 msgstr "Sekreterare lades till"
 
-#: wikikysely_project/survey/views.py:547
-#: wikikysely_project/survey/views.py:572
+#: wikikysely_project/survey/views.py:555
+#: wikikysely_project/survey/views.py:580
 msgid "User not found"
 msgstr "Användare hittades inte"
 
-#: wikikysely_project/survey/views.py:570
+#: wikikysely_project/survey/views.py:578
 msgid "Secretary removed"
 msgstr "Sekreterare togs bort"
 
-#: wikikysely_project/survey/views.py:596
+#: wikikysely_project/survey/views.py:604
 msgid "Cannot edit questions in a closed survey"
 msgstr "Det går inte att redigera frågor i en stängd enkät"
 
-#: wikikysely_project/survey/views.py:630
+#: wikikysely_project/survey/views.py:638
 msgid "Question updated"
 msgstr "Fråga uppdaterad"
 
-#: wikikysely_project/survey/views.py:650
-#: wikikysely_project/survey/views.py:653
-#: wikikysely_project/survey/views.py:748
-#: wikikysely_project/survey/views.py:751
+#: wikikysely_project/survey/views.py:657
+#: wikikysely_project/survey/views.py:660
+#: wikikysely_project/survey/views.py:805
+#: wikikysely_project/survey/views.py:808
 msgid "Survey not active"
 msgstr "Enkäten är inte aktiv"
 
-#: wikikysely_project/survey/views.py:671
-#: wikikysely_project/survey/views.py:780
-msgid "Answer saved"
-msgstr "Svar sparat"
+#: wikikysely_project/survey/views.py:668
+#: wikikysely_project/survey/views.py:821
+#, python-brace-format
+msgid ""
+"To answer the question you must log in. <a href=\"{0}\">Log in with your "
+"Wikimedia account</a>."
+msgstr ""
+"Vastataksesi kysymykseen sinun on kirjauduttava sisälle. <a "
+"href=\"{0}\">Kirjaudu Wikimedian tunnuksilla</a>."
 
-#: wikikysely_project/survey/views.py:673
-#: wikikysely_project/survey/views.py:782
-msgid "Question skipped"
-msgstr "Fråga hoppad över"
-
-#: wikikysely_project/survey/views.py:686
-#: wikikysely_project/survey/views.py:702
-#: wikikysely_project/survey/views.py:815
+#: wikikysely_project/survey/views.py:680
+#: wikikysely_project/survey/views.py:733
+#: wikikysely_project/survey/views.py:759
+#: wikikysely_project/survey/views.py:902
 msgid "No more questions"
 msgstr "Inga fler frågor"
 
-#: wikikysely_project/survey/views.py:763
-#, python-brace-format
-msgid "To answer the question you must log in. <a href=\"{0}\">Log in with your Wikimedia account</a>."
-msgstr "Vastataksesi kysymykseen sinun on kirjauduttava sisälle. <a href=\"{0}\">Kirjaudu Wikimedian tunnuksilla</a>."
+#: wikikysely_project/survey/views.py:702
+#: wikikysely_project/survey/views.py:843
+msgid "Answer saved"
+msgstr "Svar sparat"
 
-#: wikikysely_project/survey/views.py:1069
+#: wikikysely_project/survey/views.py:707
+#: wikikysely_project/survey/views.py:848
+msgid "Question skipped"
+msgstr "Fråga hoppad över"
+
+#: wikikysely_project/survey/views.py:1173
 #, python-format
 msgid "Removed %(removed)d/%(total)d answer."
 msgid_plural "Removed %(removed)d/%(total)d answers."
 msgstr[0] "Tog bort %(removed)d/%(total)d svar."
 msgstr[1] "Tog bort %(removed)d/%(total)d svar."
 
-#: wikikysely_project/survey/views.py:1075
+#: wikikysely_project/survey/views.py:1179
 #, python-format
 msgid "Removed %(removed)d/%(total)d question."
 msgid_plural "Removed %(removed)d/%(total)d questions."
 msgstr[0] "Tog bort %(removed)d/%(total)d fråga."
 msgstr[1] "Tog bort %(removed)d/%(total)d frågor."
 
-#: wikikysely_project/survey/views.py:1081
+#: wikikysely_project/survey/views.py:1185
 #, python-format
 msgid "Removed %(removed)d/%(total)d survey."
 msgid_plural "Removed %(removed)d/%(total)d surveys."
 msgstr[0] "Tog bort %(removed)d/%(total)d enkät."
 msgstr[1] "Tog bort %(removed)d/%(total)d enkäter."
 
-#: wikikysely_project/survey/views.py:1091
+#: wikikysely_project/survey/views.py:1195
 #, python-format
 msgid "Could not remove %(count)d question because it already had answers."
 msgid_plural ""
@@ -619,7 +647,7 @@ msgid_plural ""
 msgstr[0] "Kunde inte ta bort %(count)d fråga eftersom den redan hade svar."
 msgstr[1] "Kunde inte ta bort %(count)d frågor eftersom de redan hade svar."
 
-#: wikikysely_project/survey/views.py:1101
+#: wikikysely_project/survey/views.py:1205
 #, python-format
 msgid "Could not remove %(count)d survey because it already had questions."
 msgid_plural ""
@@ -627,53 +655,41 @@ msgid_plural ""
 msgstr[0] "Kunde inte ta bort %(count)d enkät eftersom den redan hade frågor."
 msgstr[1] "Kunde inte ta bort %(count)d enkäter eftersom de redan hade frågor."
 
-#: wikikysely_project/survey/views.py:1111
+#: wikikysely_project/survey/views.py:1215
 msgid "Account removed."
 msgstr "Konto borttaget."
 
-#: wikikysely_project/survey/views.py:1121
+#: wikikysely_project/survey/views.py:1225
 msgid "Account not removed because all your questions could not be deleted."
 msgstr "Konto togs inte bort eftersom alla dina frågor inte kunde tas bort."
 
-#: wikikysely_project/survey/views.py:1145
+#: wikikysely_project/survey/views.py:1249
 msgid "Answer can only be edited while the survey is running"
 msgstr "Svar kan redigeras endast när enkäten är igång"
 
-#: wikikysely_project/survey/views.py:1166
+#: wikikysely_project/survey/views.py:1270
 msgid "Answer updated"
 msgstr "Svar uppdaterat"
 
-#: wikikysely_project/survey/views.py:1188
+#: wikikysely_project/survey/views.py:1292
 msgid "Answer can only be removed while the survey is running"
 msgstr "Svar kan tas bort endast när enkäten är igång"
 
-#: wikikysely_project/survey/views.py:1235
+#: wikikysely_project/survey/views.py:1339
 msgid "Answer removed"
 msgstr "Svar borttaget"
 
-#: templates/survey/answers.html:124
-msgid "Survey information"
-msgstr "Information om enkäten"
+#~ msgid "You must be logged in to answer questions"
+#~ msgstr "Du måste vara inloggad för att kunna svara på frågorna"
 
-#: templates/survey/answers.html:126
-msgid "Number of questions"
-msgstr "Antal frågor"
+#~ msgid "No skipped questions"
+#~ msgstr "Inga överhoppade frågor"
 
-#: templates/survey/answers.html:128
-msgid "Number of respondents"
-msgstr "Antal svarande"
+#~ msgid "First question date"
+#~ msgstr "Datum för första frågan"
 
-#: templates/survey/answers.html:130
-msgid "Number of question authors"
-msgstr "Antal frågeställare"
-
-#: templates/survey/answers.html:132
-msgid "First question date"
-msgstr "Datum för första frågan"
-
-#: templates/survey/answers.html:134
-msgid "Latest question date"
-msgstr "Datum för senaste frågan"
+#~ msgid "Latest question date"
+#~ msgstr "Datum för senaste frågan"
 
 #~ msgid "Deleted questions"
 #~ msgstr "Borttagna frågor"


### PR DESCRIPTION
## Summary
- Update Finnish and Swedish translations for the answer color legend to keep the descriptive sentence fully localized

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a4d3edad58832e9803ba3082b2977f