### PR TITLE
feat: add pictogram icons to chart options

### DIFF
--- a/templates/survey/answers.html
+++ b/templates/survey/answers.html
@@ -22,15 +22,15 @@
 <div class="mb-3">
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="chartType" id="pieChartRadio" value="pie" checked>
-    <label class="form-check-label" for="pieChartRadio">{% translate 'Pie chart' %}</label>
+    <label class="form-check-label" for="pieChartRadio">◕ {% translate 'Pie chart' %}</label>
   </div>
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="chartType" id="barChartRadio" value="bar">
-    <label class="form-check-label" for="barChartRadio">{% translate 'Bar chart' %}</label>
+    <label class="form-check-label" for="barChartRadio">📊 {% translate 'Bar chart' %}</label>
   </div>
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="chartType" id="tableChartRadio" value="table">
-    <label class="form-check-label" for="tableChartRadio">{% translate 'Answer table' %}</label>
+    <label class="form-check-label" for="tableChartRadio">📋 {% translate 'Answer table' %}</label>
   </div>
 </div>
 {% translate 'Red' as red_label %}
@@ -75,7 +75,7 @@
 </div>
 <p class="mt-3">{% translate 'Total respondents' %}: {{ total_users }}</p>
 <div id="answerTableContainer" style="display:none">
-  <h2>{% translate 'Answer table' %}</h2>
+  <h2>📋 {% translate 'Answer table' %}</h2>
   <div class="table-responsive">
   <table id="answerTable" class="table stacked-table">
   <thead>


### PR DESCRIPTION
## Summary
- add Unicode icons for pie, bar and table chart options on the answers page
- display table icon in answer table heading
- use circle pictogram (U+25D5) to represent the pie chart option

## Testing
- `python manage.py test` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1b396764832e8347cc56b8b2a0c4