### PR TITLE
Show question IDs before titles and on mobile cards

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -136,19 +136,25 @@ document.addEventListener('DOMContentLoaded', () => {
             const tr = document.createElement('tr');
             tr.dataset.questionId = data.question_id;
 
-            const tdTitle = document.createElement('td');
-            tdTitle.dataset.label = data.title_label;
-            const titleLink = document.createElement('a');
-            const nextParam = encodeURIComponent(window.location.pathname + window.location.search);
-            titleLink.href = `${data.question_url}?next=${nextParam}`;
-            titleLink.textContent = data.question_text;
-            tdTitle.appendChild(titleLink);
-            tr.appendChild(tdTitle);
+              const tdIdDesktop = document.createElement('td');
+              tdIdDesktop.className = 'id-cell d-none d-md-table-cell';
+              tdIdDesktop.textContent = data.question_id;
+              tr.appendChild(tdIdDesktop);
 
-            const tdId = document.createElement('td');
-            tdId.dataset.label = data.id_label;
-            tdId.textContent = data.question_id;
-            tr.appendChild(tdId);
+              const tdTitle = document.createElement('td');
+              tdTitle.dataset.label = data.title_label;
+              const titleLink = document.createElement('a');
+              const nextParam = encodeURIComponent(window.location.pathname + window.location.search);
+              titleLink.href = `${data.question_url}?next=${nextParam}`;
+              titleLink.textContent = data.question_text;
+              tdTitle.appendChild(titleLink);
+              tr.appendChild(tdTitle);
+
+              const tdIdMobile = document.createElement('td');
+              tdIdMobile.className = 'id-cell d-md-none';
+              tdIdMobile.dataset.label = data.id_label;
+              tdIdMobile.textContent = data.question_id;
+              tr.appendChild(tdIdMobile);
 
             const tdTotal = document.createElement('td');
             tdTotal.className = 'total-answers';

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -37,8 +37,8 @@
       <table id="unanswered-table" class="table mb-3 survey-detail-table card-table"{% if not unanswered_questions %} style="display:none"{% endif %}>
         <thead>
       <tr>
-        <th>{% translate 'Title' %}</th>
         <th>{% translate 'ID' %}</th>
+        <th>{% translate 'Title' %}</th>
         <th>{% translate 'Answers' %}</th>
         <th>{% translate 'Agree' %}</th>
         <th></th>
@@ -47,8 +47,9 @@
       <tbody>
       {% for q in unanswered_questions %}
         <tr>
+        <td class="id-cell d-none d-md-table-cell">{{ q.pk }}</td>
         <td data-label="{% translate 'Title' %}" class="question-cell"><a href="{% url 'survey:answer_question' q.pk %}?next={{ request.get_full_path|urlencode }}">{{ q.text }}</a></td>
-        <td data-label="{% translate 'ID' %}" class="id-cell">{{ q.pk }}</td>
+        <td data-label="{% translate 'ID' %}" class="id-cell d-md-none">{{ q.pk }}</td>
         <td class="total-answers" data-label="{% translate 'Answers' %}">{{ q.total_answers }}</td>
         <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ q.agree_ratio|floatformat:1 }}%</td>
         <td class="text-end actions" data-label="">
@@ -69,9 +70,9 @@
 <table class="table mb-3 survey-detail-table card-table">
   <thead>
   <tr>
+    <th>{% translate 'ID' %}</th>
     <th>{% translate 'Title' %}</th>
     <th>{% translate 'Answer' %}</th>
-    <th>{% translate 'ID' %}</th>
     <th>{% translate 'Answers' %}</th>
     <th>{% translate 'Agree' %}</th>
     <th></th>
@@ -80,6 +81,7 @@
   <tbody>
   {% for a in user_answers %}
     <tr>
+      <td class="id-cell d-none d-md-table-cell">{{ a.question.pk }}</td>
       <td data-label="{% translate 'Title' %}" class="question-cell">
         <a href="{% url 'survey:answer_question' a.question.pk %}?next={{ request.get_full_path|urlencode }}">{{ a.question.text }}</a>
       </td>
@@ -97,7 +99,7 @@
         </form>
         {% endif %}
       </td>
-      <td data-label="{% translate 'ID' %}" class="id-cell">{{ a.question.pk }}</td>
+      <td data-label="{% translate 'ID' %}" class="id-cell d-md-none">{{ a.question.pk }}</td>
       <td class="total-answers" data-label="{% translate 'Answers' %}">{{ a.total_answers }}</td>
       <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ a.agree_ratio|floatformat:1 }}%</td>
       <td class="text-end actions" data-label="">
@@ -116,7 +118,7 @@
 <script src="{% static 'js/sort_tables.js' %}"></script>
 <script>
 document.addEventListener("DOMContentLoaded", () => {
-    initSortableTables(".survey-detail-table", 0);
+    initSortableTables(".survey-detail-table", 1);
 });
 </script>
 <script src="{% static 'js/survey_detail_ajax.js' %}"></script>


### PR DESCRIPTION
## Summary
- Reorder question tables so ID column appears before the title on desktop
- Add mobile-only ID field beneath each question card
- Update dynamic question row creation and default sorting

## Testing
- `python manage.py makemigrations`
- `python manage.py migrate`
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68be64436b08832e9909507c84cf3182