### PR TITLE
Avoid decreasing unanswered count when editing

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -210,6 +210,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ev.preventDefault();
         const formData = new FormData(form);
         let answerValue = '';
+        const isEdit = form.dataset.isEdit === 'true';
         if (ev.submitter && ev.submitter.name) {
           formData.append(ev.submitter.name, ev.submitter.value);
           if (ev.submitter.name === 'answer') {
@@ -358,7 +359,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         }
         const countEl = document.getElementById('unanswered-count');
-        if (countEl) {
+        if (countEl && !isEdit) {
           const newCount = Math.max(0, (parseInt(countEl.textContent, 10) || 0) - 1);
           countEl.textContent = newCount;
           updateAnswerNavLink(newCount);

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -7,7 +7,7 @@
   <div id="answerbox" class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ question.text }}</h2>
 {% if request.user.is_authenticated %}
-<form method="post" action="{% url 'survey:answer_question' question.pk %}" class="text-center ajax-answer-question" id="answer-form">
+<form method="post" action="{% url 'survey:answer_question' question.pk %}" class="text-center ajax-answer-question" id="answer-form" data-is-edit="{{ is_edit|yesno:'true,false' }}">
   {% csrf_token %}
   {% if next %}
   <input type="hidden" name="next" value="{{ next }}">
@@ -50,7 +50,7 @@
   <div class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ q.text }}</h2>
     {% if request.user.is_authenticated %}
-    <form method="post" action="{% url 'survey:answer_question' q.pk %}" class="text-center ajax-answer-question">
+    <form method="post" action="{% url 'survey:answer_question' q.pk %}" class="text-center ajax-answer-question" data-is-edit="false">
       {% csrf_token %}
       <input type="hidden" name="question_id" value="{{ q.pk }}">
       {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}


### PR DESCRIPTION
## Summary
- Flag answer form edits in HTML template
- Skip unanswered question count decrement when editing an existing answer

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68c3db0b7590832e979b701b34ba32e7