### PR TITLE
Animate question transitions

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -193,3 +193,21 @@ body {
   margin:auto; 
   max-width:65rem;'
 }
+/* Fade animations for question transitions */
+.fade-in {
+  animation: fadeIn 0.5s forwards;
+}
+
+.fade-out {
+  animation: fadeOut 0.5s forwards;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}

--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -285,10 +285,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (nextCard) {
           nextCard.classList.remove('d-none');
+          nextCard.classList.add('fade-in');
+          nextCard.addEventListener('animationend', () => {
+            nextCard.classList.remove('fade-in');
+          }, { once: true });
           updateAnswerDetails(nextCard);
         }
         if (currentCard) {
-          currentCard.remove();
+          currentCard.classList.add('fade-out');
+          currentCard.addEventListener('animationend', () => {
+            currentCard.remove();
+          }, { once: true });
         }
 
         fetch(form.action, {


### PR DESCRIPTION
## Summary
- fade out current question and fade in the next one when answering via AJAX

## Testing
- `DJANGO_DEV_SERVER=1 python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68c827b38104832e81e92d20bd82bf86