### PR TITLE
Add 'Add question' button on answer page

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -45,6 +45,9 @@
 {% endif %}
   </div>
 </div>
+<div class="text-center mb-4">
+  <a href="{% url 'survey:question_add' %}" class="btn btn-secondary">{% translate 'Add question' %}</a>
+</div>
 {% if question_stats %}
   <h2 class="mt-4">
     <a class="text-decoration-none collapse-toggle collapsed" data-bs-toggle="collapse" href="#answerDetails" role="button" aria-expanded="false" aria-controls="answerDetails">{% translate 'Answer details' %}</a>


### PR DESCRIPTION
## Summary
- Add centered "Add question" button under the answer form

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d490dcf0832e8c091a0ddb5f8211