### PR TITLE
Redirect back to embedded answer page after submitting

### DIFF
--- a/wikikysely_project/survey/tests/test_views.py
+++ b/wikikysely_project/survey/tests/test_views.py
@@ -207,6 +207,26 @@ class SurveyFlowTests(TransactionTestCase):
         )
         self.assertNotContains(response, "Return to skipped questions")
 
+    def test_answer_question_redirects_to_embed_after_answer(self):
+        survey = self._create_survey()
+        q1 = self._create_question(survey)
+        next_url = reverse("survey:answer_survey") + "?embed=1"
+        data = {"question_id": q1.pk, "answer": "yes", "next": next_url}
+        response = self.client.post(
+            reverse("survey:answer_question", args=[q1.pk]), data
+        )
+        self.assertRedirects(response, next_url)
+
+    def test_answer_question_redirects_to_embed_after_skip(self):
+        survey = self._create_survey()
+        q1 = self._create_question(survey)
+        next_url = reverse("survey:answer_survey") + "?embed=1"
+        data = {"question_id": q1.pk, "answer": "", "next": next_url}
+        response = self.client.post(
+            reverse("survey:answer_question", args=[q1.pk]), data
+        )
+        self.assertRedirects(response, next_url)
+
     def test_survey_edit(self):
         survey = self._create_survey()
         data = {

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -927,6 +927,37 @@ def answer_question(request, pk):
                     if answer_value else ""
                 )
 
+                if next_url:
+                    from urllib.parse import urlparse, parse_qs
+
+                    parsed = urlparse(next_url)
+                    if (
+                        parsed.path == reverse("survey:answer_survey")
+                        and parse_qs(parsed.query).get("embed")
+                    ):
+                        if answer_value:
+                            messages.success(
+                                request,
+                                gettext(
+                                    'Answered question #{number}: "{question}" with "{answer}"'
+                                ).format(
+                                    number=answered_question.pk,
+                                    question=answered_question.text,
+                                    answer=answer_label,
+                                ),
+                            )
+                        elif skip_message:
+                            messages.info(
+                                request,
+                                gettext(
+                                    'Skipped question #{number}: "{question}"'
+                                ).format(
+                                    number=answered_question.pk,
+                                    question=answered_question.text,
+                                ),
+                            )
+                        return redirect(next_url)
+
                 if answer is not None and next_url:
                     from urllib.parse import urlparse
                     if urlparse(next_url).path != request.path:


### PR DESCRIPTION
## Summary
- redirect back to the embedded answer flow when a user answers or skips from an embedded question page
- test redirect behaviour for both answering and skipping

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c5ad1bba14832ea82f7009147171f4