### PR TITLE
Fix extra date column in unanswered questions list

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -143,11 +143,6 @@ document.addEventListener('DOMContentLoaded', () => {
             tdId.textContent = data.question_id;
             tr.appendChild(tdId);
 
-            const tdPublished = document.createElement('td');
-            tdPublished.dataset.label = data.published_label;
-            tdPublished.textContent = data.question_published;
-            tr.appendChild(tdPublished);
-
             const tdTitle = document.createElement('td');
             tdTitle.dataset.label = data.title_label;
             const titleLink = document.createElement('a');


### PR DESCRIPTION
## Summary
- Remove published date cell when moving a question to the unanswered table after deleting an answer

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68c3de2cbb3c832e92f808c77e164d52