### PR TITLE
Show survey details for update log

### DIFF
--- a/templates/survey/survey_form.html
+++ b/templates/survey/survey_form.html
@@ -58,7 +58,7 @@
   <ul class="list-group">
     {% for log in logs %}
       <li class="list-group-item">
-        {{ log.created_at|date:"Y-m-d H:i" }} - {{ log.data.username }} - {{ log.data.action }}{% if log.data.secretary_username %} - {{ log.data.secretary_username }}{% endif %}{% if log.data.question_text %} - {{ log.data.question_text }}{% endif %}
+        {{ log.created_at|date:"Y-m-d H:i" }} - {{ log.data.username }} - {{ log.data.action }}{% if log.data.secretary_username %} - {{ log.data.secretary_username }}{% endif %}{% if log.data.question_text %} - {{ log.data.question_text }}{% endif %}{% if log.data.action == "survey_update" %} - {{ log.data.survey_description }} - {{ log.data.survey_title }} - {{ log.data.survey_state }}{% endif %}
       </li>
     {% empty %}
       <li class="list-group-item">{% translate 'No log entries' %}</li>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -242,6 +242,9 @@ class SurveyFlowTests(TransactionTestCase):
         log_survey_action(self.user, survey, "survey_update")
         response = self.client.get(reverse("survey:survey_edit"))
         self.assertContains(response, "survey_update")
+        self.assertContains(response, survey.description)
+        self.assertContains(response, survey.title)
+        self.assertContains(response, survey.state)
 
     def test_secretary_add_and_remove(self):
         survey = self._create_survey()


### PR DESCRIPTION
## Summary
- show survey description, title and state for survey update log entries
- test that edit page log displays survey details

## Testing
- `python manage.py test wikikysely_project.survey.tests.test_views.SurveyFlowTests.test_logs_shown_on_edit_page -v 2` *(fails: OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68a5335de960832e885d3aa844a9363f