### PR TITLE
Show completion message when all questions answered

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -733,19 +733,23 @@ msgstr "Markdown: **bold**, *italic*, [link](https://...), rivinvaihdot -> <br>"
 msgid "Thank you for answering"
 msgstr "Kiitos vastaamisesta"
 
-#: templates/survey/completion.html:6
+#: templates/survey/completion.html:7
 msgid "Thank you for answering, you have now seen all the questions!"
 msgstr "Kiitos vastaamisesta, olet nyt nähnyt kaikki kysymykset!"
 
 #: templates/survey/completion.html:9
+msgid "Thank you for answering, you have now answered all the questions!"
+msgstr "Kiitos vastaamisesta, olet nyt vastannut kaikkiin kysymyksiin!"
+
+#: templates/survey/completion.html:13
 msgid "Answers are knowledge that produces benefit only when used. Participate in Wikipedia and Wikimedia <a href=\"https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025\">discussions</a> and in Wikimedia Finland's decision-making and bring out your interpretation of the common good. Now you can base your opinion and refer to measured information about the community's opinions. You may cite as a source: Wikikysely 2025, question no. #1, date DD.MM.YYYY time HH.MM https://wikikysely.toolforge.org/fi/answers/"
 msgstr "Vastaukset ovat tietoa joka tuottaa hyötyä vasta käytettäessä. Osallistu Wikipedian ja Wikimedian <a href=\"https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025\">keskusteluihin</a> ja Wikimedia Suomen päätöksentekoon ja tuo esiin oma tulkintasi yhteisestä hyvästä. Nyt voit perustaa mielipiteesi ja viitata mitattuun tietoon yhteisön mielipiteistä. Lähteeksi voit ilmoittaa: Wikikysely 2025, kysymys nro #1,  päivämäärä DD.MM.YYYY kello HH.MM  https://wikikysely.toolforge.org/fi/answers/"
 
-#: templates/survey/completion.html:12
+#: templates/survey/completion.html:16
 msgid "View all answers"
 msgstr "Katso kaikkien vastaukset"
 
-#: templates/survey/completion.html:14
+#: templates/survey/completion.html:18
 msgid "Return to skipped questions"
 msgstr "Palaa ohitettuihin kysymyksiin"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -730,19 +730,23 @@ msgstr "Markdown-formatering stöds: **bold**, *italic*, [link](https://...), ra
 msgid "Thank you for answering"
 msgstr "Tack för att du svarade"
 
-#: templates/survey/completion.html:6
+#: templates/survey/completion.html:7
 msgid "Thank you for answering, you have now seen all the questions!"
 msgstr "Tack för att du svarade, du har nu sett alla frågor!"
 
 #: templates/survey/completion.html:9
+msgid "Thank you for answering, you have now answered all the questions!"
+msgstr "Tack för att du svarade, du har nu besvarat alla frågor!"
+
+#: templates/survey/completion.html:13
 msgid "Answers are knowledge that produces benefit only when used. Participate in Wikipedia and Wikimedia <a href=\"https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025\">discussions</a> and in Wikimedia Finland's decision-making and bring out your interpretation of the common good. Now you can base your opinion and refer to measured information about the community's opinions. You may cite as a source: Wikikysely 2025, question no. #1, date DD.MM.YYYY time HH.MM https://wikikysely.toolforge.org/fi/answers/"
 msgstr "Svar är kunskap som ger nytta först när den används. Delta i Wikipedia och Wikimedias <a href=\"https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025\">diskussioner</a> och i Wikimedia Finlands beslutsfattande och lyft fram din tolkning av det gemensamma bästa. Nu kan du grunda din åsikt och hänvisa till uppmätt information om gemenskapens åsikter. Som källa kan du ange: Wikikysely 2025, fråga nr #1, datum DD.MM.YYYY klockan HH.MM https://wikikysely.toolforge.org/fi/answers/"
 
-#: templates/survey/completion.html:12
+#: templates/survey/completion.html:16
 msgid "View all answers"
 msgstr "Visa alla svar"
 
-#: templates/survey/completion.html:14
+#: templates/survey/completion.html:18
 msgid "Return to skipped questions"
 msgstr "Återvänd till överhoppade frågor"
 

--- a/templates/survey/completion.html
+++ b/templates/survey/completion.html
@@ -3,7 +3,11 @@
 {% block title %}{% translate 'Thank you for answering' %}{% endblock %}
 {% block content %}
 <div class="alert alert-info">
-{% translate 'Thank you for answering, you have now seen all the questions!' %}
+  {% if has_skipped %}
+    {% translate 'Thank you for answering, you have now seen all the questions!' %}
+  {% else %}
+    {% translate 'Thank you for answering, you have now answered all the questions!' %}
+  {% endif %}
 </div>
 <p>
 {% blocktranslate trimmed %}Answers are knowledge that produces benefit only when used. Participate in Wikipedia and Wikimedia <a href="https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025">discussions</a> and in Wikimedia Finland's decision-making and bring out your interpretation of the common good. Now you can base your opinion and refer to measured information about the community's opinions. You may cite as a source: Wikikysely 2025, question no. #1, date DD.MM.YYYY time HH.MM https://wikikysely.toolforge.org/fi/answers/{% endblocktranslate %}

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -161,7 +161,10 @@ class SurveyFlowTests(TransactionTestCase):
         data = {"question_id": q1.pk, "answer": ""}
         response = self.client.post(reverse("survey:answer_survey"), data)
         self.assertTemplateUsed(response, "survey/completion.html")
-        self.assertContains(response, "Thank you for answering")
+        self.assertContains(
+            response,
+            "Thank you for answering, you have now seen all the questions!",
+        )
         self.assertContains(response, "Return to skipped questions")
 
     def test_skip_last_question_no_skip_message_answer_question(self):
@@ -172,7 +175,10 @@ class SurveyFlowTests(TransactionTestCase):
             reverse("survey:answer_question", args=[q1.pk]), data
         )
         self.assertTemplateUsed(response, "survey/completion.html")
-        self.assertContains(response, "Thank you for answering")
+        self.assertContains(
+            response,
+            "Thank you for answering, you have now seen all the questions!",
+        )
         self.assertContains(response, "Return to skipped questions")
 
     def test_answer_last_question_combined_message_answer_survey(self):
@@ -181,7 +187,10 @@ class SurveyFlowTests(TransactionTestCase):
         data = {"question_id": q1.pk, "answer": "yes"}
         response = self.client.post(reverse("survey:answer_survey"), data)
         self.assertTemplateUsed(response, "survey/completion.html")
-        self.assertContains(response, "Thank you for answering")
+        self.assertContains(
+            response,
+            "Thank you for answering, you have now answered all the questions!",
+        )
         self.assertNotContains(response, "Return to skipped questions")
 
     def test_answer_last_question_combined_message_answer_question(self):
@@ -192,7 +201,10 @@ class SurveyFlowTests(TransactionTestCase):
             reverse("survey:answer_question", args=[q1.pk]), data
         )
         self.assertTemplateUsed(response, "survey/completion.html")
-        self.assertContains(response, "Thank you for answering")
+        self.assertContains(
+            response,
+            "Thank you for answering, you have now answered all the questions!",
+        )
         self.assertNotContains(response, "Return to skipped questions")
 
     def test_survey_edit(self):


### PR DESCRIPTION
## Summary
- Display a different completion notice when all questions have been answered
- Add Finnish and Swedish translations for the new completion message
- Extend view tests to cover both completion messages

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bbd2b2b998832ebd2aff21763f9a7e