### PR TITLE
Remove skipped question data on user data deletion

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -649,6 +649,10 @@ msgid_plural "Removed %(removed)d/%(total)d surveys."
 msgstr[0] "Poistettu %(removed)d/%(total)d kysely."
 msgstr[1] "Poistettu %(removed)d/%(total)d kyselyä."
 
+#: wikikysely_project/survey/views.py:1189
+msgid "Removed data from skipped questions."
+msgstr "Poistettu tiedot ohitetuista kysymyksistä."
+
 #: wikikysely_project/survey/views.py:1195
 #, python-format
 msgid "Could not remove %(count)d question because it already had answers."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -649,6 +649,10 @@ msgid_plural "Removed %(removed)d/%(total)d surveys."
 msgstr[0] "Tog bort %(removed)d/%(total)d enkät."
 msgstr[1] "Tog bort %(removed)d/%(total)d enkäter."
 
+#: wikikysely_project/survey/views.py:1189
+msgid "Removed data from skipped questions."
+msgstr "Tog bort data om överhoppade frågor."
+
 #: wikikysely_project/survey/views.py:1195
 #, python-format
 msgid "Could not remove %(count)d question because it already had answers."

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -748,3 +748,14 @@ class SurveyFlowTests(TransactionTestCase):
         data = response.json()["questions"][0]
         self.assertEqual(data["my_answer"], "yes")
         self.assertIsNotNone(data.get("my_answered_at"))
+
+    def test_user_data_delete_removes_skipped_questions(self):
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        SkippedQuestion.objects.create(user=self.user, question=q)
+
+        response = self.client.post(reverse("survey:user_data_delete"), follow=True)
+        self.assertRedirects(response, reverse("survey:userinfo"))
+        self.assertFalse(SkippedQuestion.objects.filter(user=self.user).exists())
+        self.assertContains(response, "Removed data from skipped questions.")
+

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -1169,6 +1169,9 @@ def user_data_delete(request):
     answers_qs.delete()
     total_answers = removed_answers
 
+    # Delete information about skipped questions
+    SkippedQuestion.objects.filter(user=user).delete()
+
     removed_questions = 0
     kept_questions = 0
 
@@ -1215,6 +1218,7 @@ def user_data_delete(request):
             total_surveys,
         )
         % {"removed": removed_surveys, "total": total_surveys},
+        _("Removed data from skipped questions."),
     ]
 
     if kept_questions:


### PR DESCRIPTION
## Summary
- extend account data purge to delete skipped question records
- show message about removed skipped question data
- provide translations for skipped question removal notice
- test deletion of skipped question data

## Testing
- `python manage.py test wikikysely_project.survey.tests.test_views.SurveyFlowTests.test_user_data_delete_removes_skipped_questions -v 2` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68a522603790832ea491747e0ae18dcf