### PR TITLE
Use dropdown to edit survey answers

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -39,6 +39,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function updateSelectColor(select) {
+    select.classList.remove('bg-success', 'bg-danger', 'text-white');
+    if (select.value === 'yes') {
+      select.classList.add('bg-success', 'text-white');
+    } else if (select.value === 'no') {
+      select.classList.add('bg-danger', 'text-white');
+    }
+  }
+
   const initialNavCount = document.getElementById('unanswered-count');
   if (initialNavCount) {
     const initialCount = parseInt(initialNavCount.textContent, 10) || 0;
@@ -66,6 +75,11 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('form.ajax-answer-form').forEach(form => {
     form.addEventListener('change', event => {
       if (event.target.name !== 'answer') return;
+      if (event.target.value === 'remove') {
+        const delLink = form.querySelector('a.ajax-delete-answer');
+        if (delLink) delLink.click();
+        return;
+      }
       const formData = new FormData(form);
       fetch(form.action, {
         method: 'POST',
@@ -89,9 +103,12 @@ document.addEventListener('DOMContentLoaded', () => {
           if (totalCell) totalCell.textContent = data.total;
           if (ratioCell) ratioCell.textContent = `${formatPercentage(data.agree_ratio)}%`;
         }
+        updateSelectColor(event.target);
       }).catch(() => window.location.reload());
     });
   });
+
+  document.querySelectorAll('select.answer-select').forEach(updateSelectColor);
 
   function attachDeleteAnswer(link) {
     link.addEventListener('click', ev => {

--- a/templates/survey/survey_detail.html
+++ b/templates/survey/survey_detail.html
@@ -75,7 +75,6 @@
     <th>{% translate 'Answer' %}</th>
     <th>{% translate 'Answers' %}</th>
     <th>{% translate 'Agree' %}</th>
-    <th></th>
   </tr>
   </thead>
   <tbody>
@@ -90,24 +89,18 @@
         <form method="post" action="{% url 'survey:answer_edit' a.pk %}" class="ajax-answer-form">
           {% csrf_token %}
           <input type="hidden" name="question_id" value="{{ a.question.pk }}">
-          <div class="btn-group yes-no-group" role="group" aria-label="{% translate 'Answer' %}">
-            <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-yes" value="yes"{% if a.answer == 'yes' %} checked{% endif %}>
-            <label class="btn btn-sm btn-outline-success" for="answer-{{ a.pk }}-yes">{% translate 'Yes' %}</label>
-            <input type="radio" class="btn-check" name="answer" id="answer-{{ a.pk }}-no" value="no"{% if a.answer == 'no' %} checked{% endif %}>
-            <label class="btn btn-sm btn-outline-danger" for="answer-{{ a.pk }}-no">{% translate 'No' %}</label>
-          </div>
+          <select name="answer" class="form-select form-select-sm answer-select">
+            <option value="yes"{% if a.answer == 'yes' %} selected{% endif %}>{% translate 'Yes' %}</option>
+            <option value="no"{% if a.answer == 'no' %} selected{% endif %}>{% translate 'No' %}</option>
+            <option value="remove">{% translate 'Remove answer' %}</option>
+          </select>
+          <a href="{% url 'survey:answer_delete' a.pk %}" class="ajax-delete-answer d-none">{% translate 'Remove answer' %}</a>
         </form>
         {% endif %}
       </td>
       <td data-label="{% translate 'ID' %}" class="id-cell d-md-none">{{ a.question.pk }}</td>
       <td class="total-answers" data-label="{% translate 'Answers' %}">{{ a.total_answers }}</td>
       <td class="agree-ratio" data-label="{% translate 'Agree' %}">{{ a.agree_ratio|floatformat:1 }}%</td>
-      <td class="text-center text-md-end actions" data-label="">
-        {% if a.question.survey.state == 'running' %}
-        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-danger ajax-delete-answer d-none d-md-inline-block">{% translate 'Remove answer' %}</a>
-        <a href="{% url 'survey:answer_delete' a.pk %}" class="btn btn-sm btn-outline-secondary ajax-delete-answer d-md-none w-100 mx-auto">{% translate 'Remove answer' %}</a>
-        {% endif %}
-      </td>
     </tr>
   {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- Replace Yes/No answer buttons with a dropdown that also offers Remove answer
- Color the dropdown to reflect the current answer and handle selection changes via AJAX

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68bee004b2d8832e87dff98a77a393c5