### PR TITLE
Update answer details after AJAX question navigation

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -30,6 +30,25 @@ document.addEventListener('DOMContentLoaded', () => {
       container.prepend(alert);
     }
 
+  function updateAnswerDetails(card) {
+    if (!card) return;
+    const detailsDiv = document.getElementById('answerDetails');
+    if (!detailsDiv) return;
+    const row = detailsDiv.querySelector('tbody tr');
+    if (!row) return;
+    const yes = parseInt(card.dataset.yes, 10) || 0;
+    const no = parseInt(card.dataset.no, 10) || 0;
+    const total = yes + no;
+    const agree = total ? ((Math.max(yes, no) / total) * 100).toFixed(1) : '0.0';
+    const cells = row.children;
+    if (cells[0]) cells[0].textContent = card.dataset.questionId || '';
+    if (cells[1]) cells[1].textContent = card.dataset.published || '';
+    if (cells[2]) cells[2].textContent = yes;
+    if (cells[3]) cells[3].textContent = no;
+    if (cells[4]) cells[4].textContent = total;
+    if (cells[5]) cells[5].textContent = agree.replace('.', ',') + '%';
+  }
+
   function updateAnswerNavLink(count) {
     const navCount = document.getElementById('unanswered-count');
     if (navCount) {
@@ -266,6 +285,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (nextCard) {
           nextCard.classList.remove('d-none');
+          updateAnswerDetails(nextCard);
         }
         if (currentCard) {
           currentCard.remove();

--- a/templates/survey/answer_form.html
+++ b/templates/survey/answer_form.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% block title %}{% translate 'Answer question' %}{% endblock %}
 {% block content %}
-<div class="card mx-auto mb-4" style="max-width: 40rem;" data-question-id="{{ question.pk }}">
+<div class="card mx-auto mb-4" style="max-width: 40rem;" data-question-id="{{ question.pk }}" data-published="{{ question_stats.published|date:'Y-m-d' }}" data-yes="{{ question_stats.yes }}" data-no="{{ question_stats.no }}">
   <div id="answerbox" class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ question.text }}</h2>
 {% if request.user.is_authenticated %}
@@ -46,7 +46,7 @@
   </div>
 </div>
 {% for q in unanswered_questions %}
-<div class="card mx-auto mb-4 unanswered-card d-none" style="max-width: 40rem;" data-question-id="{{ q.pk }}">
+<div class="card mx-auto mb-4 unanswered-card d-none" style="max-width: 40rem;" data-question-id="{{ q.pk }}" data-published="{{ q.created_at|date:'Y-m-d' }}" data-yes="{{ q.yes_count }}" data-no="{{ q.no_count }}">
   <div class="card-body text-center">
     <h2 class="card-title mb-0" style="padding-bottom:0.25em;">{{ q.text }}</h2>
     {% if request.user.is_authenticated %}

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -995,7 +995,7 @@ def answer_question(request, pk):
                 )
 
                 from urllib.parse import urlparse
-                if answer is not None and next_url and urlparse(next_url).path != request.path:
+                if next_url and urlparse(next_url).path != request.path:
                     if answer_value:
                         messages.success(
                             request,
@@ -1099,7 +1099,18 @@ def answer_question(request, pk):
             user=request.user, question__survey=survey
         ).values_list("question_id", flat=True)
         unanswered_questions = unanswered_questions.exclude(id__in=answered_ids)
-    unanswered_questions = unanswered_questions.order_by("pk")
+    unanswered_questions = (
+        unanswered_questions
+        .annotate(
+            yes_count=Count(
+                "answers", filter=Q(answers__answer="yes"), distinct=True
+            ),
+            no_count=Count(
+                "answers", filter=Q(answers__answer="no"), distinct=True
+            ),
+        )
+        .order_by("pk")
+    )
     return render(
         request,
         "survey/answer_form.html",


### PR DESCRIPTION
## Summary
- Add question statistics data attributes to question cards
- Update answer details table when moving to next question via AJAX
- Include yes/no counts for preloaded questions and simplify redirect handling

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c81d13b944832eaed4d5f8a399f347