### PR TITLE
Render survey descriptions with Markdown

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -681,6 +681,10 @@ msgstr "Vastauksen voi poistaa vain, kun kysely on käynnissä"
 msgid "Answer removed"
 msgstr "Vastaus poistettu"
 
+#: wikikysely_project/survey/forms.py:24
+msgid "Markdown formatting supported: **bold**, *italic*, [link](https://...), line breaks -> <br>"
+msgstr "Markdown: **bold**, *italic*, [link](https://...), rivinvaihdot -> <br>"
+
 #~ msgid "You must be logged in to answer questions"
 #~ msgstr "Sinun tulee olla kirjautunut sisään vastataksesi kysymyksiin"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -679,6 +679,10 @@ msgstr "Svar kan tas bort endast när enkäten är igång"
 msgid "Answer removed"
 msgstr "Svar borttaget"
 
+#: wikikysely_project/survey/forms.py:24
+msgid "Markdown formatting supported: **bold**, *italic*, [link](https://...), line breaks -> <br>"
+msgstr "Markdown-formatering stöds: **bold**, *italic*, [link](https://...), radbrytningar -> <br>"
+
 #~ msgid "You must be logged in to answer questions"
 #~ msgstr "Du måste vara inloggad för att kunna svara på frågorna"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django==4.2
 social-auth-app-django==5.4.0
+markdown==3.5.1

--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
-{% load i18n static %}
+{% load i18n static markdown_extras %}
 {% block title %}{% translate 'Answers' %}{% endblock %}
 {% block content %}
-<p>{{ survey.description }}</p>
+<p>{{ survey.description|markdownify }}</p>
 {% if request.user.is_authenticated %}
     {% if data and survey.state == 'running' %}
       {% if unanswered_count %}

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n static %}
+{% load i18n static markdown_extras %}
 {% block title %}{{ survey.title }}{% endblock %}
 {% block content %}
 {% if survey.state == 'paused' %}
@@ -12,7 +12,7 @@
 {% if not questions %}
   <p class="alert alert-warning">{% translate 'This survey has no questions yet. Please add questions.' %}</p>
 {% endif %}
-<p>{{ survey.description }}</p>
+<p>{{ survey.description|markdownify }}</p>
 {% if request.user.is_authenticated %}
   <div class="mb-3">
     {% if survey.state == 'running' %}

--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -20,6 +20,11 @@ class SurveyForm(BootstrapMixin, forms.ModelForm):
     class Meta:
         model = Survey
         fields = ['title', 'description', 'state']
+        help_texts = {
+            'description': _(
+                'Markdown formatting supported: **bold**, *italic*, [link](https://...), line breaks -> <br>'
+            ),
+        }
 
 
 class SecretaryAddForm(BootstrapMixin, forms.Form):

--- a/wikikysely_project/survey/templatetags/markdown_extras.py
+++ b/wikikysely_project/survey/templatetags/markdown_extras.py
@@ -1,0 +1,15 @@
+from django import template
+from django.utils.html import escape
+from django.utils.safestring import mark_safe
+import markdown
+
+register = template.Library()
+
+@register.filter
+def markdownify(value):
+    """Render Markdown text to HTML with line breaks."""
+    if not value:
+        return ""
+    escaped = escape(value)
+    html = markdown.markdown(escaped, extensions=["nl2br"])
+    return mark_safe(html)


### PR DESCRIPTION
## Summary
- allow survey descriptions to use Markdown via custom `markdownify` filter
- mention Markdown formatting options beside the description field
- translate the new help text to Finnish and Swedish

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement markdown==3.5.1)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'markdown')*


------
https://chatgpt.com/codex/tasks/task_e_68a51799f5ec832e94d631c4b37959f8