### PR TITLE
Add dynamic citation info to completion page

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -741,9 +741,13 @@ msgstr "Kiitos vastaamisesta, olet nyt vastannut kysymyksiin, paitsi niihin jotk
 msgid "Thank you for answering, you have now answered all the questions!"
 msgstr "Kiitos vastaamisesta, olet nyt vastannut kaikkiin kysymyksiin!"
 
-#: templates/survey/completion.html:13
-msgid "Answers are knowledge that produces benefit only when used. Participate in Wikipedia and Wikimedia <a href=\"https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025\">discussions</a> and in Wikimedia Finland's decision-making and bring out your interpretation of the common good. Now you can base your opinion and refer to measured information about the community's opinions. You may cite as a source: Wikikysely 2025, question no. #1, date DD.MM.YYYY time HH.MM https://wikikysely.toolforge.org/fi/answers/"
-msgstr "Vastaukset ovat tietoa joka tuottaa hyötyä vasta käytettäessä. Osallistu Wikipedian ja Wikimedian <a href=\"https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025\">keskusteluihin</a> ja Wikimedia Suomen päätöksentekoon ja tuo esiin oma tulkintasi yhteisestä hyvästä. Nyt voit perustaa mielipiteesi ja viitata mitattuun tietoon yhteisön mielipiteistä. Lähteeksi voit ilmoittaa: Wikikysely 2025, kysymys nro #1,  päivämäärä DD.MM.YYYY kello HH.MM  https://wikikysely.toolforge.org/fi/answers/"
+#: templates/survey/completion.html:14
+msgid "Answers are knowledge that produces benefit only when used. Participate in discussions on Wikipedia and Wikimedia and in Wikimedia Finland's decision-making and bring out your interpretation of the common good. Now you can base your opinion and refer to measured information about the community's opinions."
+msgstr "Vastaukset ovat tietoa joka tuottaa hyötyä vasta käytettäessä. Osallistu Wikipedian ja Wikimedian keskusteluihin ja Wikimedia Suomen päätöksentekoon ja tuo esiin oma tulkintasi yhteisestä hyvästä. Nyt voit perustaa mielipiteesi ja viitata mitattuun tietoon yhteisön mielipiteistä."
+
+#: templates/survey/completion.html:17
+msgid "You may cite as a source: Wikikysely 2025, question number #1, %(date)s https://wikikysely.toolforge.org/%(language_code)s/answers/"
+msgstr "Lähteeksi voit ilmoittaa: Wikikysely 2025, kysymys numero #1, %(date)s https://wikikysely.toolforge.org/%(language_code)s/answers/"
 
 #: templates/survey/completion.html:16
 msgid "View all answers"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -738,9 +738,14 @@ msgstr "Tack för att du svarade, du har nu besvarat frågorna, förutom de du h
 msgid "Thank you for answering, you have now answered all the questions!"
 msgstr "Tack för att du svarade, du har nu besvarat alla frågor!"
 
-#: templates/survey/completion.html:13
-msgid "Answers are knowledge that produces benefit only when used. Participate in Wikipedia and Wikimedia <a href=\"https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025\">discussions</a> and in Wikimedia Finland's decision-making and bring out your interpretation of the common good. Now you can base your opinion and refer to measured information about the community's opinions. You may cite as a source: Wikikysely 2025, question no. #1, date DD.MM.YYYY time HH.MM https://wikikysely.toolforge.org/fi/answers/"
-msgstr "Svar är kunskap som ger nytta först när den används. Delta i Wikipedia och Wikimedias <a href=\"https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025\">diskussioner</a> och i Wikimedia Finlands beslutsfattande och lyft fram din tolkning av det gemensamma bästa. Nu kan du grunda din åsikt och hänvisa till uppmätt information om gemenskapens åsikter. Som källa kan du ange: Wikikysely 2025, fråga nr #1, datum DD.MM.YYYY klockan HH.MM https://wikikysely.toolforge.org/fi/answers/"
+#: templates/survey/completion.html:14
+#: templates/survey/completion.html:14
+msgid "Answers are knowledge that produces benefit only when used. Participate in discussions on Wikipedia and Wikimedia and in Wikimedia Finland's decision-making and bring out your interpretation of the common good. Now you can base your opinion and refer to measured information about the community's opinions."
+msgstr "Svar är kunskap som ger nytta först när den används. Delta i Wikipedia- och Wikimedia-diskussioner och i Wikimedia Finlands beslutsfattande och lyft fram din tolkning av det gemensamma bästa. Nu kan du grunda din åsikt och hänvisa till uppmätt information om gemenskapens åsikter."
+
+#: templates/survey/completion.html:17
+msgid "You may cite as a source: Wikikysely 2025, question number #1, %(date)s https://wikikysely.toolforge.org/%(language_code)s/answers/"
+msgstr "Som källa kan du ange: Wikikysely 2025, fråga nummer #1, %(date)s https://wikikysely.toolforge.org/%(language_code)s/answers/"
 
 #: templates/survey/completion.html:16
 msgid "View all answers"

--- a/templates/survey/completion.html
+++ b/templates/survey/completion.html
@@ -9,8 +9,12 @@
     {% translate 'Thank you for answering, you have now answered all the questions!' %}
   {% endif %}
 </div>
+{% now "d.m.Y" as today %}
 <p>
-{% blocktranslate trimmed %}Answers are knowledge that produces benefit only when used. Participate in Wikipedia and Wikimedia <a href="https://fi.wikipedia.org/wiki/Keskustelu_wikiprojektista:Wikikysely_2025">discussions</a> and in Wikimedia Finland's decision-making and bring out your interpretation of the common good. Now you can base your opinion and refer to measured information about the community's opinions. You may cite as a source: Wikikysely 2025, question no. #1, date DD.MM.YYYY time HH.MM https://wikikysely.toolforge.org/fi/answers/{% endblocktranslate %}
+  {% blocktranslate trimmed %}Answers are knowledge that produces benefit only when used. Participate in discussions on Wikipedia and Wikimedia and in Wikimedia Finland's decision-making and bring out your interpretation of the common good. Now you can base your opinion and refer to measured information about the community's opinions.{% endblocktranslate %}
+</p>
+<p>
+  {% blocktranslate trimmed with date=today language_code=LANGUAGE_CODE %}You may cite as a source: Wikikysely 2025, question number #1, {{ date }} https://wikikysely.toolforge.org/{{ language_code }}/answers/{% endblocktranslate %}
 </p>
 <div class="mt-3">
   <a href="{% url 'survey:survey_answers' %}" class="btn btn-info mb-2">{% translate 'View all answers' %}</a>


### PR DESCRIPTION
## Summary
- Split survey completion message into two translated paragraphs
- Include current date and language-aware answers link in citation instructions
- Update Finnish and Swedish translations

## Testing
- `python manage.py compilemessages`
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68bc0cd951d8832ea5950193185ddefa