### PR TITLE
Move skipped question link into completion alert

### DIFF
--- a/templates/survey/completion.html
+++ b/templates/survey/completion.html
@@ -5,6 +5,9 @@
 <div class="alert alert-info">
   {% if has_skipped %}
     {% translate 'Thank you for answering, you have now seen all the questions!' %}
+    <a href="{% url 'survey:answer_survey' %}" class="btn btn-secondary btn-sm ms-3">
+      {% translate 'Return to skipped questions' %}
+    </a>
   {% else %}
     {% translate 'Thank you for answering, you have now answered all the questions!' %}
   {% endif %}
@@ -14,9 +17,6 @@
 </p>
 <div class="mt-3">
   <a href="{% url 'survey:survey_answers' %}" class="btn btn-primary mb-2">{% translate 'View all answers' %}</a>
-  {% if has_skipped %}
-  <a href="{% url 'survey:answer_survey' %}" class="btn btn-secondary mb-2">{% translate 'Return to skipped questions' %}</a>
-  {% endif %}
   <a href="{% url 'survey:question_add' %}" class="btn btn-secondary mb-2">{% translate 'Add question' %}</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- place "Return to skipped questions" button inside completion notice
- clean up completion page footer buttons

## Testing
- `python manage.py test` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd5be5198832ea0bc2c44f5b91f83