### PR TITLE
Show my answers section without reload

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -259,6 +259,38 @@ document.addEventListener('DOMContentLoaded', () => {
           tr.appendChild(tdActions);
 
           tbody.prepend(tr);
+
+          const header = document.getElementById('my-answers-header');
+          if (header) {
+            header.hidden = false;
+            header.style.display = '';
+          }
+
+          const table = document.getElementById('my-answers-table');
+          if (table) {
+            table.hidden = false;
+            table.style.display = '';
+          }
+
+          const collapseDiv = document.getElementById('myAnswers');
+          if (collapseDiv) {
+            collapseDiv.hidden = false;
+            collapseDiv.style.display = '';
+            if (typeof bootstrap !== 'undefined') {
+              const coll = bootstrap.Collapse.getOrCreateInstance(collapseDiv, { toggle: false });
+              coll.show();
+            } else {
+              collapseDiv.classList.add('show');
+            }
+            const toggle = document.querySelector('a[href="#myAnswers"]');
+            if (toggle) {
+              toggle.classList.remove('collapsed');
+              toggle.setAttribute('aria-expanded', 'true');
+            }
+          }
+
+          const placeholder = tbody.querySelector('.no-answers-placeholder');
+          if (placeholder) placeholder.remove();
         }
         const countEl = document.getElementById('unanswered-count');
         if (countEl) {

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -128,13 +128,12 @@
   </div>
 {% endif %}
 {% if request.user.is_authenticated %}
-{% if user_answers %}
-  <h2 class="mt-4">
+  <h2 id="my-answers-header" class="mt-4"{% if not user_answers %} style="display:none"{% endif %}>
     <a class="text-decoration-none collapse-toggle collapsed" data-bs-toggle="collapse" href="#myAnswers" role="button" aria-expanded="false" aria-controls="myAnswers">{% translate 'My answers' %}</a>
   </h2>
-  <div id="myAnswers" class="collapse">
+  <div id="myAnswers" class="collapse"{% if not user_answers %} style="display:none"{% endif %}>
   <div class="table-responsive">
-  <table class="table mb-3 survey-detail-table stacked-table">
+  <table id="my-answers-table" class="table mb-3 survey-detail-table stacked-table"{% if not user_answers %} style="display:none"{% endif %}>
     <thead>
       <tr>
         <th>{% translate 'Answer date' %}</th>
@@ -146,6 +145,7 @@
       </tr>
     </thead>
     <tbody id="my-answers-body">
+      {% if user_answers %}
       {% for a in user_answers %}
       <tr data-question-id="{{ a.question.pk }}">
         <td data-label="{% translate 'Answer date' %}">{{ a.created_at|date:"Y-m-d" }}</td>
@@ -170,11 +170,15 @@
         </td>
       </tr>
       {% endfor %}
+      {% else %}
+      <tr class="no-answers-placeholder">
+        <td colspan="5">{% translate 'No answers' %}</td>
+      </tr>
+      {% endif %}
     </tbody>
   </table>
   </div>
   </div>
-{% endif %}
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Always render the "My answers" section and show a placeholder when empty
- Reveal hidden "My answers" header and table when an answer is added via AJAX

## Testing
- `python manage.py test` *(fails: OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68c3bfeef134832e9134dff37db00d41