### PR TITLE
Adjust mobile layout for survey question lists

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -122,9 +122,6 @@ body {
 }
 
 /* Mobile card layout for question lists */
-.card-table td.question-cell .mobile-id {
-  display: none;
-}
 @media (max-width: 800px) {
   .card-table thead {
     display: none;
@@ -153,18 +150,11 @@ body {
     font-weight: bold;
     margin-bottom: 0.25rem;
   }
-  .card-table td.id-cell {
-    display: none;
-  }
   .card-table td.question-cell {
     font-weight: bold;
   }
   .card-table td.question-cell::before {
     content: '';
-  }
-  .card-table td.question-cell .mobile-id {
-    display: inline;
-    margin-right: 0.5rem;
   }
   .card-table td.actions {
     text-align: left;
@@ -177,10 +167,10 @@ body {
     width: 100%;
     margin-top: 0.25rem;
   }
-  .card-table td.actions .btn-group.yes-no-group {
+  .card-table td.answer-cell .btn-group.yes-no-group {
     width: 100%;
   }
-  .card-table td.actions .btn-group.yes-no-group .btn {
+  .card-table td.answer-cell .btn-group.yes-no-group .btn {
     width: 50%;
     margin-right: 0;
   }

--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -136,16 +136,6 @@ document.addEventListener('DOMContentLoaded', () => {
             const tr = document.createElement('tr');
             tr.dataset.questionId = data.question_id;
 
-            const tdId = document.createElement('td');
-            tdId.dataset.label = data.id_label;
-            tdId.textContent = data.question_id;
-            tr.appendChild(tdId);
-
-            const tdPublished = document.createElement('td');
-            tdPublished.dataset.label = data.published_label;
-            tdPublished.textContent = data.question_published;
-            tr.appendChild(tdPublished);
-
             const tdTitle = document.createElement('td');
             tdTitle.dataset.label = data.title_label;
             const titleLink = document.createElement('a');
@@ -154,6 +144,11 @@ document.addEventListener('DOMContentLoaded', () => {
             titleLink.textContent = data.question_text;
             tdTitle.appendChild(titleLink);
             tr.appendChild(tdTitle);
+
+            const tdId = document.createElement('td');
+            tdId.dataset.label = data.id_label;
+            tdId.textContent = data.question_id;
+            tr.appendChild(tdId);
 
             const tdTotal = document.createElement('td');
             tdTotal.className = 'total-answers';

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -37,8 +37,8 @@
       <table id="unanswered-table" class="table mb-3 survey-detail-table card-table"{% if not unanswered_questions %} style="display:none"{% endif %}>
         <thead>
       <tr>
-        <th>{% translate 'ID' %}</th>
         <th>{% translate 'Title' %}</th>
+        <th>{% translate 'ID' %}</th>
         <th>{% translate 'Answers' %}</th>
         <th>{% translate 'Agree' %}</th>
         <th></th>
@@ -47,8 +47,8 @@
       <tbody>
       {% for q in unanswered_questions %}
         <tr>
+        <td data-label="{% translate 'Title' %}" class="question-cell"><a href="{% url 'survey:answer_question' q.pk %}?next={{ request.get_full_path|urlencode }}">{{ q.text }}</a></td>
         <td data-label="{% translate 'ID' %}" class="id-cell">{{ q.pk }}</td>
-        <td data-label="{% translate 'Title' %}" class="question-cell"><span class="mobile-id">{{ q.pk }}</span><a href="{% url 'survey:answer_question' q.pk %}?next={{ request.get_full_path|urlencode }}">{{ q.text }}</a></td>
         <td class="total-answers" data-label="{% translate 'Answers' %}">{{ q.total_answers }}</td>
         <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ q.agree_ratio|floatformat:1 }}%</td>
         <td class="text-end actions" data-label="">
@@ -69,8 +69,9 @@
 <table class="table mb-3 survey-detail-table card-table">
   <thead>
   <tr>
-    <th>{% translate 'ID' %}</th>
     <th>{% translate 'Title' %}</th>
+    <th>{% translate 'Answer' %}</th>
+    <th>{% translate 'ID' %}</th>
     <th>{% translate 'Answers' %}</th>
     <th>{% translate 'Agree' %}</th>
     <th></th>
@@ -79,15 +80,12 @@
   <tbody>
   {% for a in user_answers %}
     <tr>
-      <td data-label="{% translate 'ID' %}" class="id-cell">{{ a.question.pk }}</td>
       <td data-label="{% translate 'Title' %}" class="question-cell">
-        <span class="mobile-id">{{ a.question.pk }}</span><a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a>
+        <a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a>
       </td>
-      <td class="total-answers" data-label="{% translate 'Answers' %}">{{ a.total_answers }}</td>
-      <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ a.agree_ratio|floatformat:1 }}%</td>
-      <td class="text-end actions" data-label="">
+      <td data-label="{% translate 'Answer' %}" class="answer-cell">
         {% if a.question.survey.state == 'running' %}
-        <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="d-inline ajax-answer-form">
+        <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="ajax-answer-form">
           {% csrf_token %}
           <input type="hidden" name="question_id" value="{{ a.question.pk }}">
           <div class="btn-group yes-no-group" role="group" aria-label="{% translate 'Answer' %}">
@@ -97,7 +95,14 @@
             <label class="btn btn-sm btn-outline-danger" for="answer-{{ a.pk }}-no">{% translate 'No' %}</label>
           </div>
         </form>
-        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ms-2 ajax-delete-answer">{% translate 'Remove answer' %}</a>
+        {% endif %}
+      </td>
+      <td data-label="{% translate 'ID' %}" class="id-cell">{{ a.question.pk }}</td>
+      <td class="total-answers" data-label="{% translate 'Answers' %}">{{ a.total_answers }}</td>
+      <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ a.agree_ratio|floatformat:1 }}%</td>
+      <td class="text-end actions" data-label="">
+        {% if a.question.survey.state == 'running' %}
+        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ajax-delete-answer">{% translate 'Remove answer' %}</a>
         {% endif %}
       </td>
     </tr>


### PR DESCRIPTION
## Summary
- show questions first and yes/no answer controls on their own row in mobile views
- expose ID, answer count and agreement in stacked layout
- update AJAX helper for new column order

## Testing
- `python manage.py test` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68be3637be34832e9ea78d29575a9e75