### PR TITLE
Clarify optional pause in question flow

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -803,5 +803,5 @@ msgid "Tip:"
 msgstr "Vinkki:"
 
 #: templates/survey/answer_form.html:62
-msgid "Thank you in advance for each of your answers. You can stop whenever you like, as questions are shown in random order."
-msgstr "Kiitos jo etukäteen jokaisesta vastauksestasi. Voit lopettaa kun siltä tuntuu, sillä kysymyksiä näytetään satunnaisessa järjestyksessä."
+msgid "Thank you in advance for each of your answers. You can stop and continue when you feel like it, since the questions are shown in random order."
+msgstr "Kiitos jo etukäteen jokaisesta vastauksestasi. Voit lopettaa ja jatkaa kun siltä tuntuu, sillä kysymykset näytetään satunnaisessa järjestyksessä."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -805,3 +805,7 @@ msgstr "Om frågan var dåligt formulerad kan du <a href=\"%(question_add_url)s\
 #: templates/survey/answer_form.html:55
 msgid "Tip:"
 msgstr "Tips:"
+
+#: templates/survey/answer_form.html:62
+msgid "Thank you in advance for each of your answers. You can stop and continue when you feel like it, since the questions are shown in random order."
+msgstr "Tack på förhand för varje svar. Du kan avbryta och fortsätta när du känner för det, eftersom frågorna visas i slumpmässig ordning."

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -59,7 +59,7 @@
 {% elif show_thanks_message %}
   <div class="card-footer skip-help-container">
     <p class="fst-italic mb-0">
-      <span class="skip-help-text">{% translate "Thank you in advance for each of your answers. You can stop whenever you like, as questions are shown in random order." %}</span>
+      <span class="skip-help-text">{% translate "Thank you in advance for each of your answers. You can stop and continue when you feel like it, since the questions are shown in random order." %}</span>
     </p>
   </div>
 {% endif %}


### PR DESCRIPTION
## Summary
- Clarify skip-help text so respondents can pause and resume, noting questions are random
- Add Finnish and Swedish translations for the updated message
- Remove compiled translation catalogs from source control

## Testing
- `python manage.py compilemessages`
- `python manage.py test` *(fails: OperationalError: no such table: survey_survey)*

------
https://chatgpt.com/codex/tasks/task_e_68c53b946408832ebeedec9f51ccd336