### PR TITLE
Style remove answer button on mobile

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -86,6 +86,15 @@ body {
   justify-content: center;
 }
 
+@media (max-width: 800px) {
+  .answer-buttons .remove-answer-btn {
+    display: block;
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 /* Allow tables to shrink on small screens */
 @media (max-width: 800px) {
   .survey-detail-table th,

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -30,7 +30,7 @@
     </div>
     {% if is_edit %}
       {% if survey.state == 'running' %}
-      <a href="{% url 'survey:answer_delete' form.instance.pk %}?next={{ next|urlencode }}" class="btn btn-danger me-2" data-question-id="{{ question.pk }}">{% translate 'Remove answer' %}</a>
+      <a href="{% url 'survey:answer_delete' form.instance.pk %}?next={{ next|urlencode }}" class="btn btn-outline-secondary btn-sm ajax-delete-answer remove-answer-btn me-md-2" data-question-id="{{ question.pk }}">{% translate 'Remove answer' %}</a>
       {% endif %}
       {% if can_delete_question %}
       <a href="{% url 'survey:question_delete' question.pk %}?next={{ next|urlencode }}" class="btn btn-danger">{% translate 'Remove question' %}</a>


### PR DESCRIPTION
## Summary
- Render "Remove answer" button as secondary small button
- Expand delete button to full width and center on narrow screens

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68be773bfa8c832eb4a4bc2f0c2994f9