### PR TITLE
Show question details in answer notifications

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -163,7 +163,8 @@ class SurveyFlowTests(TransactionTestCase):
             reverse("survey:answer_survey"), data, follow=True
         )
         msgs = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn("Answer skipped. No more questions", msgs)
+        expected = f'Skipped question #{q1.pk}: "{q1.text}". No more questions'
+        self.assertIn(expected, msgs)
         self.assertNotIn("Question skipped", msgs)
 
     def test_skip_last_question_no_skip_message_answer_question(self):
@@ -174,7 +175,8 @@ class SurveyFlowTests(TransactionTestCase):
             reverse("survey:answer_question", args=[q1.pk]), data, follow=True
         )
         msgs = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn("Answer skipped. No more questions", msgs)
+        expected = f'Skipped question #{q1.pk}: "{q1.text}". No more questions'
+        self.assertIn(expected, msgs)
         self.assertNotIn("Question skipped", msgs)
 
     def test_answer_last_question_combined_message_answer_survey(self):
@@ -185,7 +187,8 @@ class SurveyFlowTests(TransactionTestCase):
             reverse("survey:answer_survey"), data, follow=True
         )
         msgs = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn("Answer saved. No more questions", msgs)
+        expected = f'Answered question #{q1.pk}: "{q1.text}" with "Yes". No more questions'
+        self.assertIn(expected, msgs)
 
     def test_answer_last_question_combined_message_answer_question(self):
         survey = self._create_survey()
@@ -195,7 +198,8 @@ class SurveyFlowTests(TransactionTestCase):
             reverse("survey:answer_question", args=[q1.pk]), data, follow=True
         )
         msgs = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn("Answer saved. No more questions", msgs)
+        expected = f'Answered question #{q1.pk}: "{q1.text}" with "Yes". No more questions'
+        self.assertIn(expected, msgs)
 
     def test_survey_edit(self):
         survey = self._create_survey()

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -704,6 +704,7 @@ def answer_survey(request):
         if form.is_valid():
             answer_value = form.cleaned_data["answer"]
             skip_message = False
+            answered_question = question
             if answer_value:
                 Answer.objects.update_or_create(
                     user=request.user,
@@ -742,22 +743,54 @@ def answer_survey(request):
             if not answer_value:
                 remaining = remaining.exclude(id=question.pk)
             question = random.choice(list(remaining)) if remaining else None
+            answer_label = (
+                gettext("Yes") if answer_value == "yes" else gettext("No")
+                if answer_value else ""
+            )
             if not question:
                 if answer_value:
                     messages.success(
-                        request, _("Answer saved. No more questions")
+                        request,
+                        gettext(
+                            'Answered question #{number}: "{question}" with "{answer}". No more questions'
+                        ).format(
+                            number=answered_question.pk,
+                            question=answered_question.text,
+                            answer=answer_label,
+                        ),
                     )
                 elif skip_message:
                     messages.info(
-                        request, _("Answer skipped. No more questions")
+                        request,
+                        gettext(
+                            'Skipped question #{number}: "{question}". No more questions'
+                        ).format(
+                            number=answered_question.pk,
+                            question=answered_question.text,
+                        ),
                     )
                 else:
                     messages.info(request, _("No more questions"))
                 return redirect("survey:survey_detail")
             if answer_value:
-                messages.success(request, _("Answer saved"))
+                messages.success(
+                    request,
+                    gettext(
+                        'Answered question #{number}: "{question}" with "{answer}"'
+                    ).format(
+                        number=answered_question.pk,
+                        question=answered_question.text,
+                        answer=answer_label,
+                    ),
+                )
             if skip_message:
-                messages.info(request, _("Question skipped"))
+                messages.info(
+                    request,
+                    gettext('Skipped question #{number}: "{question}"').format(
+                        number=answered_question.pk,
+                        question=answered_question.text,
+                    ),
+                )
             form = AnswerForm(initial={"question_id": question.pk})
     else:
         answered_questions = Answer.objects.filter(
@@ -858,6 +891,7 @@ def answer_question(request, pk):
             if form.is_valid():
                 answer_value = form.cleaned_data["answer"]
                 skip_message = False
+                answered_question = question
                 if answer_value:
                     Answer.objects.update_or_create(
                         user=request.user,
@@ -888,14 +922,35 @@ def answer_question(request, pk):
                         }
                     )
 
+                answer_label = (
+                    gettext("Yes") if answer_value == "yes" else gettext("No")
+                    if answer_value else ""
+                )
+
                 if answer is not None and next_url:
                     from urllib.parse import urlparse
-                    print(next_url)
-
                     if urlparse(next_url).path != request.path:
-                        print("REDIRECT")
-                        if skip_message:
-                            messages.info(request, _("Question skipped"))
+                        if answer_value:
+                            messages.success(
+                                request,
+                                gettext(
+                                    'Answered question #{number}: "{question}" with "{answer}"'
+                                ).format(
+                                    number=answered_question.pk,
+                                    question=answered_question.text,
+                                    answer=answer_label,
+                                ),
+                            )
+                        elif skip_message:
+                            messages.info(
+                                request,
+                                gettext(
+                                    'Skipped question #{number}: "{question}"'
+                                ).format(
+                                    number=answered_question.pk,
+                                    question=answered_question.text,
+                                ),
+                            )
                         return redirect(next_url)
 
                 answered_questions = Answer.objects.filter(
@@ -929,19 +984,47 @@ def answer_question(request, pk):
                 if not question:
                     if answer_value:
                         messages.success(
-                            request, _("Answer saved. No more questions")
+                            request,
+                            gettext(
+                                'Answered question #{number}: "{question}" with "{answer}". No more questions'
+                            ).format(
+                                number=answered_question.pk,
+                                question=answered_question.text,
+                                answer=answer_label,
+                            ),
                         )
                     elif skip_message:
                         messages.info(
-                            request, _("Answer skipped. No more questions")
+                            request,
+                            gettext(
+                                'Skipped question #{number}: "{question}". No more questions'
+                            ).format(
+                                number=answered_question.pk,
+                                question=answered_question.text,
+                            ),
                         )
                     else:
                         messages.info(request, _("No more questions"))
                     return redirect("survey:survey_detail")
                 if answer_value:
-                    messages.success(request, _("Answer saved"))
+                    messages.success(
+                        request,
+                        gettext(
+                            'Answered question #{number}: "{question}" with "{answer}"'
+                        ).format(
+                            number=answered_question.pk,
+                            question=answered_question.text,
+                            answer=answer_label,
+                        ),
+                    )
                 if skip_message:
-                    messages.info(request, _("Question skipped"))
+                    messages.info(
+                        request,
+                        gettext('Skipped question #{number}: "{question}"').format(
+                            number=answered_question.pk,
+                            question=answered_question.text,
+                        ),
+                    )
                 answer = None
                 form = AnswerForm(initial={"question_id": question.pk})
             else:


### PR DESCRIPTION
## Summary
- Display question number, text, and selected answer in notification messages
- Indicate skipped questions with their number and text
- Update tests for new notification content

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68b85e85475c832eabc127c8e88bc36d