### PR TITLE
Add ARIA attributes to survey answer progress bars

### DIFF
--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -46,8 +46,8 @@
     </td>
     <td class="w-100">
       <div class="progress" style="height: 1.25rem;">
-        <div class="progress-bar bg-success text-black" role="progressbar" style="width: {% widthratio row.yes total_users 100 %}%">{{ row.yes }}</div>
-        <div class="progress-bar bg-danger text-light" role="progressbar" style="width: {% widthratio row.no total_users 100 %}%">{{ row.no }}</div>
+        <div class="progress-bar bg-success text-black" role="progressbar" style="width: {% widthratio row.yes total_users 100 %}%" aria-valuenow="{{ row.yes }}" aria-valuemin="0" aria-valuemax="{{ total_users }}">{{ row.yes }}</div>
+        <div class="progress-bar bg-danger text-light" role="progressbar" style="width: {% widthratio row.no total_users 100 %}%" aria-valuenow="{{ row.no }}" aria-valuemin="0" aria-valuemax="{{ total_users }}">{{ row.no }}</div>
       </div>
     </td>
   </tr>


### PR DESCRIPTION
## Summary
- add aria-valuenow, aria-valuemin, and aria-valuemax to yes/no progress bars

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2` *(fails: test_add_question_page_disabled_when_paused, test_user_data_delete_removes_skipped_questions)*

------
https://chatgpt.com/codex/tasks/task_e_68b83ba6e7e0832e9cb665597cf632bd