### PR TITLE
Ensure only latest alert shown on answer page

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function showAlert(message, type = 'info') {
       const container = document.querySelector('.container');
       if (!container) return;
+      container.querySelectorAll('.alert').forEach(el => el.remove());
       const alert = document.createElement('div');
       alert.className = `alert alert-${type} alert-dismissible fade show`;
       alert.setAttribute('role', 'alert');


### PR DESCRIPTION
## Summary
- Remove existing alerts before displaying a new one so answering or skipping a question only shows the most recent notification

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f4ee2fc8832ead3e08044cbeebee