### PR TITLE
Combine final answer and completion messages

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -613,6 +613,11 @@ msgstr "Ei enempää kysymyksiä"
 msgid "Answer saved"
 msgstr "Vastaus tallennettu"
 
+#: wikikysely_project/survey/views.py:735
+#: wikikysely_project/survey/views.py:915
+msgid "Answer saved. No more questions"
+msgstr "Vastaus tallennettu. Ei enempää kysymyksiä"
+
 #: wikikysely_project/survey/views.py:707
 #: wikikysely_project/survey/views.py:848
 msgid "Question skipped"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -613,6 +613,11 @@ msgstr "Inga fler frågor"
 msgid "Answer saved"
 msgstr "Svar sparat"
 
+#: wikikysely_project/survey/views.py:735
+#: wikikysely_project/survey/views.py:915
+msgid "Answer saved. No more questions"
+msgstr "Svar sparat. Inga fler frågor"
+
 #: wikikysely_project/survey/views.py:707
 #: wikikysely_project/survey/views.py:848
 msgid "Question skipped"

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -177,6 +177,26 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertIn("No more questions", msgs)
         self.assertNotIn("Question skipped", msgs)
 
+    def test_answer_last_question_combined_message_answer_survey(self):
+        survey = self._create_survey()
+        q1 = self._create_question(survey)
+        data = {"question_id": q1.pk, "answer": "yes"}
+        response = self.client.post(
+            reverse("survey:answer_survey"), data, follow=True
+        )
+        msgs = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertIn("Answer saved. No more questions", msgs)
+
+    def test_answer_last_question_combined_message_answer_question(self):
+        survey = self._create_survey()
+        q1 = self._create_question(survey)
+        data = {"question_id": q1.pk, "answer": "yes"}
+        response = self.client.post(
+            reverse("survey:answer_question", args=[q1.pk]), data, follow=True
+        )
+        msgs = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertIn("Answer saved. No more questions", msgs)
+
     def test_survey_edit(self):
         survey = self._create_survey()
         data = {

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -700,7 +700,6 @@ def answer_survey(request):
                 SkippedQuestion.objects.filter(
                     user=request.user, question=question
                 ).delete()
-                messages.success(request, _("Answer saved"))
             else:
                 SkippedQuestion.objects.get_or_create(
                     user=request.user, question=question
@@ -731,8 +730,15 @@ def answer_survey(request):
                 remaining = remaining.exclude(id=question.pk)
             question = random.choice(list(remaining)) if remaining else None
             if not question:
-                messages.info(request, _("No more questions"))
+                if answer_value:
+                    messages.success(
+                        request, _("Answer saved. No more questions")
+                    )
+                else:
+                    messages.info(request, _("No more questions"))
                 return redirect("survey:survey_detail")
+            if answer_value:
+                messages.success(request, _("Answer saved"))
             if skip_message:
                 messages.info(request, _("Question skipped"))
             form = AnswerForm(initial={"question_id": question.pk})
@@ -844,7 +850,6 @@ def answer_question(request, pk):
                     SkippedQuestion.objects.filter(
                         user=request.user, question=question
                     ).delete()
-                    messages.success(request, _("Answer saved"))
                 else:
                     SkippedQuestion.objects.get_or_create(
                         user=request.user, question=question
@@ -905,8 +910,15 @@ def answer_question(request, pk):
                     )
 
                 if not question:
-                    messages.info(request, _("No more questions"))
+                    if answer_value:
+                        messages.success(
+                            request, _("Answer saved. No more questions")
+                        )
+                    else:
+                        messages.info(request, _("No more questions"))
                     return redirect("survey:survey_detail")
+                if answer_value:
+                    messages.success(request, _("Answer saved"))
                 if skip_message:
                     messages.info(request, _("Question skipped"))
                 answer = None


### PR DESCRIPTION
## Summary
- Show a single "Answer saved. No more questions" notice when the final question is answered
- Translate the new combined message into Finnish and Swedish
- Test that answering the last question emits the combined message

## Testing
- `python manage.py compilemessages`
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68a50e6d03ac832e8349dadeeb911763