### PR TITLE
Ota käyttöön django-parler kyselyn monikielisille kentille

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django==4.2
 social-auth-app-django==5.4.0
 markdown==3.5.1
+django-parler==2.3

--- a/wikikysely_project/settings.py
+++ b/wikikysely_project/settings.py
@@ -26,6 +26,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'social_django',
+    'parler',
     'wikikysely_project.survey',
 ]
 
@@ -80,6 +81,18 @@ LANGUAGES = [
 ]
 
 LOCALE_PATHS = [BASE_DIR / 'locale']
+
+PARLER_LANGUAGES = {
+    None: (
+        {'code': 'fi'},
+        {'code': 'sv'},
+        {'code': 'en'},
+    ),
+    'default': {
+        'fallbacks': ['fi'],
+        'hide_untranslated': False,
+    }
+}
 
 TIME_ZONE = 'UTC'
 

--- a/wikikysely_project/survey/admin.py
+++ b/wikikysely_project/survey/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from parler.admin import TranslatableAdmin
 from .models import Survey, Question, Answer
 
 
@@ -7,7 +8,7 @@ class QuestionInline(admin.TabularInline):
     extra = 0
 
 
-class SurveyAdmin(admin.ModelAdmin):
+class SurveyAdmin(TranslatableAdmin):
     inlines = [QuestionInline]
     list_display = ('title', 'state', 'deleted')
     list_filter = ('state', 'deleted')

--- a/wikikysely_project/survey/forms.py
+++ b/wikikysely_project/survey/forms.py
@@ -1,6 +1,7 @@
 from django import forms
-from .models import Survey, Question, Answer
 from django.utils.translation import gettext_lazy as _
+from parler.forms import TranslatableModelForm
+from .models import Survey, Question, Answer
 
 
 class BootstrapMixin:
@@ -16,7 +17,7 @@ class BootstrapMixin:
                 field.widget.attrs["class"] = f"{classes} form-control".strip()
 
 
-class SurveyForm(BootstrapMixin, forms.ModelForm):
+class SurveyForm(BootstrapMixin, TranslatableModelForm):
     class Meta:
         model = Survey
         fields = ['title', 'description', 'state']

--- a/wikikysely_project/survey/management/commands/create_test_data.py
+++ b/wikikysely_project/survey/management/commands/create_test_data.py
@@ -29,6 +29,8 @@ class Command(BaseCommand):
                 survey = Survey.objects.create(
                     title=_('Main Survey'),
                     description='',
+                    title_old=_('Main Survey'),
+                    description_old='',
                     creator=users[0],
                     state='running',
                 )

--- a/wikikysely_project/survey/management/commands/migrate_survey_texts.py
+++ b/wikikysely_project/survey/management/commands/migrate_survey_texts.py
@@ -1,0 +1,23 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from wikikysely_project.survey.models import Survey
+
+
+class Command(BaseCommand):
+    help = "Copy Survey.title_old and description_old into translation fields"
+
+    def handle(self, *args, **options):
+        default_language = settings.LANGUAGE_CODE
+        count = 0
+        for survey in Survey.objects.all():
+            if survey.title_old or survey.description_old:
+                survey.set_current_language(default_language)
+                if survey.title_old:
+                    survey.title = survey.title_old
+                if survey.description_old:
+                    survey.description = survey.description_old
+                survey.save()
+                count += 1
+        self.stdout.write(self.style.SUCCESS(f"Updated {count} surveys."))
+

--- a/wikikysely_project/survey/models.py
+++ b/wikikysely_project/survey/models.py
@@ -1,16 +1,21 @@
 from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from parler.models import TranslatableModel, TranslatedFields
 
 
-class Survey(models.Model):
+class Survey(TranslatableModel):
     STATE_CHOICES = [
         ('running', _('Running')),
         ('paused', _('Paused')),
         ('closed', _('Closed')),
     ]
-    title = models.CharField(_('Title'), max_length=255)
-    description = models.TextField(_('Description'), blank=True)
+    title_old = models.CharField(_('Title'), max_length=255, blank=True)
+    description_old = models.TextField(_('Description'), blank=True)
+    translations = TranslatedFields(
+        title=models.CharField(_('Title'), max_length=255),
+        description=models.TextField(_('Description'), blank=True),
+    )
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.PROTECT, null=True, blank=True
     )
@@ -34,7 +39,7 @@ class Survey(models.Model):
         return self.state == 'running' and not self.deleted
 
     def __str__(self):
-        return self.title
+        return self.safe_translation_getter('title') or self.title_old
 
 
 class Question(models.Model):


### PR DESCRIPTION
## Summary
- Käytä django-parleria survey-mallin monikielisiin title ja description -kenttiin
- Säilytä vanha data title_old ja description_old -kentissä ja lisää migraatiokomento
- Päivitä admin ja lomakkeet tukemaan käännöskenttiä

## Testing
- `pip install django-parler==2.3` (fails: Could not find a version that satisfies the requirement django-parler==2.3)
- `python manage.py check` (fails: ModuleNotFoundError: No module named 'parler')
- `python manage.py makemigrations --dry-run` (fails: ModuleNotFoundError: No module named 'parler')

------
https://chatgpt.com/codex/tasks/task_e_68bc975efb54832e8e807d16dd231ac2