### PR TITLE
Align remove answer button with yes/no options

### DIFF
--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -96,8 +96,8 @@
             <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-no" value="no"{% if a.answer == 'no' %} checked{% endif %}>
             <label class="btn btn-sm btn-outline-danger" for="answer-{{ a.pk }}-no">{% translate 'No' %}</label>
           </div>
+          <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ms-2 ajax-delete-answer">{% translate 'Remove answer' %}</a>
         </form>
-        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ms-2 ajax-delete-answer">{% translate 'Remove answer' %}</a>
         {% endif %}
       </td>
     </tr>


### PR DESCRIPTION
## Summary
- Show the “Remove answer” control to the right of the yes/no choices in survey details

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68bebe36e31c832e95dcd23741b21da0