### PR TITLE
Use AJAX to answer questions and update answer list

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -3,11 +3,11 @@
 {% load i18n %}
 {% block title %}{% translate 'Answer question' %}{% endblock %}
 {% block content %}
-<div class="card mx-auto mb-4" style="max-width: 40rem;">
+<div class="card mx-auto mb-4" style="max-width: 40rem;" data-question-id="{{ question.pk }}">
   <div id="answerbox" class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ question.text }}</h2>
 {% if request.user.is_authenticated %}
-<form method="post" action="{% url 'survey:answer_question' question.pk %}" class="text-center">
+<form method="post" action="{% url 'survey:answer_question' question.pk %}" class="text-center ajax-answer-question" id="answer-form">
   {% csrf_token %}
   {% if next %}
   <input type="hidden" name="next" value="{{ next }}">
@@ -46,11 +46,11 @@
   </div>
 </div>
 {% for q in unanswered_questions %}
-<div class="card mx-auto mb-4" style="max-width: 40rem;">
+<div class="card mx-auto mb-4 unanswered-card" style="max-width: 40rem;" data-question-id="{{ q.pk }}">
   <div class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ q.text }}</h2>
     {% if request.user.is_authenticated %}
-    <form method="post" action="{% url 'survey:answer_question' q.pk %}" class="text-center">
+    <form method="post" action="{% url 'survey:answer_question' q.pk %}" class="text-center ajax-answer-question">
       {% csrf_token %}
       <input type="hidden" name="question_id" value="{{ q.pk }}">
       {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
@@ -145,7 +145,7 @@
         <th></th>
       </tr>
     </thead>
-    <tbody>
+    <tbody id="my-answers-body">
       {% for a in user_answers %}
       <tr data-question-id="{{ a.question.pk }}">
         <td data-label="{% translate 'Answer date' %}">{{ a.created_at|date:"Y-m-d" }}</td>
@@ -189,6 +189,10 @@ document.addEventListener("DOMContentLoaded", () => {
 const yesLabel = '{{ yes_label|escapejs }}';
 const noLabel = '{{ no_label|escapejs }}';
 const noAnswersLabel = '{{ no_answers_label|escapejs }}';
+const answerDateLabel = '{{ _("Answer date")|escapejs }}';
+const titleLabel = '{{ _("Title")|escapejs }}';
+const answersLabel = '{{ _("Answers")|escapejs }}';
+const agreeLabel = '{{ _("Agree")|escapejs }}';
 const successColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-success').trim() || 'green';
 const dangerColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-danger').trim() || 'red';
 const placeholderColor = getComputedStyle(document.documentElement).getPropertyValue('--bs-secondary-bg').trim() ||


### PR DESCRIPTION
## Summary
- Submit survey answers via AJAX to avoid page reloads
- Remove answered question cards and add them to the "My answers" table dynamically

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c392d18578832e90164a8f4b055fb7