### PR TITLE
Show thank-you message after answering

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -801,3 +801,7 @@ msgstr "Jos kysymys oli huonosti muotoiltu, niin voit <a href=\"%(question_add_u
 #: templates/survey/answer_form.html:55
 msgid "Tip:"
 msgstr "Vinkki:"
+
+#: templates/survey/answer_form.html:62
+msgid "Thank you in advance for each of your answers. You can stop whenever you like, as questions are shown in random order."
+msgstr "Kiitos jo etukäteen jokaisesta vastauksestasi. Voit lopettaa kun siltä tuntuu, sillä kysymyksiä näytetään satunnaisessa järjestyksessä."

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -56,6 +56,12 @@
       <span class="skip-help-text">{{ skip_help_message|safe }}</span>
     </p>
   </div>
+{% elif show_thanks_message %}
+  <div class="card-footer skip-help-container">
+    <p class="fst-italic mb-0">
+      <span class="skip-help-text">{% translate "Thank you in advance for each of your answers. You can stop whenever you like, as questions are shown in random order." %}</span>
+    </p>
+  </div>
 {% endif %}
 
 {% if question_stats %}

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -867,6 +867,7 @@ def answer_question(request, pk):
     can_delete_question = False
     next_url = request.GET.get("next") or request.POST.get("next")
     show_skip_help = False
+    show_thanks_message = False
 
     if not request.user.is_authenticated:
         login_url = f"{reverse('social:begin', args=['mediawiki'])}?next={request.path}"
@@ -898,6 +899,7 @@ def answer_question(request, pk):
                     SkippedQuestion.objects.filter(
                         user=request.user, question=question
                     ).delete()
+                    show_thanks_message = True
                 else:
                     SkippedQuestion.objects.get_or_create(
                         user=request.user, question=question
@@ -1046,6 +1048,7 @@ def answer_question(request, pk):
             "no_answers_label": no_answers_label,
             "next": next_url,
             "show_skip_help": show_skip_help,
+            "show_thanks_message": show_thanks_message,
         },
     )
 


### PR DESCRIPTION
## Summary
- Display a thank-you note after answering, using the same footer area that shows skip hints.
- Pass a `show_thanks_message` flag from the view and translate the note to Finnish.
- Restore compiled translation binaries so `.mo` files are unchanged.

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f7b376f8832ea8442650334361e0