### PR TITLE
Show added question text in success notification

### DIFF
--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -433,7 +433,10 @@ def question_add(request):
                 question.survey = survey
                 question.creator = request.user
                 question.save()
-                messages.success(request, _("Question added"))
+                messages.success(
+                    request,
+                    _("Question added") + f": {question.text}",
+                )
                 return redirect("survey:survey_detail")
     else:
         form = QuestionForm()


### PR DESCRIPTION
## Summary
- include the submitted question text in the "Question added" success message
- adjust tests to expect the new message and fix HTML assertions

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b865eb9cd0832ead515526ce670218