### PR TITLE
Ensure AJAX progression for direct question pages

### DIFF
--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -7,7 +7,7 @@
   <div id="answerbox" class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ question.text }}</h2>
 {% if request.user.is_authenticated %}
-<form method="post" action="{% url 'survey:answer_question' question.pk %}" class="text-center{% if not next or next == request.path %} ajax-answer-question{% endif %}" id="answer-form" data-is-edit="{{ is_edit|yesno:'true,false' }}">
+<form method="post" action="{% url 'survey:answer_question' question.pk %}" class="text-center{% if not is_edit and unanswered_questions or not next or next == request.path %} ajax-answer-question{% endif %}" id="answer-form" data-is-edit="{{ is_edit|yesno:'true,false' }}">
   {% csrf_token %}
   {% if next %}
   <input type="hidden" name="next" value="{{ next }}">
@@ -50,7 +50,7 @@
   <div class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ q.text }}</h2>
     {% if request.user.is_authenticated %}
-    <form method="post" action="{% url 'survey:answer_question' q.pk %}" class="text-center{% if not next or next == request.path %} ajax-answer-question{% endif %}" data-is-edit="false">
+    <form method="post" action="{% url 'survey:answer_question' q.pk %}" class="text-center{% if not is_edit and unanswered_questions or not next or next == request.path %} ajax-answer-question{% endif %}" data-is-edit="false">
       {% csrf_token %}
       <input type="hidden" name="question_id" value="{{ q.pk }}">
       {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}


### PR DESCRIPTION
## Summary
- Load next unanswered question via AJAX when visiting a question directly and more remain
- Apply AJAX class to hidden question forms as well

## Testing
- `python manage.py test` *(fails: Response didn't redirect as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68c673b8165c832e878cf3e09898a0f6