### PR TITLE
Add top bar link for adding questions

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,7 @@
       {% url 'survey:survey_answers' as survey_answers_url %}
       {% url 'survey:userinfo' as userinfo_url %}
       {% url 'survey:survey_edit' as survey_edit_url %}
+      {% url 'survey:question_add' as question_add_url %}
       <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link{% if request.path == survey_detail_url %} active{% endif %}" href="{{ survey_detail_url }}">{% translate 'Questions' %}</a></li>
         {% if unanswered_count is not None %}
@@ -41,6 +42,9 @@
         <li class="nav-item"><span id="answer-nav-link" class="nav-link text-secondary">{% translate 'Answer survey' %}</span></li>
         {% endif %}
         <li class="nav-item"><a class="nav-link{% if request.path == survey_answers_url %} active{% endif %}" href="{{ survey_answers_url }}">{% translate 'Answers' %}</a></li>
+        {% if request.user.is_authenticated %}
+        <li class="nav-item"><a class="nav-link{% if request.path == question_add_url %} active{% endif %}" href="{{ question_add_url }}">{% translate 'Add question' %}</a></li>
+        {% endif %}
         {% if can_edit %}
         <li class="nav-item"><a class="nav-link{% if request.path == survey_edit_url %} active{% endif %}" href="{{ survey_edit_url }}">{% translate 'Edit survey' %}</a></li>
         {% endif %}


### PR DESCRIPTION
## Summary
- allow authenticated users to quickly add new questions via a top bar link

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68a502243760832ea7e6751c37a121ce