### PR TITLE
Show only one question at a time on answer page

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -247,6 +247,10 @@ document.addEventListener('DOMContentLoaded', () => {
           }
           const qid = data.question_id;
           document.querySelectorAll(`[data-question-id="${qid}"]`).forEach(el => el.remove());
+          const nextCard = document.querySelector('.unanswered-card.d-none');
+          if (nextCard) {
+            nextCard.classList.remove('d-none');
+          }
           if (data.message) {
             showAlert(data.message, data.message_type || 'info');
           }

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -46,7 +46,7 @@
   </div>
 </div>
 {% for q in unanswered_questions %}
-<div class="card mx-auto mb-4 unanswered-card" style="max-width: 40rem;" data-question-id="{{ q.pk }}">
+<div class="card mx-auto mb-4 unanswered-card d-none" style="max-width: 40rem;" data-question-id="{{ q.pk }}">
   <div class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ q.text }}</h2>
     {% if request.user.is_authenticated %}


### PR DESCRIPTION
## Summary
- Hide all additional unanswered question cards on the answer page so only one question is visible at a time
- Reveal the next question card dynamically after a submission

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68c4310a3120832e9f6d0b3923134feb