### PR TITLE
Return status message from AJAX answers

### DIFF
--- a/static/js/answer_survey_ajax.js
+++ b/static/js/answer_survey_ajax.js
@@ -69,7 +69,15 @@ document.addEventListener('DOMContentLoaded', () => {
         'X-CSRFToken': getCookie('csrftoken') || ''
       },
       body: data
-    }).then(() => {
+    }).then(resp => resp.ok ? resp.json() : {}).then(data => {
+      const msgEl = document.getElementById('ajax-message');
+      if (msgEl && data.message) {
+        msgEl.textContent = data.message;
+        msgEl.className = `alert ${data.skipped ? 'alert-info' : 'alert-success'}`;
+      }
+      if (typeof data.unanswered_count === 'number') {
+        updateAnswerNavLink(data.unanswered_count);
+      }
       showNext();
     });
   }


### PR DESCRIPTION
## Summary
- Add message, skipped flag, and unanswered count to `answer_ajax`
- Show server message in survey AJAX UI
- Test `answer_ajax` messaging

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c3381c8c74832e9cdff4ede7bf0aa2