### PR TITLE
Clarify random-order question message and translations

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -802,6 +802,6 @@ msgstr "Jos kysymys oli huonosti muotoiltu, niin voit <a href=\"%(question_add_u
 msgid "Tip:"
 msgstr "Vinkki:"
 
-#: templates/survey/answer_form.html:62
-msgid "Thank you in advance for each of your answers. You can stop whenever you like, as questions are shown in random order."
-msgstr "Kiitos jo etukäteen jokaisesta vastauksestasi. Voit lopettaa kun siltä tuntuu, sillä kysymyksiä näytetään satunnaisessa järjestyksessä."
+#: templates/survey/answer_form.html:82
+msgid "Thank you in advance for each of your answers. You can stop and continue when you feel like it, since the questions are shown in random order."
+msgstr "Kiitos jo etukäteen jokaisesta vastauksestasi. Voit lopettaa ja jatkaa kun siltä tuntuu, sillä kysymykset näytetään satunnaisessa järjestyksessä."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -805,3 +805,7 @@ msgstr "Om frågan var dåligt formulerad kan du <a href=\"%(question_add_url)s\
 #: templates/survey/answer_form.html:55
 msgid "Tip:"
 msgstr "Tips:"
+
+#: templates/survey/answer_form.html:82
+msgid "Thank you in advance for each of your answers. You can stop and continue when you feel like it, since the questions are shown in random order."
+msgstr "Tack på förhand för varje svar. Du kan sluta och fortsätta när du vill, eftersom frågorna visas i slumpmässig ordning."

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -79,7 +79,7 @@ If the question was poorly worded, you can <a href="{{ question_add_url }}">add<
 </div>
 <div id="thanks-message" class="card-footer skip-help-container"{% if not show_thanks_message %} style="display:none"{% endif %}>
   <p class="fst-italic mb-0">
-    <span class="skip-help-text">{% translate "Thank you in advance for each of your answers. You can stop whenever you like, as questions are shown in random order." %}</span>
+    <span class="skip-help-text">{% translate "Thank you in advance for each of your answers. You can stop and continue when you feel like it, since the questions are shown in random order." %}</span>
   </p>
 </div>
 


### PR DESCRIPTION
## Summary
- Clarify thank-you text on question page to mention pausing and resuming
- Add Finnish and Swedish translations for the updated message
- Remove compiled translation files from commit

## Testing
- `python manage.py compilemessages`
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68c548c29574832ea938f1b4636ca18b