### PR TITLE
Enable AJAX question answering with dynamic updates

### DIFF
--- a/static/js/answer_form_ajax.js
+++ b/static/js/answer_form_ajax.js
@@ -1,0 +1,84 @@
+document.addEventListener('DOMContentLoaded', () => {
+  function getCookie(name) {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) return parts.pop().split(';').shift();
+  }
+
+  function formatPercentage(value) {
+    const num = typeof value === 'number' ? value : parseFloat(value);
+    if (Number.isNaN(num)) return value;
+    return num.toFixed(1).replace('.', ',');
+  }
+
+  function updateAnswerNavLink(count) {
+    const navCount = document.getElementById('unanswered-count');
+    if (navCount) {
+      navCount.textContent = count;
+    }
+
+    const navLink = document.getElementById('answer-nav-link');
+    if (!navLink) return;
+
+    if (count > 0 && navLink.tagName === 'SPAN') {
+      const url = navLink.dataset.answerUrl;
+      const newLink = document.createElement('a');
+      newLink.id = 'answer-nav-link';
+      newLink.className = 'nav-link';
+      newLink.href = url;
+      newLink.innerHTML = navLink.innerHTML;
+      navLink.replaceWith(newLink);
+    } else if (count === 0 && navLink.tagName === 'A') {
+      const url = navLink.href;
+      const newSpan = document.createElement('span');
+      newSpan.id = 'answer-nav-link';
+      newSpan.className = 'nav-link text-secondary';
+      newSpan.dataset.answerUrl = url;
+      newSpan.innerHTML = navLink.innerHTML;
+      navLink.replaceWith(newSpan);
+    }
+  }
+
+  const form = document.getElementById('answer-question-form');
+  if (!form) return;
+
+  form.addEventListener('submit', ev => {
+    ev.preventDefault();
+    const formData = new FormData(form);
+    if (ev.submitter && ev.submitter.name) {
+      formData.append(ev.submitter.name, ev.submitter.value);
+    }
+
+    fetch(form.action, {
+      method: 'POST',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRFToken': getCookie('csrftoken') || ''
+      },
+      body: formData
+    }).then(resp => resp.ok ? resp.json() : Promise.reject()).then(data => {
+      if (!data || !data.success) { window.location.reload(); return; }
+
+      const yesCell = document.getElementById('yes-count');
+      const noCell = document.getElementById('no-count');
+      const totalCell = document.getElementById('total-count');
+      const agreeCell = document.getElementById('agree-ratio');
+      const noCount = data.total - data.yes_count;
+      if (yesCell) yesCell.textContent = data.yes_count;
+      if (noCell) noCell.textContent = noCount;
+      if (totalCell) totalCell.textContent = data.total;
+      if (agreeCell) agreeCell.textContent = `${formatPercentage(data.agree_ratio)}%`;
+
+      if (typeof data.unanswered_count !== 'undefined') {
+        updateAnswerNavLink(data.unanswered_count);
+      }
+
+      const msgBox = document.getElementById('ajax-message');
+      if (msgBox) {
+        msgBox.className = 'alert alert-success mt-2';
+        msgBox.textContent = data.message || '';
+      }
+    }).catch(() => window.location.reload());
+  });
+});
+

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -6,8 +6,9 @@
 <div class="card mx-auto mb-4" style="max-width: 40rem;">
   <div id="answerbox" class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ question.text }}</h2>
+    <div id="ajax-message"></div>
 {% if request.user.is_authenticated %}
-<form method="post" action="{% url 'survey:answer_question' question.pk %}" class="text-center">
+<form id="answer-question-form" method="post" action="{% url 'survey:answer_question' question.pk %}" class="text-center">
   {% csrf_token %}
   {% if next %}
   <input type="hidden" name="next" value="{{ next }}">
@@ -95,10 +96,10 @@
       <tr>
         <td data-label="{% translate 'ID' %}">{{ question.pk }}</td>
         <td data-label="{% translate 'Published' %}">{{ question_stats.published|date:"Y-m-d" }}</td>
-        <td data-label="{% translate 'Yes' %}">{{ question_stats.yes }}</td>
-        <td data-label="{% translate 'No' %}">{{ question_stats.no }}</td>
-        <td data-label="{% translate 'Total' %}">{{ question_stats.total }}</td>
-        <td data-label="{% translate 'Agree' %}">{{ question_stats.agree_ratio|floatformat:1 }}%</td>
+        <td id="yes-count" data-label="{% translate 'Yes' %}">{{ question_stats.yes }}</td>
+        <td id="no-count" data-label="{% translate 'No' %}">{{ question_stats.no }}</td>
+        <td id="total-count" data-label="{% translate 'Total' %}">{{ question_stats.total }}</td>
+        <td id="agree-ratio" data-label="{% translate 'Agree' %}">{{ question_stats.agree_ratio|floatformat:1 }}%</td>
       </tr>
     </tbody>
   </table>
@@ -248,4 +249,5 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 </script>
 <script src="{% static 'js/survey_detail_ajax.js' %}"></script>
+<script src="{% static 'js/answer_form_ajax.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Load question stats and form elements with IDs to allow dynamic DOM updates
- Implement frontend script to submit answers via AJAX and refresh counts
- Extend view to return JSON with updated counts and messages

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68c3141f6b50832eb793d708a5627fed