### PR TITLE
Improve link color contrast for accessibility

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,13 @@
+/* Improve link color contrast for accessibility */
+:root {
+  --bs-link-color: #0b7285;
+  --bs-link-hover-color: #095c65;
+}
+[data-bs-theme="dark"] {
+  --bs-link-color: #4dabf7;
+  --bs-link-hover-color: #339af0;
+}
+
 body {
   padding-bottom: 60px;
 }


### PR DESCRIPTION
## Summary
- adjust default and dark theme link colors to meet WCAG 2.2 contrast

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68b842a6c58c832e97f0d1bc628d5cc7