### PR TITLE
Return to referring page after editing answers

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -240,6 +240,11 @@ document.addEventListener('DOMContentLoaded', () => {
         body: formData
         }).then(resp => resp.ok ? resp.json() : Promise.reject()).then(data => {
           if (!data || !data.success) { window.location.reload(); return; }
+          const nextField = form.querySelector('input[name="next"]');
+          if (isEdit && nextField && nextField.value) {
+            window.location.href = nextField.value;
+            return;
+          }
           const qid = data.question_id;
           document.querySelectorAll(`[data-question-id="${qid}"]`).forEach(el => el.remove());
           if (data.message) {


### PR DESCRIPTION
## Summary
- Ensure AJAX answer form redirects back to the originating page after editing an answer by honoring the hidden `next` field

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c40c09e850832e85f6fa7013cae826