### PR TITLE
Fix invalid HTML in question form template

### DIFF
--- a/templates/survey/question_form.html
+++ b/templates/survey/question_form.html
@@ -29,5 +29,4 @@
     <a href="{% if LANGUAGE_CODE == 'en' %}https://fi.wikipedia.org/wiki/Wikiprojekti:Wikikysely_2025/ohjeet/en{% elif LANGUAGE_CODE == 'sv' %}https://fi.wikipedia.org/wiki/Wikiprojekti:Wikikysely_2025/ohjeet/sv{% else %}https://fi.wikipedia.org/wiki/Wikiprojekti:Wikikysely_2025/ohjeet{% endif %}" target="_blank">{% translate 'Read more instructions' %}</a>
   </p>
   {% endif %}
-</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove stray closing div from question form template to avoid HTML parse errors when survey is paused

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement django==4.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a6cfc3f860832ebecf468230024cad