### PR TITLE
Link questions in wikitext results and ensure bar visibility

### DIFF
--- a/templates/survey/answers_wikitext.txt
+++ b/templates/survey/answers_wikitext.txt
@@ -8,8 +8,8 @@
 {% for row in data %}
 <tr>
 <td>{{ row.question.pk }}</td>
-<td style="min-width:15rem"> {% if request.user.is_authenticated %}<a href="{% url 'survey:answer_question' row.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ row.question.text }}</a>{% else %}{{ row.question.text }}{% endif %}</td>
-<td style="width:100%"><div style="background-color:#e9ecef;border:1px solid black;display:flex;border-radius:0.25rem;margin-bottom:0.25em;margin-top:0.25em;">{% if row.yes  %}<div style="width: {% widthratio row.yes total_users 100 %}%;background-color:#198754;color:#000;display:flex;align-items:center;justify-content:center;">{{ row.yes }}</div>{% endif %}{% if row.no  %}<div style="width: {% widthratio row.no total_users 100 %}%;background-color:#dc3545;color:#fff;display:flex;align-items:center;justify-content:center;">{{ row.no }}</div>{% endif %}</div></td>
+<td style="width:20rem">[https://wikikysely.toolforge.org/fi/question/{{ row.question.pk }} {{ row.question.text }}]</td>
+<td style="width:100%"><div style="background-color:#e9ecef;border:1px solid black;display:flex;border-radius:0.25rem;margin-bottom:0.25em;margin-top:0.25em;min-height:1.5em;">{% if row.yes  %}<div style="width: {% widthratio row.yes total_users 100 %}%;background-color:#198754;color:#000;display:flex;align-items:center;justify-content:center;min-height:1.5em;">{{ row.yes }}</div>{% endif %}{% if row.no  %}<div style="width: {% widthratio row.no total_users 100 %}%;background-color:#dc3545;color:#fff;display:flex;align-items:center;justify-content:center;min-height:1.5em;">{{ row.no }}</div>{% endif %}</div></td>
 </tr>
 {% endfor %}
 </table>

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -508,6 +508,13 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(data["survey"]["title"], survey.title)
         self.assertEqual(len(data["data"]), 1)
 
+    def test_answers_wikitext_has_question_links(self):
+        survey = self._create_survey()
+        question = self._create_question(survey)
+        response = self.client.get(reverse("survey:survey_answers_wikitext"))
+        expected = f"[https://wikikysely.toolforge.org/fi/question/{question.pk} {question.text}]"
+        self.assertContains(response, expected)
+
     def test_answer_saved_to_correct_question_and_user(self):
         survey = self._create_survey()
         questions = self._create_questions(survey, 10)


### PR DESCRIPTION
## Summary
- Fix wikitext results table to use 20rem question column with a direct link to the question
- Ensure bar chart bars have a minimum height of 1.5em even with no responses
- Add regression test for wikitext question link

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b8718d6068832eacc296270923a668