### PR TITLE
style: improve mobile delete answer button

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -31,7 +31,9 @@
     {% if is_edit %}
       {% if survey.state == 'running' %}
       <a href="{% url 'survey:answer_delete' form.instance.pk %}?next={{ next|urlencode }}" class="btn btn-danger me-2 d-none d-md-inline-block" data-question-id="{{ question.pk }}">{% translate 'Remove answer' %}</a>
-      <a href="{% url 'survey:answer_delete' form.instance.pk %}?next={{ next|urlencode }}" class="link-danger d-md-none me-2" data-question-id="{{ question.pk }}">{% translate 'Remove answer' %}</a>
+      <a href="{% url 'survey:answer_delete' form.instance.pk %}?next={{ next|urlencode }}"
+         class="btn btn-sm btn-secondary d-block w-100 mx-auto mb-2 d-md-none"
+         data-question-id="{{ question.pk }}">{% translate 'Remove answer' %}</a>
       {% endif %}
       {% if can_delete_question %}
       <a href="{% url 'survey:question_delete' question.pk %}?next={{ next|urlencode }}" class="btn btn-danger">{% translate 'Remove question' %}</a>


### PR DESCRIPTION
## Summary
- render mobile-only "Remove answer" as a full-width small secondary button centered on the page

## Testing
- `python manage.py test` *(fails: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68be79fccff8832ea26ccb9ee3e5d7f3