### PR TITLE
Show message when skipping final survey question

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -618,6 +618,11 @@ msgstr "Vastaus tallennettu"
 msgid "Answer saved. No more questions"
 msgstr "Vastaus tallennettu. Ei enempää kysymyksiä"
 
+#: wikikysely_project/survey/views.py:738
+#: wikikysely_project/survey/views.py:923
+msgid "Answer skipped. No more questions"
+msgstr "Vastaus ohitettu. Ei enempää kysymyksiä"
+
 #: wikikysely_project/survey/views.py:707
 #: wikikysely_project/survey/views.py:848
 msgid "Question skipped"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -618,6 +618,11 @@ msgstr "Svar sparat"
 msgid "Answer saved. No more questions"
 msgstr "Svar sparat. Inga fler frågor"
 
+#: wikikysely_project/survey/views.py:738
+#: wikikysely_project/survey/views.py:923
+msgid "Answer skipped. No more questions"
+msgstr "Svar hoppat över. Inga fler frågor"
+
 #: wikikysely_project/survey/views.py:707
 #: wikikysely_project/survey/views.py:848
 msgid "Question skipped"

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -163,7 +163,7 @@ class SurveyFlowTests(TransactionTestCase):
             reverse("survey:answer_survey"), data, follow=True
         )
         msgs = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn("No more questions", msgs)
+        self.assertIn("Answer skipped. No more questions", msgs)
         self.assertNotIn("Question skipped", msgs)
 
     def test_skip_last_question_no_skip_message_answer_question(self):
@@ -174,7 +174,7 @@ class SurveyFlowTests(TransactionTestCase):
             reverse("survey:answer_question", args=[q1.pk]), data, follow=True
         )
         msgs = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn("No more questions", msgs)
+        self.assertIn("Answer skipped. No more questions", msgs)
         self.assertNotIn("Question skipped", msgs)
 
     def test_answer_last_question_combined_message_answer_survey(self):

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -734,6 +734,10 @@ def answer_survey(request):
                     messages.success(
                         request, _("Answer saved. No more questions")
                     )
+                elif skip_message:
+                    messages.info(
+                        request, _("Answer skipped. No more questions")
+                    )
                 else:
                     messages.info(request, _("No more questions"))
                 return redirect("survey:survey_detail")
@@ -913,6 +917,10 @@ def answer_question(request, pk):
                     if answer_value:
                         messages.success(
                             request, _("Answer saved. No more questions")
+                        )
+                    elif skip_message:
+                        messages.info(
+                            request, _("Answer skipped. No more questions")
                         )
                     else:
                         messages.info(request, _("No more questions"))


### PR DESCRIPTION
## Summary
- show "Answer skipped. No more questions" when the last question is skipped
- add Finnish and Swedish translations for the new message
- update skip tests for new combined message

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68a511f790fc832e8039008abfb094ec