### PR TITLE
Show completion message after answering all questions

### DIFF
--- a/templates/survey/completion.html
+++ b/templates/survey/completion.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}Kiitos vastaamisesta{% endblock %}
+{% block content %}
+<div class="alert alert-info">
+Kiitos vastaamisesta, olet nyt nähnyt kaikki kysymykset!
+</div>
+<p>
+Vastaukset ovat tietoa joka tuottaa hyötyä vasta käytettäessä. Osallistu Wikipedian ja -median <a href="https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025">keskusteluihin</a> ja Wikimedia Suomen päätöksentekoon ja tuo esiin oma tulkintasi yhteisestä hyvästä. Nyt voit perustaa mielipiteesi ja viitata mitattuun tietoon yhteisön mielipiteistä. Lähteeksi voit ilmoittaa: Wikikysely 2025, kysymys nro #1,  päivämäärä DD.MM.YYYY kello HH.MM  https://wikikysely.toolforge.org/fi/answers/
+</p>
+<div class="mt-3">
+  <a href="{% url 'survey:survey_answers' %}" class="btn btn-primary mb-2">Katso kaikkien vastaukset</a>
+  {% if has_skipped %}
+  <a href="{% url 'survey:answer_survey' %}" class="btn btn-secondary mb-2">Palaa ohitettuihin kysymyksiin</a>
+  {% endif %}
+  <a href="{% url 'survey:question_add' %}" class="btn btn-secondary mb-2">Lisää kysymys</a>
+</div>
+{% endblock %}

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -159,47 +159,41 @@ class SurveyFlowTests(TransactionTestCase):
         survey = self._create_survey()
         q1 = self._create_question(survey)
         data = {"question_id": q1.pk, "answer": ""}
-        response = self.client.post(
-            reverse("survey:answer_survey"), data, follow=True
-        )
-        msgs = [m.message for m in get_messages(response.wsgi_request)]
-        expected = f'Skipped question #{q1.pk}: "{q1.text}". No more questions'
-        self.assertIn(expected, msgs)
-        self.assertNotIn("Question skipped", msgs)
+        response = self.client.post(reverse("survey:answer_survey"), data)
+        self.assertTemplateUsed(response, "survey/completion.html")
+        self.assertContains(response, "Kiitos vastaamisesta")
+        self.assertContains(response, "Palaa ohitettuihin kysymyksiin")
 
     def test_skip_last_question_no_skip_message_answer_question(self):
         survey = self._create_survey()
         q1 = self._create_question(survey)
         data = {"question_id": q1.pk, "answer": ""}
         response = self.client.post(
-            reverse("survey:answer_question", args=[q1.pk]), data, follow=True
+            reverse("survey:answer_question", args=[q1.pk]), data
         )
-        msgs = [m.message for m in get_messages(response.wsgi_request)]
-        expected = f'Skipped question #{q1.pk}: "{q1.text}". No more questions'
-        self.assertIn(expected, msgs)
-        self.assertNotIn("Question skipped", msgs)
+        self.assertTemplateUsed(response, "survey/completion.html")
+        self.assertContains(response, "Kiitos vastaamisesta")
+        self.assertContains(response, "Palaa ohitettuihin kysymyksiin")
 
     def test_answer_last_question_combined_message_answer_survey(self):
         survey = self._create_survey()
         q1 = self._create_question(survey)
         data = {"question_id": q1.pk, "answer": "yes"}
-        response = self.client.post(
-            reverse("survey:answer_survey"), data, follow=True
-        )
-        msgs = [m.message for m in get_messages(response.wsgi_request)]
-        expected = f'Answered question #{q1.pk}: "{q1.text}" with "Yes". No more questions'
-        self.assertIn(expected, msgs)
+        response = self.client.post(reverse("survey:answer_survey"), data)
+        self.assertTemplateUsed(response, "survey/completion.html")
+        self.assertContains(response, "Kiitos vastaamisesta")
+        self.assertNotContains(response, "Palaa ohitettuihin kysymyksiin")
 
     def test_answer_last_question_combined_message_answer_question(self):
         survey = self._create_survey()
         q1 = self._create_question(survey)
         data = {"question_id": q1.pk, "answer": "yes"}
         response = self.client.post(
-            reverse("survey:answer_question", args=[q1.pk]), data, follow=True
+            reverse("survey:answer_question", args=[q1.pk]), data
         )
-        msgs = [m.message for m in get_messages(response.wsgi_request)]
-        expected = f'Answered question #{q1.pk}: "{q1.text}" with "Yes". No more questions'
-        self.assertIn(expected, msgs)
+        self.assertTemplateUsed(response, "survey/completion.html")
+        self.assertContains(response, "Kiitos vastaamisesta")
+        self.assertNotContains(response, "Palaa ohitettuihin kysymyksiin")
 
     def test_survey_edit(self):
         survey = self._create_survey()


### PR DESCRIPTION
## Summary
- display a thank-you page once the user has seen all survey questions
- include buttons to view all answers, revisit skipped questions, or add a question
- update answer flow logic and tests for the new completion page

## Testing
- `python manage.py test` *(fails: sqlite3.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a0bdae88832eaf9fc05160e1f305