### PR TITLE
Show skip or thanks message after AJAX answers

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -245,6 +245,17 @@ document.addEventListener('DOMContentLoaded', () => {
           if (data.message) {
             showAlert(data.message, data.message_type || 'info');
           }
+          if (!isEdit) {
+            const skipHelp = document.getElementById('skip-help-message');
+            const thanksMsg = document.getElementById('thanks-message');
+            if (answerValue === '') {
+              if (skipHelp) skipHelp.style.display = '';
+              if (thanksMsg) thanksMsg.style.display = 'none';
+            } else if (answerValue === 'yes' || answerValue === 'no') {
+              if (skipHelp) skipHelp.style.display = 'none';
+              if (thanksMsg) thanksMsg.style.display = '';
+            }
+          }
           if (answerValue === 'yes' || answerValue === 'no') {
           const tbody = document.getElementById('my-answers-body');
         if (tbody) {

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -67,24 +67,21 @@
   </div>
 </div>
 {% endfor %}
-{% if show_skip_help %}
-  {% url 'survey:question_add' as question_add_url %}
-  {% blocktrans trimmed with question_add_url=question_add_url asvar skip_help_message %}
-  If the question was poorly worded, you can <a href="{{ question_add_url }}">add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data.
-  {% endblocktrans %}
-  <div class="card-footer skip-help-container">
-    <p class="fst-italic mb-0">
-      <span class="skip-help-label">{% translate 'Tip:' %}</span>
-      <span class="skip-help-text">{{ skip_help_message|safe }}</span>
-    </p>
-  </div>
-{% elif show_thanks_message %}
-  <div class="card-footer skip-help-container">
-    <p class="fst-italic mb-0">
-      <span class="skip-help-text">{% translate "Thank you in advance for each of your answers. You can stop whenever you like, as questions are shown in random order." %}</span>
-    </p>
-  </div>
-{% endif %}
+{% url 'survey:question_add' as question_add_url %}
+{% blocktrans trimmed with question_add_url=question_add_url asvar skip_help_message %}
+If the question was poorly worded, you can <a href="{{ question_add_url }}">add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data.
+{% endblocktrans %}
+<div id="skip-help-message" class="card-footer skip-help-container"{% if not show_skip_help %} style="display:none"{% endif %}>
+  <p class="fst-italic mb-0">
+    <span class="skip-help-label">{% translate 'Tip:' %}</span>
+    <span class="skip-help-text">{{ skip_help_message|safe }}</span>
+  </p>
+</div>
+<div id="thanks-message" class="card-footer skip-help-container"{% if not show_thanks_message %} style="display:none"{% endif %}>
+  <p class="fst-italic mb-0">
+    <span class="skip-help-text">{% translate "Thank you in advance for each of your answers. You can stop whenever you like, as questions are shown in random order." %}</span>
+  </p>
+</div>
 
 {% if question_stats %}
   <h2 class="mt-4">


### PR DESCRIPTION
## Summary
- Toggle skip help and thanks messages based on AJAX answer submission
- Always render message containers in answer form for dynamic display

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68c3faeaf02c832e8d6a061c46585508