### PR TITLE
Check for remaining questions before completion

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -355,11 +355,20 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         const countEl = document.getElementById('unanswered-count');
         if (countEl && !isEdit) {
-          const newCount = Math.max(0, (parseInt(countEl.textContent, 10) || 0) - 1);
+          let newCount = typeof data.unanswered_count !== 'undefined'
+            ? data.unanswered_count
+            : Math.max(0, (parseInt(countEl.textContent, 10) || 0) - 1);
           countEl.textContent = newCount;
           updateAnswerNavLink(newCount);
-          if (typeof completionUrl !== 'undefined' && newCount === 0) {
-            window.location.href = completionUrl;
+          if (typeof completionUrl !== 'undefined') {
+            const remainingForms = document.querySelectorAll('form.ajax-answer-question').length;
+            if (remainingForms === 0) {
+              if (newCount === 0) {
+                window.location.href = completionUrl;
+              } else {
+                window.location.reload();
+              }
+            }
           }
         }
       }).catch(() => window.location.reload());

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -943,6 +943,19 @@ def answer_question(request, pk):
                                 ),
                             }
                         )
+                    answered_ids = Answer.objects.filter(
+                        user=request.user, question__survey=survey
+                    ).values_list("question_id", flat=True)
+                    skipped_ids = SkippedQuestion.objects.filter(
+                        user=request.user, question__survey=survey
+                    ).values_list("question_id", flat=True)
+                    remaining = (
+                        survey.questions.filter(visible=True)
+                        .exclude(id__in=answered_ids)
+                        .exclude(id__in=skipped_ids)
+                        .count()
+                    )
+                    data["unanswered_count"] = remaining
                     return JsonResponse(data)
 
                 answer_label = (


### PR DESCRIPTION
## Summary
- Validate with server whether unanswered questions remain after a submission.
- Update survey page script to reload or finish based on server-reported count.

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e0b3097c832ea8e5c2fd68c1a303