### PR TITLE
Add 'Add question' link to navbar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,7 @@
       {% url 'survey:answer_survey' as answer_survey_url %}
       {% url 'survey:survey_answers' as survey_answers_url %}
       {% url 'survey:userinfo' as userinfo_url %}
+      {% url 'survey:question_add' as question_add_url %}
       {% url 'survey:survey_edit' as survey_edit_url %}
       <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
@@ -41,6 +42,9 @@
         <li class="nav-item"><span id="answer-nav-link" class="nav-link text-secondary">{% translate 'Answer survey' %}</span></li>
         {% endif %}
         <li class="nav-item"><a class="nav-link{% if request.path == survey_answers_url %} active{% endif %}" href="{{ survey_answers_url }}">{% translate 'Answers' %}</a></li>
+        {% if request.user.is_authenticated %}
+        <li class="nav-item"><a class="nav-link{% if request.path == question_add_url %} active{% endif %}" href="{{ question_add_url }}">{% translate 'Add question' %}</a></li>
+        {% endif %}
         {% if can_edit %}
         <li class="nav-item"><a class="nav-link{% if request.path == survey_edit_url %} active{% endif %}" href="{{ survey_edit_url }}">{% translate 'Edit survey' %}</a></li>
         {% endif %}


### PR DESCRIPTION
## Summary
- add Add question link between Answers and Edit survey in top navigation

## Testing
- `python manage.py test` (fails: no such table: survey_survey)


------
https://chatgpt.com/codex/tasks/task_e_68a4d86176e0832ebc740eee031f497b