### PR TITLE
Redirect edited answers back to question list

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -433,9 +433,7 @@ class SurveyFlowTests(TransactionTestCase):
         )
         answer.refresh_from_db()
         self.assertEqual(answer.answer, "no")
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("question", response.context)
-        self.assertNotEqual(response.context["question"].pk, questions[0].pk)
+        self.assertRedirects(response, reverse("survey:survey_detail"))
 
     def test_redirects_to_next_unanswered_when_next_same_page(self):
         survey = self._create_survey()


### PR DESCRIPTION
## Summary
- Ensure editing an existing answer redirects users to the survey overview
- Adjust tests for new redirect behavior

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c3e622339c832e908a2bd5e3061888