### PR TITLE
Add tip label to skipped question guidance

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -793,3 +793,7 @@ msgstr "Palaa ohitettuihin kysymyksiin"
 #: templates/survey/answer_form.html:50
 msgid "If the question was poorly worded, you can <a href=\"%(question_add_url)s\">add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data."
 msgstr "Jos kysymys oli huonosti muotoiltu, niin voit <a href=\"%(question_add_url)s\">lisätä</a> samasta aiheesta vain vähänkin poikkeavan uuden kysymyksen. Eri näkökulmat samoihin aiheisiin auttavat tekemään perustellumpia tulkintoja vastausaineistosta."
+
+#: templates/survey/answer_form.html:55
+msgid "Tip:"
+msgstr "Vinkki:"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -796,3 +796,7 @@ msgstr "Återvänd till överhoppade frågor"
 #: templates/survey/answer_form.html:50
 msgid "If the question was poorly worded, you can <a href=\"%(question_add_url)s\">add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data."
 msgstr "Om frågan var dåligt formulerad kan du <a href=\"%(question_add_url)s\">lägga till</a> en ny fråga om samma ämne även om den bara skiljer sig lite. Olika perspektiv på samma ämnen hjälper till att göra mer välgrundade tolkningar av svarsmaterialet."
+
+#: templates/survey/answer_form.html:55
+msgid "Tip:"
+msgstr "Tips:"

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -50,7 +50,12 @@
   {% blocktrans trimmed with question_add_url=question_add_url asvar skip_help_message %}
   If the question was poorly worded, you can <a href="{{ question_add_url }}">add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data.
   {% endblocktrans %}
-  <div class="card-footer"><p class="fst-italic mb-0">{{ skip_help_message|safe }}</p></div>
+  <div class="card-footer">
+    <p class="fst-italic mb-0">
+      <span class="skip-help-label">{% translate 'Tip:' %}</span>
+      <span class="skip-help-text">{{ skip_help_message|safe }}</span>
+    </p>
+  </div>
 {% endif %}
 
 {% if question_stats %}


### PR DESCRIPTION
## Summary
- prefix skipped-question advice with a separate, stylable "Tip:" label
- localize the new label in Finnish and Swedish

## Testing
- `python manage.py compilemessages`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bc03afbf40832ebd3b47cbc883c7b5