### PR TITLE
Constrain embed progress bars to 30% width

### DIFF
--- a/templates/survey/answers_embed.html
+++ b/templates/survey/answers_embed.html
@@ -12,12 +12,17 @@
 <div class="container mt-4">
   <h1>{% translate 'Answers' %}</h1>
   <table class="table">
+    <colgroup>
+      <col style="width:5%">
+      <col style="width:65%">
+      <col style="width:30%">
+    </colgroup>
     <tbody>
     {% for row in data %}
       <tr>
         <td>{{ row.question.pk }}</td>
         <td>{{ row.question.text }}</td>
-        <td class="w-100">
+        <td>
           <div class="progress" style="height: 1.25rem;">
             <div class="progress-bar bg-success text-black" role="progressbar" style="width: {% widthratio row.yes total_users 100 %}%" aria-valuenow="{{ row.yes }}" aria-valuemin="0" aria-valuemax="{{ total_users }}">{{ row.yes }}</div>
             <div class="progress-bar bg-danger text-light" role="progressbar" style="width: {% widthratio row.no total_users 100 %}%" aria-valuenow="{{ row.no }}" aria-valuemin="0" aria-valuemax="{{ total_users }}">{{ row.no }}</div>


### PR DESCRIPTION
## Summary
- Set a fixed column layout in the embed answers table so progress bars occupy 30% of each row

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: survey_userprofile)*

------
https://chatgpt.com/codex/tasks/task_e_68c58a2259a0832eb08aa9b7038f34ad