### PR TITLE
Exclude current question from unanswered list

### DIFF
--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -1093,7 +1093,7 @@ def answer_question(request, pk):
     no_label = gettext("No")
     no_answers_label = gettext("No answers")
     timeline_data = json.dumps(question_stats["timeline"])
-    unanswered_questions = survey.questions.filter(visible=True)
+    unanswered_questions = survey.questions.filter(visible=True).exclude(pk=question.pk)
     if request.user.is_authenticated:
         answered_ids = Answer.objects.filter(
             user=request.user, question__survey=survey


### PR DESCRIPTION
## Summary
- prevent the current question from appearing in the unanswered list when answering a question

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c5bc83f0dc832ea9a5009296b3f59c