### PR TITLE
Hide extra unanswered questions for direct question links

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -45,7 +45,8 @@
 {% endif %}
   </div>
 </div>
-{% for q in unanswered_questions %}
+{% if unanswered_questions %}
+  {% for q in unanswered_questions %}
 <div class="card mx-auto mb-4 unanswered-card" style="max-width: 40rem;" data-question-id="{{ q.pk }}">
   <div class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ q.text }}</h2>
@@ -66,7 +67,8 @@
     {% endif %}
   </div>
 </div>
-{% endfor %}
+  {% endfor %}
+{% endif %}
 {% url 'survey:question_add' as question_add_url %}
 {% blocktrans trimmed with question_add_url=question_add_url asvar skip_help_message %}
 If the question was poorly worded, you can <a href="{{ question_add_url }}">add</a> a new question on the same topic even if it differs only slightly. Different perspectives on the same topics help make more reasoned interpretations of the response data.

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -1092,13 +1092,10 @@ def answer_question(request, pk):
     no_label = gettext("No")
     no_answers_label = gettext("No answers")
     timeline_data = json.dumps(question_stats["timeline"])
-    unanswered_questions = survey.questions.filter(visible=True)
-    if request.user.is_authenticated:
-        answered_ids = Answer.objects.filter(
-            user=request.user, question__survey=survey
-        ).values_list("question_id", flat=True)
-        unanswered_questions = unanswered_questions.exclude(id__in=answered_ids)
-    unanswered_questions = unanswered_questions.order_by("pk")
+    # When answering a question via a direct link, we don't show other
+    # unanswered questions on the page. Use an empty queryset so the
+    # template loop renders nothing.
+    unanswered_questions = Question.objects.none()
     return render(
         request,
         "survey/answer_form.html",


### PR DESCRIPTION
## Summary
- Stop `answer_question` view from sending extra unanswered questions when a question is opened directly
- Guard unanswered question list in `answer_form` template to show only when provided

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c40804bb20832eb5630f74f2e0a4d3