### PR TITLE
Fix question add link to respect current site and language

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -790,6 +790,6 @@ msgstr "Palaa ohitettuihin kysymyksiin"
 
 #~ msgid "Submit"
 #~ msgstr "Lähetä"
-#: templates/survey/answer_form.html:49
-msgid "If the question was poorly worded, you can <a href='http://127.0.0.1:8000/fi/survey/question/add/'>add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data."
-msgstr "Jos kysymys oli huonosti muotoiltu, niin voit <a href='http://127.0.0.1:8000/fi/survey/question/add/'>lisätä</a> samasta aiheesta vain vähänkin poikkeavan uuden kysymyksen. Eri näkökulmat samoihin aiheisiin auttavat tekemään perustellumpia tulkintoja vastausaineistosta."
+#: templates/survey/answer_form.html:50
+msgid "If the question was poorly worded, you can <a href=\"%(question_add_url)s\">add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data."
+msgstr "Jos kysymys oli huonosti muotoiltu, niin voit <a href=\"%(question_add_url)s\">lisätä</a> samasta aiheesta vain vähänkin poikkeavan uuden kysymyksen. Eri näkökulmat samoihin aiheisiin auttavat tekemään perustellumpia tulkintoja vastausaineistosta."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -793,6 +793,6 @@ msgstr "Återvänd till överhoppade frågor"
 
 #~ msgid "Submit"
 #~ msgstr "Skicka"
-#: templates/survey/answer_form.html:49
-msgid "If the question was poorly worded, you can <a href='http://127.0.0.1:8000/fi/survey/question/add/'>add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data."
-msgstr "Om frågan var dåligt formulerad kan du <a href='http://127.0.0.1:8000/fi/survey/question/add/'>lägga till</a> en ny fråga om samma ämne även om den bara skiljer sig lite. Olika perspektiv på samma ämnen hjälper till att göra mer välgrundade tolkningar av svarsmaterialet."
+#: templates/survey/answer_form.html:50
+msgid "If the question was poorly worded, you can <a href=\"%(question_add_url)s\">add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data."
+msgstr "Om frågan var dåligt formulerad kan du <a href=\"%(question_add_url)s\">lägga till</a> en ny fråga om samma ämne även om den bara skiljer sig lite. Olika perspektiv på samma ämnen hjälper till att göra mer välgrundade tolkningar av svarsmaterialet."

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -45,8 +45,9 @@
 {% endif %}
   </div>
   {% if show_skip_help %}
-  {% blocktrans trimmed asvar skip_help_message %}
-  If the question was poorly worded, you can <a href='http://127.0.0.1:8000/fi/survey/question/add/'>add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data.
+  {% url 'survey:question_add' as question_add_url %}
+  {% blocktrans trimmed with question_add_url=question_add_url asvar skip_help_message %}
+  If the question was poorly worded, you can <a href="{{ question_add_url }}">add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data.
   {% endblocktrans %}
   <div class="card-footer"><p class="fst-italic mb-0">{{ skip_help_message|safe }}</p></div>
   {% endif %}


### PR DESCRIPTION
## Summary
- replace hardcoded question creation link with dynamic `question_add` URL
- update Finnish and Swedish translations to use URL placeholder

## Testing
- `python manage.py compilemessages`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf6c93bc8832ea4993de93a8df5be