### PR TITLE
Clarify completion message for skipped survey questions

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -734,8 +734,8 @@ msgid "Thank you for answering"
 msgstr "Kiitos vastaamisesta"
 
 #: templates/survey/completion.html:7
-msgid "Thank you for answering, you have now seen all the questions!"
-msgstr "Kiitos vastaamisesta, olet nyt nähnyt kaikki kysymykset!"
+msgid "Thank you for answering, you have now answered the questions, except those you skipped!"
+msgstr "Kiitos vastaamisesta, olet nyt vastannut kysymyksiin, paitsi niihin jotka ohitit!"
 
 #: templates/survey/completion.html:9
 msgid "Thank you for answering, you have now answered all the questions!"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -731,8 +731,8 @@ msgid "Thank you for answering"
 msgstr "Tack för att du svarade"
 
 #: templates/survey/completion.html:7
-msgid "Thank you for answering, you have now seen all the questions!"
-msgstr "Tack för att du svarade, du har nu sett alla frågor!"
+msgid "Thank you for answering, you have now answered the questions, except those you skipped!"
+msgstr "Tack för att du svarade, du har nu besvarat frågorna, förutom de du hoppade över!"
 
 #: templates/survey/completion.html:9
 msgid "Thank you for answering, you have now answered all the questions!"

--- a/templates/survey/completion.html
+++ b/templates/survey/completion.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="alert alert-info">
   {% if has_skipped %}
-    {% translate 'Thank you for answering, you have now seen all the questions!' %}
+    {% translate 'Thank you for answering, you have now answered the questions, except those you skipped!' %}
   {% else %}
     {% translate 'Thank you for answering, you have now answered all the questions!' %}
   {% endif %}

--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -163,7 +163,7 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertTemplateUsed(response, "survey/completion.html")
         self.assertContains(
             response,
-            "Thank you for answering, you have now seen all the questions!",
+            "Thank you for answering, you have now answered the questions, except those you skipped!",
         )
         self.assertContains(response, "Return to skipped questions")
 
@@ -177,7 +177,7 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertTemplateUsed(response, "survey/completion.html")
         self.assertContains(
             response,
-            "Thank you for answering, you have now seen all the questions!",
+            "Thank you for answering, you have now answered the questions, except those you skipped!",
         )
         self.assertContains(response, "Return to skipped questions")
 


### PR DESCRIPTION
## Summary
- Clarify survey completion alert when questions were skipped
- Update Finnish and Swedish translations for the revised message
- Adjust view tests to match updated wording

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bbebe601a0832eb0b197ac3642bd9f