### PR TITLE
Restrict redirect for new survey answers

### DIFF
--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -995,7 +995,7 @@ def answer_question(request, pk):
                 )
 
                 from urllib.parse import urlparse
-                if next_url and urlparse(next_url).path != request.path:
+                if answer is not None and next_url and urlparse(next_url).path != request.path:
                     if answer_value:
                         messages.success(
                             request,


### PR DESCRIPTION
## Summary
- only redirect to provided next URL when editing an existing answer

## Testing
- `python manage.py test` (fails: test_redirects_to_next_after_answering, test_redirects_to_next_after_skip)


------
https://chatgpt.com/codex/tasks/task_e_68c608cf7404832e9ead33b9881cc60d