### PR TITLE
Show message for answered or skipped questions

### DIFF
--- a/static/js/answer_form_ajax.js
+++ b/static/js/answer_form_ajax.js
@@ -75,7 +75,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const msgBox = document.getElementById('ajax-message');
       if (msgBox) {
-        msgBox.className = 'alert alert-success mt-2';
+        const alertType = data.skipped ? 'alert-info' : 'alert-success';
+        msgBox.className = `alert ${alertType} mt-2`;
         msgBox.textContent = data.message || '';
       }
     }).catch(() => window.location.reload());

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -997,6 +997,7 @@ def answer_question(request, pk):
                             "question_id": question.pk,
                             "unanswered_count": unanswered_count,
                             "message": message,
+                            "skipped": not bool(answer_value),
                         }
                     )
 


### PR DESCRIPTION
## Summary
- Display dedicated alert after answering or skipping a question
- Include skipped flag in AJAX response to style message box

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c32eb51c50832eac85b42f7d0695a8