### PR TITLE
Show alert when survey paused on question form

### DIFF
--- a/templates/survey/question_form.html
+++ b/templates/survey/question_form.html
@@ -3,10 +3,13 @@
 {% block title %}{% if is_edit %}{% translate 'Edit question' %}{% else %}{% translate 'Add question' %}{% endif %}{% endblock %}
 {% block content %}
 <h1>{% if is_edit %}{% translate 'Edit question' %}{% else %}{% translate 'Add question' %}{% endif %}</h1>
+  {% if survey.state == 'paused' %}
+  <div class="alert alert-info">{% translate 'Survey not active' %}</div>
+  {% endif %}
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit" class="btn btn-primary me-2">{% translate 'Save' %}</button>
+    <button type="submit" class="btn btn-primary me-2"{% if survey.state == 'paused' %} disabled{% endif %}>{% translate 'Save' %}</button>
     <a href="{% url 'survey:survey_detail' %}" class="btn btn-secondary">{% translate 'Cancel' %}</a>
     {% if is_edit and can_delete_question %}
     <a href="{% url 'survey:question_delete' form.instance.pk %}" class="btn btn-danger ms-2">{% translate 'Remove question' %}</a>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -277,6 +277,18 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(question.text, "What do you think?")
         self.assertRedirects(response, reverse("survey:survey_detail"))
 
+    def test_add_question_page_disabled_when_paused(self):
+        survey = self._create_survey()
+        survey.state = "paused"
+        survey.save()
+        response = self.client.get(reverse("survey:question_add"))
+        self.assertContains(response, "Survey not active")
+        self.assertContains(
+            response,
+            '<button type="submit" class="btn btn-primary me-2" disabled>',
+            html=True,
+        )
+
     def test_delete_and_restore_question(self):
         survey = self._create_survey()
         question = self._create_question(survey)


### PR DESCRIPTION
## Summary
- show "Survey not active" alert on question form when the survey is paused
- disable the question save button while survey paused
- add regression test for paused survey question form

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68a538e1dc10832eb19481c1190bdfbe