### PR TITLE
Return to previous page after answering or skipping

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -447,6 +447,32 @@ class SurveyFlowTests(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["question"].pk, questions[1].pk)
 
+    def test_redirects_to_next_after_answering(self):
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        next_url = reverse("survey:survey_detail")
+        response = self.client.post(
+            f"{reverse('survey:answer_question', args=[q.pk])}?next={next_url}",
+            {"question_id": q.pk, "answer": "yes"},
+            follow=True,
+        )
+        self.assertRedirects(response, next_url)
+        messages = list(response.context["messages"])
+        self.assertTrue(any("Answered question" in m.message for m in messages))
+
+    def test_redirects_to_next_after_skip(self):
+        survey = self._create_survey()
+        q = self._create_question(survey)
+        next_url = reverse("survey:survey_detail")
+        response = self.client.post(
+            f"{reverse('survey:answer_question', args=[q.pk])}?next={next_url}",
+            {"question_id": q.pk, "answer": ""},
+            follow=True,
+        )
+        self.assertRedirects(response, next_url)
+        messages = list(response.context["messages"])
+        self.assertTrue(any("Skipped question" in m.message for m in messages))
+
     def test_results_view(self):
         survey = self._create_survey()
         question = self._create_question(survey)

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -991,31 +991,29 @@ def answer_question(request, pk):
                     if answer_value else ""
                 )
 
-                if answer is not None and next_url:
-                    from urllib.parse import urlparse
-                    if urlparse(next_url).path != request.path:
-                        if answer_value:
-                            messages.success(
-                                request,
-                                gettext(
-                                    'Answered question #{number}: "{question}" with "{answer}"'
-                                ).format(
-                                    number=answered_question.pk,
-                                    question=answered_question.text,
-                                    answer=answer_label,
-                                ),
-                            )
-                        elif skip_message:
-                            messages.info(
-                                request,
-                                gettext(
-                                    'Skipped question #{number}: "{question}"'
-                                ).format(
-                                    number=answered_question.pk,
-                                    question=answered_question.text,
-                                ),
-                            )
-                        return redirect(next_url)
+                from urllib.parse import urlparse
+                if next_url and urlparse(next_url).path != request.path:
+                    if answer_value:
+                        messages.success(
+                            request,
+                            gettext(
+                                'Answered question #{number}: "{question}" with "{answer}"'
+                            ).format(
+                                number=answered_question.pk,
+                                question=answered_question.text,
+                                answer=answer_label,
+                            ),
+                        )
+                    elif skip_message:
+                        messages.info(
+                            request,
+                            gettext('Skipped question #{number}: "{question}"').
+                            format(
+                                number=answered_question.pk,
+                                question=answered_question.text,
+                            ),
+                        )
+                    return redirect(next_url)
 
                 answered_questions = Answer.objects.filter(
                     user=request.user, question__survey=survey


### PR DESCRIPTION
## Summary
- Redirect back to the originating page when saving or skipping a question
- Show notification on questions page after answering or skipping
- Add regression tests for redirection and notifications

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c4253b7124832e89b1ef8952e9923f