### PR TITLE
Annotate unanswered questions with answer counts

### DIFF
--- a/static/js/survey_detail_ajax.js
+++ b/static/js/survey_detail_ajax.js
@@ -83,6 +83,9 @@ document.addEventListener('DOMContentLoaded', () => {
     updateAnswerNavLink(initialCount);
   }
 
+  const firstCard = document.querySelector('.card[data-question-id]:not(.unanswered-card)');
+  updateAnswerDetails(firstCard);
+
   function attachDeleteQuestion(link) {
     link.addEventListener('click', ev => {
       ev.preventDefault();

--- a/wikikysely_project/survey/views.py
+++ b/wikikysely_project/survey/views.py
@@ -841,7 +841,10 @@ def answer_survey(request):
         unanswered_questions = unanswered_questions.exclude(id__in=answered_ids)
     if question:
         unanswered_questions = unanswered_questions.exclude(id=question.pk)
-    unanswered_questions = unanswered_questions.order_by("pk")
+    unanswered_questions = unanswered_questions.annotate(
+        yes_count=Count("answers", filter=Q(answers__answer="yes")),
+        no_count=Count("answers", filter=Q(answers__answer="no")),
+    ).order_by("pk")
     return render(
         request,
         "survey/answer_form.html",


### PR DESCRIPTION
## Summary
- annotate unanswered questions with yes/no counts in `answer_survey`
- update DOMContentLoaded to refresh Answer details table for first question

## Testing
- `python manage.py test` *(fails: no such table: survey_userprofile)*

------
https://chatgpt.com/codex/tasks/task_e_68c82d3d5770832e880d20c84d1a7bb8