### PR TITLE
Show guidance after skipping question

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -790,3 +790,6 @@ msgstr "Palaa ohitettuihin kysymyksiin"
 
 #~ msgid "Submit"
 #~ msgstr "Lähetä"
+#: templates/survey/answer_form.html:49
+msgid "If the question was poorly worded, you can <a href='http://127.0.0.1:8000/fi/survey/question/add/'>add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data."
+msgstr "Jos kysymys oli huonosti muotoiltu, niin voit <a href='http://127.0.0.1:8000/fi/survey/question/add/'>lisätä</a> samasta aiheesta vain vähänkin poikkeavan uuden kysymyksen. Eri näkökulmat samoihin aiheisiin auttavat tekemään perustellumpia tulkintoja vastausaineistosta."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -793,3 +793,6 @@ msgstr "Återvänd till överhoppade frågor"
 
 #~ msgid "Submit"
 #~ msgstr "Skicka"
+#: templates/survey/answer_form.html:49
+msgid "If the question was poorly worded, you can <a href='http://127.0.0.1:8000/fi/survey/question/add/'>add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data."
+msgstr "Om frågan var dåligt formulerad kan du <a href='http://127.0.0.1:8000/fi/survey/question/add/'>lägga till</a> en ny fråga om samma ämne även om den bara skiljer sig lite. Olika perspektiv på samma ämnen hjälper till att göra mer välgrundade tolkningar av svarsmaterialet."

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -44,6 +44,12 @@
 </form>
 {% endif %}
   </div>
+  {% if show_skip_help %}
+  {% blocktrans trimmed asvar skip_help_message %}
+  If the question was poorly worded, you can <a href='http://127.0.0.1:8000/fi/survey/question/add/'>add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data.
+  {% endblocktrans %}
+  <div class="card-footer"><p class="fst-italic mb-0">{{ skip_help_message|safe }}</p></div>
+  {% endif %}
 </div>
 {% if question_stats %}
   <h2 class="mt-4">

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -866,6 +866,7 @@ def answer_question(request, pk):
     answer = None
     can_delete_question = False
     next_url = request.GET.get("next") or request.POST.get("next")
+    show_skip_help = False
 
     if not request.user.is_authenticated:
         login_url = f"{reverse('social:begin', args=['mediawiki'])}?next={request.path}"
@@ -902,6 +903,7 @@ def answer_question(request, pk):
                         user=request.user, question=question
                     )
                     skip_message = True
+                    show_skip_help = True
 
                 if request.headers.get("X-Requested-With") == "XMLHttpRequest":
                     yes_count = question.answers.filter(answer="yes").count()
@@ -1043,6 +1045,7 @@ def answer_question(request, pk):
             "no_label": no_label,
             "no_answers_label": no_answers_label,
             "next": next_url,
+            "show_skip_help": show_skip_help,
         },
     )
 


### PR DESCRIPTION
## Summary
- show guidance under the answer box after a question is skipped
- include Finnish, Swedish and English translations for the guidance text

## Testing
- `python manage.py test`
- `python manage.py compilemessages`


------
https://chatgpt.com/codex/tasks/task_e_68bbf23d6408832eb9548344d9a393b0