### PR TITLE
Improve mobile question view and document test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,13 @@ Unit tests use Django's built-in test runner. After installing the dependencies
 and setting up the virtual environment, run:
 
 ```bash
+python manage.py makemigrations
+python manage.py migrate
 DJANGO_DEV_SERVER=1 python manage.py test -v 2
 ```
 
-The command will create a temporary database and execute the test suite.
+The migration commands ensure the test database is up to date before executing
+the suite. The final command will create a temporary database and execute all tests.
 
 ## Resetting the local environment
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -121,6 +121,71 @@ body {
   }
 }
 
+/* Mobile card layout for question lists */
+.card-table td.question-cell .mobile-id {
+  display: none;
+}
+@media (max-width: 800px) {
+  .card-table thead {
+    display: none;
+  }
+  .card-table,
+  .card-table tbody,
+  .card-table tr,
+  .card-table td {
+    display: block;
+    width: 100%;
+  }
+  .card-table tr {
+    border: 1px solid var(--bs-table-border-color, #dee2e6);
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  .card-table td {
+    border: none;
+    padding: 0;
+    margin-bottom: 0.5rem;
+  }
+  .card-table td::before {
+    content: attr(data-label);
+    display: block;
+    font-weight: bold;
+    margin-bottom: 0.25rem;
+  }
+  .card-table td.id-cell {
+    display: none;
+  }
+  .card-table td.question-cell {
+    font-weight: bold;
+  }
+  .card-table td.question-cell::before {
+    content: '';
+  }
+  .card-table td.question-cell .mobile-id {
+    display: inline;
+    margin-right: 0.5rem;
+  }
+  .card-table td.actions {
+    text-align: left;
+  }
+  .card-table td.actions::before {
+    content: '';
+  }
+  .card-table td.actions .btn {
+    display: block;
+    width: 100%;
+    margin-top: 0.25rem;
+  }
+  .card-table td.actions .btn-group.yes-no-group {
+    width: 100%;
+  }
+  .card-table td.actions .btn-group.yes-no-group .btn {
+    width: 50%;
+    margin-right: 0;
+  }
+}
+
 .mobile-sort {
   display: none;
 }

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -34,7 +34,7 @@
 {% endif %}
         <h2 id="unanswered-header" class="mt-3"{% if not unanswered_questions %} style="display:none"{% endif %}>{% translate 'Unanswered questions' %}</h2>
       <div class="table-responsive">
-      <table id="unanswered-table" class="table mb-3 survey-detail-table stacked-table"{% if not unanswered_questions %} style="display:none"{% endif %}>
+      <table id="unanswered-table" class="table mb-3 survey-detail-table card-table"{% if not unanswered_questions %} style="display:none"{% endif %}>
         <thead>
       <tr>
         <th>{% translate 'ID' %}</th>
@@ -47,11 +47,11 @@
       <tbody>
       {% for q in unanswered_questions %}
         <tr>
-        <td data-label="{% translate 'ID' %}">{{ q.pk }}</td>
-        <td data-label="{% translate 'Title' %}"><a href="{% url 'survey:answer_question' q.pk %}?next={{ request.get_full_path|urlencode }}">{{ q.text }}</a></td>
+        <td data-label="{% translate 'ID' %}" class="id-cell">{{ q.pk }}</td>
+        <td data-label="{% translate 'Title' %}" class="question-cell"><span class="mobile-id">{{ q.pk }}</span><a href="{% url 'survey:answer_question' q.pk %}?next={{ request.get_full_path|urlencode }}">{{ q.text }}</a></td>
         <td class="total-answers" data-label="{% translate 'Answers' %}">{{ q.total_answers }}</td>
         <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ q.agree_ratio|floatformat:1 }}%</td>
-        <td class="text-end" data-label="">
+        <td class="text-end actions" data-label="">
           {% if request.user.is_authenticated and request.user == q.creator and q.total_answers == 0 and survey.state != 'closed' %}
           <a href="{% url 'survey:question_edit' q.pk %}" class="btn btn-sm btn-warning me-2">{% translate 'Edit' %}</a>
           <a href="{% url 'survey:question_delete' q.pk %}" class="btn btn-sm btn-danger ajax-delete-question">{% translate 'Remove question' %}</a>
@@ -66,7 +66,7 @@
 {% if user_answers %}
 <h2 class="mt-4">{% translate 'My answers' %}</h2>
 <div class="table-responsive">
-<table class="table mb-3 survey-detail-table stacked-table">
+<table class="table mb-3 survey-detail-table card-table">
   <thead>
   <tr>
     <th>{% translate 'ID' %}</th>
@@ -79,13 +79,13 @@
   <tbody>
   {% for a in user_answers %}
     <tr>
-      <td data-label="{% translate 'ID' %}">{{ a.question.pk }}</td>
-      <td data-label="{% translate 'Title' %}">
-        <a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a>
+      <td data-label="{% translate 'ID' %}" class="id-cell">{{ a.question.pk }}</td>
+      <td data-label="{% translate 'Title' %}" class="question-cell">
+        <span class="mobile-id">{{ a.question.pk }}</span><a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a>
       </td>
       <td class="total-answers" data-label="{% translate 'Answers' %}">{{ a.total_answers }}</td>
       <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ a.agree_ratio|floatformat:1 }}%</td>
-      <td class="text-end" data-label="">
+      <td class="text-end actions" data-label="">
         {% if a.question.survey.state == 'running' %}
         <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline ajax-answer-form">
           {% csrf_token %}


### PR DESCRIPTION
## Summary
- Display survey questions in a card-style layout on small screens
- Add responsive CSS for the new card view
- Document running migrations before executing tests

## Testing
- `python manage.py makemigrations`
- `python manage.py migrate`
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68be32d8051c832ea100f0c821332605